### PR TITLE
Material methods to return MCNP and ALARA strings.

### DIFF
--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1259,7 +1259,7 @@ class Material(_Material, collections.MutableMapping):
 
 
     def mcnp(self, frac_type='mass'):
-        """mcnp_str(self, frac_type='mass')
+        """mcnp(self, frac_type='mass')
         This method returns an MCNP material card in string form. Relevant
         attributes are added as MCNP valid comments.
 
@@ -1311,8 +1311,25 @@ class Material(_Material, collections.MutableMapping):
 
         return s
 
+
+    def write_mcnp(self, filename, frac_type='mass'):
+        """write_mcnp(self, filename, frac_type='mass')
+        The method appends an MCNP mass fraction definition, with
+        attributes to the file with the supplied filename.
+
+        Parameters
+        ----------
+        filename : str
+            The file to append the material definition to.
+        frac_type : str, optional
+            Either 'mass' or 'atom'. Speficies whether mass or atom fractions
+            are used to describe material composition.
+        """
+        with open(filename, 'a') as f:
+            f.write(self.mcnp(frac_type))
+
     def alara(self):
-        """alara_str(self)
+        """alara(self)
         This method returns an ALARA material in string form, with relevant
         attributes as ALARA valid comments.
 
@@ -1359,6 +1376,19 @@ class Material(_Material, collections.MutableMapping):
                                                  frac, str(nucname.znum(iso)))
 
         return s
+
+    def write_alara(self, filename):
+        """write_alara(self, filename)
+        The method appends an ALARA material d$efinition, with attributes
+        to the file with the supplied filename.
+
+        Parameters
+        ----------
+        filename : str
+            The file to append the material definition to.
+        """
+        with open(filename, 'a') as f:
+            f.write(self.alara())
 
 #####################################
 ### Material generation functions ###

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1048,6 +1048,82 @@ def test_alara():
                 '     u:238 9.6000E-01 92\n')
     assert_equal(written, expected)
 
+def test_write_mcnp():
+    if 'mcnp_mass_fracs.txt' in os.listdir('.'):
+        os.remove('mcnp_mass_fracs.txt')
+
+    leu = Material(nucvec={'U235': 0.04, 'U238': 0.96}, 
+                   attrs={'mat_number': 2, 
+                          'table_ids': {'92235':'15c', '92238':'25c'},
+                          'mat_name':'LEU', 
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          'name':'leu'}, 
+                   density=19.1)
+
+    leu.write_mcnp('mcnp_mass_fracs.txt')
+    leu.write_mcnp('mcnp_mass_fracs.txt', frac_type='atom')
+
+    with open('mcnp_mass_fracs.txt') as f:
+        written = f.read()
+    expected = ('C name: leu\n'
+                'C density = 19.1\n'
+                'C source: Some URL\n'
+                'C comments: this is a long comment that will definitly go over the 80 character\n'
+                'C  limit, for science\n'
+                'm2\n'
+                '     92235.15c -4.0000E-02\n'
+                '     92238.25c -9.6000E-01\n'
+                'C name: leu\n'
+                'C density = 19.1\n'
+                'C source: Some URL\n'
+                'C comments: this is a long comment that will definitly go over the 80 character\n'
+                'C  limit, for science\n'
+                'm2\n'
+                '     92235.15c 4.0491E-02\n'
+                '     92238.25c 9.5951E-01\n')
+    assert_equal(written, expected)
+    os.remove('mcnp_mass_fracs.txt')
+
+
+def test_write_alara():
+    if 'alara.txt' in os.listdir('.'):
+        os.remove('alara.txt')
+
+    leu = Material(nucvec={'U235': 0.04, 'U238': 0.96}, attrs={\
+          'mat_number':2, 'table_ids':{'922350':'15c', '922380':'25c'},\
+          'name':'LEU', 'source':'Some URL', \
+          'comments': \
+'this is a long comment that will definitly go over the 80 character limit, for science', \
+            }, density=19.1)
+    leu2 = Material(nucvec={'U235': 0.04, 'U238': 0.96}, attrs={\
+          'mat_number':2,}, density=19.1)
+    leu3 = Material(nucvec={'U235': 0.04, 'U238': 0.96})
+
+    leu.write_alara('alara.txt')
+    leu2.write_alara('alara.txt')
+    leu3.write_alara('alara.txt')
+
+    with open('alara.txt') as f:
+        written = f.read()
+    expected = ('# mat number: 2\n'
+                '# source: Some URL\n'
+                '# comments: this is a long comment that will definitly go over the 80 character\n'
+                '#  limit, for science\n'
+                'LEU 19.1 2\n'
+                '     u:235 4.0000E-02 92\n'
+                '     u:238 9.6000E-01 92\n'
+                '# mat number: 2\n'
+                'mat2_rho-19.1 19.1 2\n'
+                '     u:235 4.0000E-02 92\n'
+                '     u:238 9.6000E-01 92\n'
+                'mat<mat_num>_rho-<rho> <rho> 2\n'
+                '     u:235 4.0000E-02 92\n'
+                '     u:238 9.6000E-01 92\n')
+    assert_equal(written, expected)
+    os.remove('alara.txt')
+
 def test_natural_elements():
     water = Material()
     water.from_atom_frac({10000000: 2.0, 80000000: 1.0})


### PR DESCRIPTION
This PR tweaks existing methods that write MCNP and ALARA `Material` representations to a supplied file. Instead, they now return strings. This is necessary for `mesh_to_geom` functionality in `mcnp`.
