### PR TITLE
Clarified cython dependency

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -24,7 +24,7 @@ PyNE has the following dependencies:
    #. `CMake <http://www.cmake.org/>`_ (>= 2.8.5)
    #. `NumPy <http://www.numpy.org/>`_
    #. `SciPy <http://www.scipy.org/>`_
-   #. `Cython <http://cython.org/>`_
+   #. `Cython <http://cython.org/>`_ (>= 0.19.1)
    #. `HDF5 <http://www.hdfgroup.org/HDF5/>`_
    #. `PyTables <http://www.pytables.org/>`_
    #. `Python 2.7 <http://www.python.org/>`_


### PR DESCRIPTION
Just adding the required Cython version to the readme. This is the most common problem I have encountered helping others install PyNE on Linux.
