### PR TITLE
Mac env installation instructions

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -67,12 +67,17 @@ or from public sources on the internet.
 
 On MacOSX, it may be necessary to add the pyne library path to the 
 ``DYLD_FALLBACK_LIBRARY_PATH`` environment variable *before* running 
-``setup.py`` or ``nuc_data_make``. To do this, add the following lines to your 
-``~/.bashrc`` file (where ``/path/to/pyne/lib`` is the absolute path to the 
+``nuc_data_make``. To do this, add the following lines to your 
+``~/.bashrc`` file where ``/path/to/pyne/lib`` is the absolute path to the 
 directory containing libpyne.dylib :: 
 
     DYLD_FALLBACK_LIBRARY_PATH="${DYLD_FALLBACK_LIBRARY_PATH}:/path/to/pyne/lib"
     export DYLD_FALLBACK_LIBRARY_PATH
+
+Once those lines have been added, run the following command before running 
+``nuc_data_make`` ::
+
+    source ~/.bashrc
 
 .. install-end
 


### PR DESCRIPTION
This just adds some lines to the installation instructions in order to keep macosx folks from seeing issue #177 again. I think it will probably be necessary on all macs.
