### PR TITLE
FindCython doesn't find local cython.

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -22,7 +22,21 @@
 # limitations under the License.
 #=============================================================================
 
-find_program( CYTHON_EXECUTABLE NAMES cython cython.bat )
+# Use the Cython executable that lives next to the Python executable
+# if it is a local installation.
+find_package( PythonInterp )
+if( PYTHONINTERP_FOUND )
+  get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat
+    HINTS ${_python_path}
+    )
+else()
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat
+    )
+endif()
+
 
 include( FindPackageHandleStandardArgs )
 FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE )


### PR DESCRIPTION
Detect the cython executable in the same path as the python
executable used in a local installation.

Reported by Paul Romano.

@paulromano please test this and re-open the issue in the upstream repo if it does not fix the issue for you.
