### PR TITLE
Still old "pyne.stlconverters" imports in code.

### DIFF
--- a/pyne/apigen/main.py
+++ b/pyne/apigen/main.py
@@ -41,8 +41,8 @@ def main():
                     ('map', 'str', 'vector[double]'),
                     ]
         stlwrap.genfiles(template, 
-                         fname='pyne/stlconverters', 
-                         testname="pyne/tests/test_stlconverters")
+                         fname='pyne/stlcontainers', 
+                         testname="pyne/tests/test_stlcontainers")
 
 if __name__ == '__main__':
     main()

--- a/pyne/apigen/stlwrap.py
+++ b/pyne/apigen/stlwrap.py
@@ -676,7 +676,7 @@ def genpxd(template, header=None):
     return pxd
 
 
-_testheader = '''"""Tests the part of stlconverters that is accessible from Python."""
+_testheader = '''"""Tests the part of stlcontainers that is accessible from Python."""
 ###################
 ###  WARNING!!! ###
 ###################
@@ -694,7 +694,7 @@ import os
 import numpy  as np
 import tables as tb
 
-import pyne.stlconverters as conv
+import pyne.stlcontainers as conv
 
 
 '''

--- a/pyne/data.pxd
+++ b/pyne/data.pxd
@@ -21,5 +21,5 @@ cimport pyne.pyne_config
 import pyne.pyne_config
 
 cimport cpp_nucname
-cimport pyne.stlconverters as conv
-import pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv
+import pyne.stlcontainers as conv

--- a/pyne/data.pyx
+++ b/pyne/data.pyx
@@ -32,8 +32,8 @@ cimport pyne.nucname
 import pyne.nucname
 
 cimport cpp_data
-cimport pyne.stlconverters as conv
-import pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv
+import pyne.stlcontainers as conv
 
 
 #

--- a/pyne/enrichment.pyx
+++ b/pyne/enrichment.pyx
@@ -21,7 +21,7 @@ ELSE:
 from pyne cimport nucname
 from pyne import nucname
 
-from pyne cimport stlconverters as conv
+from pyne cimport stlcontainers as conv
 
 cimport pyne.cpp_material
 cimport pyne.material

--- a/pyne/material.pxd
+++ b/pyne/material.pxd
@@ -11,7 +11,7 @@ ELSE:
     from pyne._includes.libcpp.string cimport string as std_string
     from pyne._includes.libcpp.map cimport map as cpp_map
 cimport cpp_material
-cimport pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv
 
 
 cdef cpp_map[int, double] dict_to_comp(dict)

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -22,8 +22,8 @@ ELSE:
     from pyne._includes.libcpp.string cimport string as std_string
     from pyne._includes.libcpp.map cimport map as cpp_map
 cimport cpp_material
-cimport pyne.stlconverters as conv
-import pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv
+import pyne.stlcontainers as conv
 
 cimport cpp_jsoncpp
 cimport jsoncpp

--- a/pyne/nucname.pxd
+++ b/pyne/nucname.pxd
@@ -20,8 +20,8 @@ cimport pyne.pyne_config
 import pyne.pyne_config
 
 cimport cpp_nucname
-cimport pyne.stlconverters as conv
-import pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv
+import pyne.stlcontainers as conv
 
 #
 # Conversion dictionaries

--- a/pyne/nucname.pyx
+++ b/pyne/nucname.pyx
@@ -20,8 +20,8 @@ cimport pyne.pyne_config
 import pyne.pyne_config
 
 cimport cpp_nucname
-cimport pyne.stlconverters as conv
-import pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv
+import pyne.stlcontainers as conv
 
 #
 # Conversion dictionaries

--- a/pyne/rxname.pxd
+++ b/pyne/rxname.pxd
@@ -18,4 +18,4 @@ cimport pyne.pyne_config
 
 cimport cpp_nucname
 cimport cpp_rxname
-cimport pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv

--- a/pyne/rxname.pyx
+++ b/pyne/rxname.pyx
@@ -153,8 +153,8 @@ import pyne.pyne_config
 
 cimport cpp_nucname
 cimport cpp_rxname
-cimport pyne.stlconverters as conv
-import pyne.stlconverters as conv
+cimport pyne.stlcontainers as conv
+import pyne.stlcontainers as conv
 
 # names
 cdef conv._SetStr names_proxy = conv.SetStr(False)

--- a/pyne/tests/test_stlcontainers.py
+++ b/pyne/tests/test_stlcontainers.py
@@ -1,4 +1,4 @@
-"""Tests the part of stlconverters that is accessible from Python."""
+"""Tests the part of stlcontainers that is accessible from Python."""
 ###################
 ###  WARNING!!! ###
 ###################


### PR DESCRIPTION
There are still some imports for `pyne.stlconverters` in the code, while the module was apparently renamed to `pyne.stlcontainers`, breakting the build.
This pull request should tackle all occurences in code. The documentation is not updated yet and still contains a page for `stlcontainers`.
