### PR TITLE
Changed nuc_weight to atomic_mass.

### DIFF
--- a/cpp/data.cpp
+++ b/cpp/data.cpp
@@ -3,14 +3,14 @@
 #include "data.h"
 
 
-/****************************/
-/*** nuc_weight Functions ***/
-/****************************/
-std::map<int, double> pyne::nuc_weight_map = std::map<int, double>();
+/*****************************/
+/*** atomic_mass Functions ***/
+/*****************************/
+std::map<int, double> pyne::atomic_mass_map = std::map<int, double>();
 
-void pyne::_load_nuc_weight_map()
+void pyne::_load_atomic_mass_map()
 {
-  // Loads the importnat parts of atomic_wight table into nuc_weight_map
+  // Loads the important parts of atomic_wight table into atomic_mass_map
 
   //Check to see if the file is in HDF5 format.
   if (!pyne::file_exists(pyne::NUC_DATA_PATH))
@@ -45,17 +45,17 @@ void pyne::_load_nuc_weight_map()
 
   // Ok now that we have the array of stucts, put it in the map
   for(int n = 0; n < atomic_weight_length; n++)
-    nuc_weight_map[atomic_weight_array[n].nuc_zz] = atomic_weight_array[n].mass;
+    atomic_mass_map[atomic_weight_array[n].nuc_zz] = atomic_weight_array[n].mass;
 };
 
 
-double pyne::nuc_weight(int nuc)
+double pyne::atomic_mass(int nuc)
 {
   // Find the nuclide;s weight in AMU
   std::map<int, double>::iterator nuc_iter, nuc_end;
 
-  nuc_iter = nuc_weight_map.find(nuc);
-  nuc_end = nuc_weight_map.end();
+  nuc_iter = atomic_mass_map.find(nuc);
+  nuc_end = atomic_mass_map.end();
 
   // First check if we already have the nuc weight in the map
   if (nuc_iter != nuc_end)
@@ -63,13 +63,13 @@ double pyne::nuc_weight(int nuc)
 
   // Next, fill up the map with values from the 
   // nuc_data.h5, if the map is empty.
-  if (nuc_weight_map.empty())
+  if (atomic_mass_map.empty())
   {
     // Don't fail if we can't load the library
     try
     {
-      _load_nuc_weight_map();
-      return nuc_weight(nuc);
+      _load_atomic_mass_map();
+      return atomic_mass(nuc);
     }
     catch(...){};
   };
@@ -81,8 +81,8 @@ double pyne::nuc_weight(int nuc)
   // state weight...not strictly true, but good guess.
   if (0 < nuc_zz%10)
   {
-    aw = nuc_weight((nuc_zz/10)*10);
-    nuc_weight_map[nuc] = aw;
+    aw = atomic_mass((nuc_zz/10)*10);
+    atomic_mass_map[nuc] = aw;
     return aw;
   };
 
@@ -90,22 +90,22 @@ double pyne::nuc_weight(int nuc)
   // take a best guess based on the 
   // aaa number.
   aw = (double) ((nuc_zz/10)%1000);
-  nuc_weight_map[nuc] = aw;
+  atomic_mass_map[nuc] = aw;
   return aw;
 };
 
 
-double pyne::nuc_weight(char * nuc)
+double pyne::atomic_mass(char * nuc)
 {
   int nuc_zz = nucname::zzaaam(nuc);
-  return nuc_weight(nuc_zz);
+  return atomic_mass(nuc_zz);
 };
 
 
-double pyne::nuc_weight(std::string nuc)
+double pyne::atomic_mass(std::string nuc)
 {
   int nuc_zz = nucname::zzaaam(nuc);
-  return nuc_weight(nuc_zz);
+  return atomic_mass(nuc_zz);
 };
 
 
@@ -125,7 +125,7 @@ std::map<int, double> pyne::b_map = std::map<int, double>();
 
 void pyne::_load_scattering_lengths()
 {
-  // Loads the importnat parts of atomic_wight table into nuc_weight_map
+  // Loads the important parts of atomic_wight table into atomic_mass_map
 
   //Check to see if the file is in HDF5 format.
   if (!pyne::file_exists(pyne::NUC_DATA_PATH))
@@ -387,7 +387,7 @@ std::map<int, double> pyne::decay_const_map = std::map<int, double>();
 
 void pyne::_load_atomic_decay()
 {
-  // Loads the importnat parts of atomic_decay table into memory
+  // Loads the important parts of atomic_decay table into memory
 
   //Check to see if the file is in HDF5 format.
   if (!pyne::file_exists(pyne::NUC_DATA_PATH))

--- a/cpp/data.h
+++ b/cpp/data.h
@@ -22,10 +22,10 @@ namespace pyne
 {
   extern std::string NUC_DATA_PATH;
 
-  /****************************/
-  /*** nuc_weight Functions ***/
-  /****************************/
-  extern std::map<int, double> nuc_weight_map;
+  /*****************************/
+  /*** atomic_mass Functions ***/
+  /*****************************/
+  extern std::map<int, double> atomic_mass_map;
 
   typedef struct atomic_weight_struct {
     char nuc_name[6];
@@ -35,10 +35,10 @@ namespace pyne
     double abund;
   } atomic_weight_struct;
 
-  void _load_nuc_weight_map();
-  double nuc_weight(int);
-  double nuc_weight(char *);
-  double nuc_weight(std::string);
+  void _load_atomic_mass_map();
+  double atomic_mass(int);
+  double atomic_mass(char *);
+  double atomic_mass(std::string);
 
 
   /***********************************/

--- a/cpp/material.cpp
+++ b/cpp/material.cpp
@@ -580,7 +580,7 @@ double pyne::Material::molecular_weight(double apm)
   // Calculate the atomic weight of the Material
   double inverseA = 0.0;
   for (pyne::comp_iter nuc = comp.begin(); nuc != comp.end(); nuc++)
-    inverseA += (nuc->second) / pyne::nuc_weight(nuc->first);
+    inverseA += (nuc->second) / pyne::atomic_mass(nuc->first);
 
   if (inverseA == 0.0)
     return inverseA;
@@ -860,7 +860,7 @@ std::map<int, double> pyne::Material::to_atom_frac()
   std::map<int, double> atom_fracs = std::map<int, double>();
 
   for (comp_iter ci = comp.begin(); ci != comp.end(); ci++)
-    atom_fracs[ci->first] = (ci->second) * mat_mw / pyne::nuc_weight(ci->first);
+    atom_fracs[ci->first] = (ci->second) * mat_mw / pyne::atomic_mass(ci->first);
 
   return atom_fracs;
 };
@@ -878,7 +878,7 @@ void pyne::Material::from_atom_frac(std::map<int, double> atom_fracs)
 
   for (std::map<int, double>::iterator afi = atom_fracs.begin(); afi != atom_fracs.end(); afi++)
   {
-    comp[afi->first] = (afi->second) * pyne::nuc_weight(afi->first);
+    comp[afi->first] = (afi->second) * pyne::atomic_mass(afi->first);
     atoms_per_mol += (afi->second);
   };
 

--- a/docs/source/libref/data.rst
+++ b/docs/source/libref/data.rst
@@ -13,16 +13,16 @@ All functionality may be found in the ``data`` module::
 
  from pyne import data
 
--------------
-Atomic Weight
--------------
+-----------
+Atomic Mass
+-----------
 
-.. autofunction:: nuc_weight(nuc)
+.. autofunction:: atomic_mass(nuc)
 
-.. data:: nuc_weight_map
+.. data:: atomic_mass_map
 
     A mapping from zzaaam-nuclides to their mass weights.
-    This is used by :func:`nuc_weight` under the hood.
+    This is used by :func:`atomic_mass` under the hood.
 
 
 ----------

--- a/docs/source/usersguide/material.rst
+++ b/docs/source/usersguide/material.rst
@@ -193,7 +193,7 @@ Plutonium vector.
 Molecular Weights & Atom Fractions
 ----------------------------------
 You may also calculate the molecular weight of a material via the :meth:`Material.molecular_weight` method.
-This uses the :func:`pyne.data.nuc_weight` function to look up the atomic weight values of
+This uses the :func:`pyne.data.atomic_mass` function to look up the atomic mass values of
 the constituent nuclides.
 
 .. code-block:: ipython

--- a/pyne/api.py
+++ b/pyne/api.py
@@ -5,7 +5,7 @@ from pyne.pyne_config import nuc_data, pyne_start, pyne_conf
 from pyne.nucname import zzaaam, name
 
 # Get common data functions
-from pyne.data import nuc_weight
+from pyne.data import atomic_mass
 
 # Materials
 from pyne.material import Material

--- a/pyne/cpp_data.pxd
+++ b/pyne/cpp_data.pxd
@@ -6,11 +6,11 @@ cimport std
 cimport extra_types
 
 cdef extern from "data.h" namespace "pyne":
-    # nuc_weight functions
-    map[int, double] nuc_weight_map
-    double nuc_weight(int) except +
-    double nuc_weight(char *) except +
-    double nuc_weight(std.string) except +
+    # atomic_mass functions
+    map[int, double] atomic_mass_map
+    double atomic_mass(int) except +
+    double atomic_mass(char *) except +
+    double atomic_mass(std.string) except +
 
 
     # Scattering length functions

--- a/pyne/data.pyx
+++ b/pyne/data.pyx
@@ -27,37 +27,37 @@ import pyne.stlconverters as conv
 
 
 #
-# nuc_weight functions
+# atomic_mass functions
 #
-cdef conv._MapIntDouble nuc_weight_map_proxy = conv.MapIntDouble(False)
-nuc_weight_map_proxy.map_ptr = &cpp_data.nuc_weight_map
-nuc_weight_map = nuc_weight_map_proxy
+cdef conv._MapIntDouble atomic_mass_map_proxy = conv.MapIntDouble(False)
+atomic_mass_map_proxy.map_ptr = &cpp_data.atomic_mass_map
+atomic_mass_map = atomic_mass_map_proxy
 
-def nuc_weight(nuc):
-    """Finds the weight of a nuclide in [amu].
+def atomic_mass(nuc):
+    """Finds the atomic mass of a nuclide in [amu].
 
     Parameters
     ----------
-    nuc : int or str 
+    nuc : int or str
         Input nuclide.
 
     Returns
     -------
-    weight : float
-        Atomic weight of this nuclide [amu].
+    mass : float
+        Atomic mass of this nuclide [amu].
 
     Notes
     -----
     If the nuclide is not found, the A-number is returned as a float.
     """
     if isinstance(nuc, int):
-        weight = cpp_data.nuc_weight(<int> nuc)
+        mass = cpp_data.atomic_mass(<int> nuc)
     elif isinstance(nuc, basestring):
-        weight = cpp_data.nuc_weight(<char *> nuc)
+        mass = cpp_data.atomic_mass(<char *> nuc)
     else:
         raise pyne.nucname.NucTypeError(nuc)
 
-    return weight
+    return mass
 
 
 

--- a/pyne/tests/test_data.py
+++ b/pyne/tests/test_data.py
@@ -9,15 +9,15 @@ from nose.tools import assert_equal, assert_not_equal, assert_raises, raises, as
 from pyne import data
 import numpy as np
 
-def test_nuc_weight():
+def test_atomic_mass():
     o16 = [15.99491461957, 16.0]
     u235 = [235.043931368, 235.0]
     am242m = [242.059550625, 242.0]
 
     # zzaam form
-    assert_in(data.nuc_weight(80160),  o16)
-    assert_in(data.nuc_weight(922350), u235)
-    assert_in(data.nuc_weight(952421), am242m)
+    assert_in(data.atomic_mass(80160),  o16)
+    assert_in(data.atomic_mass(922350), u235)
+    assert_in(data.atomic_mass(952421), am242m)
 
 
 def test_b_coherent():

--- a/pyne/xs/channels.py
+++ b/pyne/xs/channels.py
@@ -164,7 +164,7 @@ def sigma_s_gh(nuc, T, E_g=None, E_n=None, phi_n=None):
     # Get some needed data
     G = len(xs_cache['E_g']) - 1
     b = pyne.data.b(nuc_zz)
-    aw = pyne.data.nuc_weight(nuc_zz)
+    aw = pyne.data.atomic_mass(nuc_zz)
 
     # OMG FIXME So hard!
     ## Initialize the scattering kernel

--- a/pyne/xs/models.pyx
+++ b/pyne/xs/models.pyx
@@ -568,7 +568,7 @@ def sigma_s(E, b=1.0, M_A=1.0, T=300.0):
     See Also
     --------
     pyne.data.b : scattering length data.
-    pyne.data.nuc_weight : Atomic mass data.
+    pyne.data.atomic_mass : Atomic mass data.
 
     """
     kT_over_AE = k * T / ((M_A / m_n) * E)

--- a/pyne/xs/tests/test_channels.py
+++ b/pyne/xs/tests/test_channels.py
@@ -96,7 +96,7 @@ def test_sigma_f():
 def test_sigma_s_gh():
     # Tests stub
     b = pyne.data.b('H1')
-    aw = pyne.data.nuc_weight('H1')
+    aw = pyne.data.atomic_mass('H1')
     E = np.logspace(-6, 1, 10)[::-1]
     E_centers = (E[1:] + E[:-1]) / 2.0
     expected = np.diag(pyne.xs.models.sigma_s(E_centers, b, aw, 600.0))


### PR DESCRIPTION
As per discussion on the email list, I've changed all instances of the nuc_weight function in pyne.data to atomic_mass to better reflect what the actual data is. Anthony- I've assigned you to review the pull request since you wrote all the infrastructure and will best be suited to identify whether I've screwed anything up :)
