### PR TITLE
Add environment PATH to hints to find Cython.

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -29,7 +29,7 @@ if( PYTHONINTERP_FOUND )
   get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
   find_program( CYTHON_EXECUTABLE
     NAMES cython cython.bat
-    HINTS ${_python_path}
+    HINTS ENV PATH ${_python_path}
     )
 else()
   find_program( CYTHON_EXECUTABLE


### PR DESCRIPTION
This allows my machine to find the newly installed upgrade to Cython, rather than the still-existing earlier version.
