### PR TITLE
Default to release build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project( pyne )
 # 'include()' command, 'find_package()' command.
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake )
 
+#Default to release build type
+set(CMAKE_BUILD_TYPE Release)
+
 # give an option for whether this should be built as a CI project
 option(IS_CI "Is this project being built under continuous integration?" FALSE)
 


### PR DESCRIPTION
Set CMAKE_BUILD_TYPE to release. This adds the 03 flag to the compilation of c/c++. Factor 2x improvement in speed! (for the random function I chose).

timeit results on test_uranium_cascade pyne:staging 
10000 loops, best of 3: 121 µs per loop
timeit results on test_uranium_cascade crbates:build_type
10000 loops, best of 3: 64.7 µs per loop 
