### PR TITLE
fixed several memory leaks of local HD5Read buffers

### DIFF
--- a/cpp/data.cpp
+++ b/cpp/data.cpp
@@ -68,6 +68,8 @@ void pyne::_load_atomic_mass_map()
     atomic_mass_map[atomic_weight_array[n].nuc] = atomic_weight_array[n].mass;
     natural_abund_map[atomic_weight_array[n].nuc] = atomic_weight_array[n].abund;
   }
+
+  delete[] atomic_weight_array;
 };
 
 
@@ -255,6 +257,8 @@ void pyne::_load_scattering_lengths()
     b_coherent_map[scat_len_array[n].nuc] = scat_len_array[n].b_coherent;
     b_incoherent_map[scat_len_array[n].nuc] = scat_len_array[n].b_incoherent;
   };
+
+  delete[] scat_len_array;
 };
 
 
@@ -544,6 +548,8 @@ void pyne::_load_atomic_decay()
     if (0.0 != atom_dec_array[n].decay_const)
       decay_children_map[from_nuc].insert(to_nuc);
   };
+
+  delete[] atom_dec_array;
 };
 
 

--- a/cpp/h5wrap.h
+++ b/cpp/h5wrap.h
@@ -200,6 +200,8 @@ namespace h5wrap
     cpp_set.insert(&mem_arr[0], &mem_arr[arr_len[0]]);
 
     H5Dclose(dset);
+
+    delete[] mem_arr;
     return cpp_set;
   };
 


### PR DESCRIPTION
Several local buffers used in calls to HD5Read were not deallocated before exiting the local scope. Most of these were added by commit a48a5409c84ec78cd6369beb9be6e1f25bf0a6f4.
