### PR TITLE
Remove matplolib dependency (fixes #148)

### DIFF
--- a/pyne/endf.pyx
+++ b/pyne/endf.pyx
@@ -25,7 +25,6 @@ np.import_array()
 
 from pyne cimport cpp_nucname
 
-import matplotlib.pyplot as plt
 from math import e
 
 from pyne import nucname
@@ -1973,9 +1972,6 @@ class ENDFTab2Record(object):
                 self.INT.append(INT)
                 line = line[22:]
             m = m + toRead
-
-    def plot(self):
-        plt.plot(self.x, self.y)
 
 class ENDFRecord(object):
     def __init__(self, fh):


### PR DESCRIPTION
Please note: this only removes the matplotlib dependency from pyne.endf
and all modules that depend on it. pyne.gui.aceviewer still needs
matplotlib.
