### PR TITLE
Use ctypes.cdll's LoadLibrary function so no path editing is required 

### DIFF
--- a/pyne/__init__.py
+++ b/pyne/__init__.py
@@ -9,7 +9,7 @@ if os.name == 'nt':
     libtype = '.dll'
 elif sys.platform == 'darwin':
     libtype = '.dylib'
-liblist = ['libpyne', 'libpyne_data', 'libpyne_material', 'libpyne_enrichemnt', 'libpyne_nucname', 'libpyne_rxname']
+liblist = ['libpyne', 'libpyne_data', 'libpyne_material', 'libpyne_enrichment', 'libpyne_nucname', 'libpyne_rxname']
 
 if libtype is not None:
     for item in liblist:


### PR DESCRIPTION
This loads all the libraries in /lib in the correct order (needed on windows at least) so no changes to the path on any platform are required after install and before using pyne.
