### PR TITLE
Added MultiMaterial class, mixing functions, and nosetests

### DIFF
--- a/cpp/material.cpp
+++ b/cpp/material.cpp
@@ -321,7 +321,6 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath, std:
   hid_t comp_values_array_type = H5Tarray_create2(H5T_NATIVE_DOUBLE, 1, nuc_dims);
 
   // make the data table type
-<<<<<<< HEAD
   H5Tinsert(desc, "mass", HOFFSET(pyne::material_struct, mass), H5T_NATIVE_DOUBLE);
   H5Tinsert(desc, "density", HOFFSET(pyne::material_struct, density), 
             H5T_NATIVE_DOUBLE);
@@ -329,12 +328,6 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath, std:
             H5T_NATIVE_DOUBLE);
   H5Tinsert(desc, "comp", HOFFSET(pyne::material_struct, comp), 
             comp_values_array_type);
-=======
-  data_desc.insertMember("mass", HOFFSET(pyne::material_struct, mass), H5::PredType::NATIVE_DOUBLE);
-  data_desc.insertMember("density", HOFFSET(pyne::material_struct, density), H5::PredType::NATIVE_DOUBLE);
-  data_desc.insertMember("atoms_per_mol", HOFFSET(pyne::material_struct, atoms_per_mol), H5::PredType::NATIVE_DOUBLE);
-  data_desc.insertMember("comp", HOFFSET(pyne::material_struct, comp), comp_values_array_type);
->>>>>>> 28a3807353f21ea90338f913f6b6f4892f165355
 
   material_struct * mat_data  = new material_struct[material_struct_size];
   (*mat_data).mass = mass;
@@ -577,11 +570,8 @@ void pyne::Material::write_text (std::string filename)
     f << "Mass    " << mass << "\n";
 
   if (0 <= density)
-<<<<<<< HEAD
     f << "Density "  << density << "\n";
-=======
     f << "Density    "  << density << "\n";
->>>>>>> 28a3807353f21ea90338f913f6b6f4892f165355
   
   if (0 <= atoms_per_mol)
     f << "APerM   " << atoms_per_mol << "\n";

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -21,10 +21,7 @@ cdef extern from "material.h" namespace "pyne":
         Material(map[int, double]) except +
         Material(map[int, double], double) except +
         Material(map[int, double], double, double) except +
-<<<<<<< HEAD
         Material(map[int, double], double, double, double) except +
-=======
->>>>>>> 28a3807353f21ea90338f913f6b6f4892f165355
         Material(map[int, double], double, double, double, cpp_jsoncpp.Value) except +
         Material(char *) except +
         Material(char *, double) except +

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1012,10 +1012,7 @@ cdef class _Material:
                 return
             mbm = self.mult_by_mass()
             mbm.map_ptr.erase(<int> key)
-<<<<<<< HEAD
             new_matp = new cpp_material.Material(mbm.map_ptr[0], -1.0)
-=======
->>>>>>> 28a3807353f21ea90338f913f6b6f4892f165355
             new_matp = new cpp_material.Material(mbm.map_ptr[0], -1.0, -1.0)
             self.mat_pointer = new_matp
             self._comp = None


### PR DESCRIPTION
A MultiMaterial object has one attribute, _mats, which is a dictionary with Material objects as keys and mass or volume fractions as values. Two member functions, mix_by_mass and mix_by_volume, are used in order to convert the MultiMaterial object into a Material object. Whether mass fractions or volume fractions are used is not implicit within the data structure; it depends which member function is called by the user.

Previously, the plan was to have the MultiMaterial class have member functions that print out materials definitions in many formats (e.g. MCNP, ALARA). However now I think it would make more sense to make these member functions of the Material class.
