### PR TITLE
Relative Import Paths

### DIFF
--- a/pyne/__init__.py
+++ b/pyne/__init__.py
@@ -5,4 +5,4 @@ if os.name == 'nt':
     lib = os.path.join(os.path.split(__file__)[0], 'lib')
     os.environ['PATH'] = ";".join([lib] + p)
     
-from pyne.pyne_config import *
+from .pyne_config import *

--- a/pyne/api.py
+++ b/pyne/api.py
@@ -1,14 +1,6 @@
 # Important config tools
-from pyne.pyne_config import nuc_data, pyne_start, pyne_conf
+from .pyne_config import nuc_data, pyne_start, pyne_conf
 
 # Important naming functions
-from pyne.nucname import id, name
+from .nucname import id, name
 
-# Get common data functions
-from pyne.data import atomic_mass
-
-# Materials
-from pyne.material import Material
-
-# Bins
-from pyne.bins import ninespace, stair_step

--- a/pyne/apigen/stlwrap.py
+++ b/pyne/apigen/stlwrap.py
@@ -579,10 +579,10 @@ IF CYTHON_VERSION_MAJOR == 0 and CYTHON_VERSION_MINOR >= 17:
     from libcpp.map cimport map as cpp_map
     from libcpp.vector cimport vector as cpp_vector
 ELSE:
-    from pyne._includes.libcpp.string cimport string as std_string
-    from pyne._includes.libcpp.utility cimport pair
-    from pyne._includes.libcpp.map cimport map as cpp_map
-    from pyne._includes.libcpp.vector cimport vector as cpp_vector
+    from ._includes.libcpp.string cimport string as std_string
+    from ._includes.libcpp.utility cimport pair
+    from ._includes.libcpp.map cimport map as cpp_map
+    from ._includes.libcpp.vector cimport vector as cpp_vector
 cimport extra_types
 
 cdef extra_types.complex_t py2c_complex(object pyv):
@@ -651,10 +651,10 @@ IF CYTHON_VERSION_MAJOR == 0 and CYTHON_VERSION_MINOR >= 17:
     from libcpp.map cimport map as cpp_map
     from libcpp.vector cimport vector as cpp_vector
 ELSE:
-    from pyne._includes.libcpp.string cimport string as std_string
-    from pyne._includes.libcpp.utility cimport pair
-    from pyne._includes.libcpp.map cimport map as cpp_map
-    from pyne._includes.libcpp.vector cimport vector as cpp_vector
+    from ._includes.libcpp.string cimport string as std_string
+    from ._includes.libcpp.utility cimport pair
+    from ._includes.libcpp.map cimport map as cpp_map
+    from ._includes.libcpp.vector cimport vector as cpp_vector
 cimport extra_types
 
 cimport numpy as np
@@ -694,7 +694,7 @@ import os
 import numpy  as np
 import tables as tb
 
-import pyne.stlcontainers as conv
+import .stlcontainers as conv
 
 
 '''

--- a/pyne/data.pyx
+++ b/pyne/data.pyx
@@ -79,7 +79,7 @@ natural_abund_map_proxy.map_ptr = &cpp_data.natural_abund_map
 natural_abund_map = natural_abund_map_proxy
 
 # initialize natural_abund_map
-cpp_data.natural_abund(<int>10000000)
+cpp_data.natural_abund(<int> 10000000)
 
 abundance_by_z = dict([(i, []) for i in range(1,119)])
 for zas, abundance in natural_abund_map.items():

--- a/pyne/dbgen/atomic_weight.py
+++ b/pyne/dbgen/atomic_weight.py
@@ -6,9 +6,9 @@ import pkgutil
 import numpy as np
 import tables as tb
 
-from pyne import nucname
-from pyne.dbgen.api import BASIC_FILTERS
-from pyne.dbgen.isotopic_abundance import get_isotopic_abundances
+from .. import nucname
+from .api import BASIC_FILTERS
+from .isotopic_abundance import get_isotopic_abundances
 
 # Note that since ground state and meta-stable isotopes are of the same atomic weight, 
 # the meta-stables have been discluded from the following data sets.

--- a/pyne/dbgen/cinder.py
+++ b/pyne/dbgen/cinder.py
@@ -7,9 +7,9 @@ from glob import glob
 import numpy as np
 import tables as tb
 
-from pyne import nucname
-from pyne.utils import failure
-from pyne.dbgen.api import BASIC_FILTERS
+from .. import nucname
+from ..utils import failure
+from .api import BASIC_FILTERS
 
 def grab_cinder_dat(build_dir="", datapath=''):
     """Grabs the cinder.dat file from the DATAPATH directory if not already present."""

--- a/pyne/dbgen/decay.py
+++ b/pyne/dbgen/decay.py
@@ -7,9 +7,9 @@ from zipfile import ZipFile
 import numpy as np
 import tables as tb
 
-from pyne import nucname
-from pyne import ensdf
-from pyne.dbgen.api import BASIC_FILTERS
+from .. import nucname
+from .. import ensdf
+from .api import BASIC_FILTERS
 
 def grab_ensdf_decay(build_dir=""):
     """Grabs the ENSDF decay data files

--- a/pyne/dbgen/eaf.py
+++ b/pyne/dbgen/eaf.py
@@ -11,8 +11,8 @@ from gzip import GzipFile
 import numpy as np
 import tables as tb
 
-from pyne import nucname
-from pyne.dbgen.api import BASIC_FILTERS
+from .. import nucname
+from .api import BASIC_FILTERS
 
 
 def grab_eaf_data(build_dir=""):

--- a/pyne/dbgen/materials_library.py
+++ b/pyne/dbgen/materials_library.py
@@ -7,12 +7,13 @@ This currently consists to natural element materials and those coming from PNNL'
 
 import csv    
 import re
-from pyne.material import Material
 import tables as tb
 import numpy as np
-from pyne import nucname
 import os
-from pyne.data import natural_abund, natural_abund_map
+
+from .. import nucname
+from ..data import natural_abund, natural_abund_map
+from ..material import Material
 
 elemental_mats = {}
 names = []

--- a/pyne/dbgen/nuc_data_make.py
+++ b/pyne/dbgen/nuc_data_make.py
@@ -4,16 +4,16 @@ import urllib2
 import shutil
 from distutils.dir_util import mkpath, remove_tree
 
-from pyne.api import nuc_data
-from pyne.utils import message
-from pyne.dbgen.api import build_dir
-from pyne.dbgen.decay import make_decay
-from pyne.dbgen.atomic_weight import make_atomic_weight
-from pyne.dbgen.materials_library import make_materials_library
-from pyne.dbgen.scattering_lengths import make_scattering_lengths
-from pyne.dbgen.simple_xs import make_simple_xs
-from pyne.dbgen.cinder import make_cinder
-from pyne.dbgen.eaf import make_eaf
+from ..api import nuc_data
+from ..utils import message
+from .api import build_dir
+from .decay import make_decay
+from .atomic_weight import make_atomic_weight
+from .materials_library import make_materials_library
+from .scattering_lengths import make_scattering_lengths
+from .simple_xs import make_simple_xs
+from .cinder import make_cinder
+from .eaf import make_eaf
 
 # Thanks to http://patorjk.com/software/taag/
 # and http://www.chris.com/ascii/index.php?art=creatures/dragons (Jeff Ferris)

--- a/pyne/dbgen/scattering_lengths.py
+++ b/pyne/dbgen/scattering_lengths.py
@@ -11,8 +11,8 @@ import urllib2
 import numpy as np
 import tables as tb
 
-from pyne import nucname
-from pyne.dbgen.api import BASIC_FILTERS
+from .. import nucname
+from .api import BASIC_FILTERS
 
 
 def grab_scattering_lengths(build_dir="", file_out='scattering_lengths.html'):

--- a/pyne/dbgen/simple_xs.py
+++ b/pyne/dbgen/simple_xs.py
@@ -4,10 +4,10 @@ import os
 import numpy as np
 import tables as tb
 
-from pyne import nucname
-from pyne.utils import to_barns
-from pyne.dbgen.api import BASIC_FILTERS
-from pyne.dbgen.kaeri import grab_kaeri_nuclide, parse_for_all_isotopes
+from .. import nucname
+from ..utils import to_barns
+from .api import BASIC_FILTERS
+from .kaeri import grab_kaeri_nuclide, parse_for_all_isotopes
 
 
 def grab_kaeri_simple_xs(build_dir=""):

--- a/pyne/ensdf.py
+++ b/pyne/ensdf.py
@@ -3,7 +3,7 @@ import re
 import numpy as np
 
 from pyne import nucname
-from pyne.utils import to_sec
+from .utils import to_sec
 
 
 _level_regex = re.compile('([ \d]{3}[ A-Za-z]{2})  L (.{10}).{20}(.{10}).{28}([ M])([ 1-9])')

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -21,15 +21,15 @@ import warnings
 
 import numpy as np
 
-from pyne.material import Material
-from pyne.material import MultiMaterial
+from .material import Material
+from .material import MultiMaterial
 from pyne import nucname
 from binaryreader import _BinaryReader, _FortranRecord
 
 # Mesh specific imports
 try:
     from itaps import iMesh
-    from pyne.mesh import Mesh, StatMesh, MeshError
+    from .mesh import Mesh, StatMesh, MeshError
 except ImportError:
     warnings.warn("the PyTAPS optional dependency could not be imported. "
                   "Some aspects of the mcnp module may be incomplete.", ImportWarning)

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -10,7 +10,7 @@ except ImportError:
     raise ImportError("The mesh module requires imports of iMesh, iBase, and"
           " iMeshExtensions from PyTAPS")
 
-from pyne.material import Material, MaterialLibrary
+from .material import Material, MaterialLibrary
 
 # dictionary of lamba functions for mesh arithmetic
 _ops = {"+": lambda val_1, val_2: (val_1 + val_2), 

--- a/pyne/origen22.py
+++ b/pyne/origen22.py
@@ -5,7 +5,7 @@ from itertools import chain, imap, izip
 import numpy as np
 
 from pyne import nucname
-from pyne.material import Material, from_atom_frac
+from .material import Material, from_atom_frac
 
 # Table 4.2 in ORIGEN 2.2 manual
 ORIGEN_TIME_UNITS = [None,              # No zero unit

--- a/pyne/ptrac_to_hdf5.py
+++ b/pyne/ptrac_to_hdf5.py
@@ -2,11 +2,11 @@
 """Read a MCNP Ptrac file and save it in HDF5 format."""
 
 import tables
-from pyne import mcnp
+from . import mcnp
 try:
     import argparse
 except ImportError:
-    import pyne._argparse as argparse
+    from . import _argparse as argparse
 
 def main():
     argparser = argparse.ArgumentParser(description="write the contents of a MCNP PTRAC file to a HDF5 table")

--- a/pyne/rxdata.py
+++ b/pyne/rxdata.py
@@ -1,5 +1,5 @@
 import collections
-# import pyne.endf as endf
+# import .endf as endf
 
 class RxLib(object):
     """RxLib is a parent type which implements an abstract representation of

--- a/pyne/simplesim/cards.py
+++ b/pyne/simplesim/cards.py
@@ -1,6 +1,6 @@
 """The :py:mod:`cards` module can be imported as such::
 
-    from pyne.simplesim import cards
+    from .simplesim import cards
 
 The user creates cards, typically only working with the constructors, and then
 adds the cards to a :py:class:`pyne.simplesim.definition.IDefinition`. The user
@@ -291,9 +291,9 @@ import warnings
 
 import numpy as np
 
-from pyne import nucname
-from pyne import material
-import pyne.simplesim.nestedgeom as ng
+from .. import nucname
+from .. import material
+from . import nestedgeom as ng
 
 def _validate_name(value, isunique=False):
     if value.find(' ') != -1:
@@ -3552,7 +3552,7 @@ class ICellSurfTally(ITally):
         Alternatively, the cards can be specified by something like the
         following (see :py:mod:`pyne.simplesim.nestedgeom`)::
 
-            import pyne.simplesim.nestedgeom as ng
+            import .simplesim.nestedgeom as ng
             unit = ng.Surf('sA') < ng.FCell('cA')
             tally = SurfaceFlux('fuel', 'neutron', unit)
 

--- a/pyne/simplesim/definition.py
+++ b/pyne/simplesim/definition.py
@@ -2,7 +2,7 @@
 
 """The ``definition`` module can be imported as such::
 
-    from pyne.simplesim import definition
+    from .simplesim import definition
 
 ********
 Overview
@@ -62,8 +62,8 @@ except ImportError:
 
 import numpy as np
 
-from pyne import material
-from pyne.simplesim import cards
+from .. import material
+from . import cards
 
 class IDefinition(object):
     """This class is not used by the user. Abstract base class for

--- a/pyne/simplesim/inputfile.py
+++ b/pyne/simplesim/inputfile.py
@@ -2,7 +2,7 @@
 
 """The ``inputfile`` module can be imported as such::
 
-    from pyne.simplesim import inputfile
+    from .simplesim import inputfile
 
 
 ********
@@ -40,8 +40,8 @@ import warnings
 
 import numpy as np
 
-from pyne.simplesim import definition
-from pyne.simplesim import cards
+from . import definition
+from . import cards
 
 class IInputFile(object):
     """This class is not used directly by the user. Abstract base class for

--- a/pyne/simplesim/nestedgeom.py
+++ b/pyne/simplesim/nestedgeom.py
@@ -10,7 +10,7 @@ comments and mcnp strings.
 The names of classes here are fairly short, so the user may not want to import
 the entire namespace. A suggested way to import the module is::
 
-    import pyne.simplesim.nestedgeom as ng
+    import .simplesim.nestedgeom as ng
 
 
 An inheritance diagram of all the classes in this module can be found at

--- a/pyne/transmute/chainsolve.py
+++ b/pyne/transmute/chainsolve.py
@@ -5,15 +5,15 @@ import numpy as np
 from scipy import linalg
 #from scipy import sparse  # <-- SPARSE
 
-from pyne import utils
-from pyne import data
-from pyne import rxname
-from pyne import nucname
-from pyne import nuc_data
-from pyne.material import Material, from_atom_frac
-from pyne.xs.data_source import NullDataSource, EAFDataSource
-from pyne.xs.cache import XSCache
-from pyne.xs.channels import sigma_a
+from .. import utils
+from .. import data
+from .. import rxname
+from .. import nucname
+from .. import nuc_data
+from ..material import Material, from_atom_frac
+from ..xs.data_source import NullDataSource, EAFDataSource
+from ..xs.cache import XSCache
+from ..xs.channels import sigma_a
 
 class Transmuter(object):
     """A class for transmuting materials using an ALARA-like chain solver."""

--- a/pyne/xs/api.py
+++ b/pyne/xs/api.py
@@ -1,5 +1,5 @@
-from pyne.xs.cache import xs_cache
+from .xs.cache import xs_cache
 
-from pyne.xs import models
-from pyne.xs.models import partial_energy_matrix, phi_g
-from pyne.xs.channels import sigma_f
+from .xs import models
+from .xs.models import partial_energy_matrix, phi_g
+from .xs.channels import sigma_f

--- a/pyne/xs/cache.py
+++ b/pyne/xs/cache.py
@@ -6,10 +6,10 @@ from collections import MutableMapping
 import numpy as np
 import tables as tb
 
-from pyne import nucname
-from pyne.pyne_config import pyne_conf
-from pyne.xs.models import partial_energy_matrix, phi_g
-from pyne.xs import data_source
+from .. import nucname
+from ..pyne_config import pyne_conf
+from .models import partial_energy_matrix, phi_g
+from . import data_source
 
 
 def _same_arr_or_none(a, b): 

--- a/pyne/xs/channels.py
+++ b/pyne/xs/channels.py
@@ -12,14 +12,14 @@ np.seterr(all='ignore')
 import scipy.integrate
 import tables as tb
 
-import pyne
-import pyne.data
-import pyne.xs.models
-from pyne import nucname
-from pyne import rxname
-from pyne.xs import cache
-from pyne.xs.models import group_collapse
-from pyne.material import Material
+from .. import nuc_data
+from .. import data
+from .. import nucname
+from .. import rxname
+from ..material import Material
+from . import models
+from . import cache
+from .models import group_collapse
 
 
 def _prep_cache(xs_cache, E_g=None, phi_g=None):
@@ -145,8 +145,8 @@ def sigma_s_gh(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None):
     # Get some needed data
     E_g = xs_cache['E_g']
     G = len(E_g) - 1
-    b = pyne.data.b(nuc)
-    aw = pyne.data.atomic_mass(nuc)
+    b = data.b(nuc)
+    aw = data.atomic_mass(nuc)
 
     # OMG FIXME So hard!
     ## Initialize the scattering kernel
@@ -172,7 +172,7 @@ def sigma_s_gh(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None):
 
     # Temporary stub
     E_g_centers = (E_g[1:] + E_g[:-1]) / 2.0
-    sig_s = pyne.xs.models.sigma_s(E_g_centers, b, aw, temp)
+    sig_s = models.sigma_s(E_g_centers, b, aw, temp)
     sig_s_gh = np.diag(sig_s)
 
     xs_cache[key] = sig_s_gh
@@ -419,7 +419,7 @@ def chi(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None, eres=101)
 
     # Get the the set of nuclides we know we need chi for.  
     if 'fissionable_nucs' not in xs_cache:
-        with tb.openFile(pyne.nuc_data, 'r') as f:
+        with tb.openFile(nuc_data, 'r') as f:
             if '/neutron/cinder_xs/fission' in f:
                 fn = set(f.root.neutron.cinder_xs.fission.cols.nuc)
             else:
@@ -436,7 +436,7 @@ def chi(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None, eres=101)
     if (nuc in fissionable_nucs):
         for g in range(G):
             E_space = np.logspace(np.log10(E_g[g]), np.log10(E_g[g+1]), eres)
-            dnumer = pyne.xs.models.chi(E_space)
+            dnumer = models.chi(E_space)
             numer = scipy.integrate.trapz(dnumer, E_space)
             denom = (E_g[g+1] - E_g[g])
             chi_g[g] = (numer / denom)

--- a/pyne/xs/data_source.py
+++ b/pyne/xs/data_source.py
@@ -6,11 +6,11 @@ import StringIO
 import numpy as np
 import tables as tb
 
-from pyne import nuc_data
-from pyne import nucname
-from pyne import rxname
-from pyne.xs.models import partial_energy_matrix, group_collapse
-from pyne.endf import Library
+from .. import nuc_data
+from .. import nucname
+from .. import rxname
+from ..endf import Library
+from .models import partial_energy_matrix, group_collapse
 
 class DataSource(object):
     """Base cross section data source.


### PR DESCRIPTION
I updated some import statements to be relative to the package.  I found this to help with some of the recent nuc_data_make issues, though I am not 100% certain it is required to fix those.  This is generally a good idea anyway so that you don't end up with modules from multiple installations being pulled in due to a weird PYTHONPATH state.  Inspired by #212.
