### PR TITLE
ace.py restructuring

### DIFF
--- a/pyne/ace.py
+++ b/pyne/ace.py
@@ -20,6 +20,7 @@ generates ACE-format cross sections.
 .. moduleauthor:: Paul Romano <romano7@gmail.com>
 """
 
+import numpy as np
 from numpy import zeros, copy, meshgrid, interp, linspace, pi, arccos, concatenate
 from bisect import bisect_right
 
@@ -131,7 +132,10 @@ class Library(object):
             table.JXS = [int(i) for i in ''.join(lines[8:12]).split()]
 
             # Read XSS array
-            table.XSS = [float(i) for i in ''.join(lines[12:12+n_lines]).split()]
+            #table.XSS = [float(i) for i in ''.join(lines[12:12+n_lines]).split()]
+            datastr = ''.join(lines[12:12+n_lines])
+            xss = np.fromstring(datastr, sep=' ')
+            table.XSS = list(xss)
 
             # Insert empty object at beginning of NXS, JXS, and XSS
             # arrays so that the indexing will be the same as
@@ -975,7 +979,8 @@ class NeutronTable(AceTable):
 
     def _get_float(self, n_values = 1):
         if n_values > 1:
-            values = self.XSS[self.index:self.index+n_values]
+            ind = self.index
+            values = self.XSS[ind:ind+n_values]
             self.index += n_values
             return values
         else:
@@ -985,8 +990,8 @@ class NeutronTable(AceTable):
             
     def _get_int(self, n_values = 1):
         if n_values > 1:
-            values = [int(i) for i in 
-                      self.XSS[self.index:self.index+n_values]]
+            ind = self.index
+            values = [int(i) for i in self.XSS[ind:ind+n_values]]
             self.index += n_values
             return values
         else:


### PR DESCRIPTION
This is mostly aimed at Paul R.

I have restructured the ace file a bit to be more Pythonic, separate model from view, and add Library.read() backdoor to only parse the data that the user is interested (all of it by default).

I used the U235 ENDF7 data and the following functions to test it with:

``` python
from pyne import ace

def test_ace1():
    ace_lib = ace.Library('92235ENDF7.ace')
    ace_lib.read()

def test_ace2():
    ace_lib = ace.Library('92235ENDF7.ace')
    ace_lib.read('92235.03c')

if __name__ == "__main__":
    #test_ace1()
    test_ace2()
```

The timing are from the old version and this one are basically the same for the whole file and the backdoor is much faster.

``` python
# Old version
In [3]: timeit test_ace.test_ace1()
1 loops, best of 3: 725 ms per loop
```

``` python
# New version
In [5]: timeit test_ace.test_ace1()
1 loops, best of 3: 745 ms per loop

In [6]: timeit test_ace.test_ace2()
1 loops, best of 3: 203 ms per loop
```
