### PR TITLE
Bug Fixes on MCNP SurfSrc Class (niss variable improper assign to long, wrong labels on tracks); more PEP8 on mcnp.py

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -351,7 +351,6 @@ class SurfSrc(_BinaryReader):
             self.ncrd = tablelengths.get_int()[0]      # histories to surf.src
             self.njsw = tablelengths.get_int()[0]      # number of surfaces
             self.niss = tablelengths.get_int()[0]      # histories to surf.src
-            # self.notsure2 = tablelengths.get_int()[0]  # number of surfaces
 
         if self.np1 < 0:
             # read table 2 record; more size info


### PR DESCRIPTION
The track records should have these labels (in this order)
1. nps
2. bitarray
3. wgt
4. erg
5. tme
6. x
7. y
8. z
9. u
10. v
11. cs

Direction cosine `w` is backed out from `u` and `v`.

Also @scopatz, we had a discussion about optional `max_tracks` on the `print_tracklist()` function, but I reverted a commit and it got lost until I realized that I needed it (when finally using it).  The rest is just complaints I found during flake8 checks.

Unit tests pass on my slow laptop but should be double-checked.

```
Ran 662 tests in 11.232s

OK
```
