### PR TITLE
Removed extraneous whitespace from MCNP geom input generation function.

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1976,7 +1976,7 @@ def mesh_to_geom(mesh, frac_type='mass', title_card="Generated from PyNE Mesh"):
     surf_cards = _mesh_to_surf_cards(mesh, divs)
     mat_cards = _mesh_to_mat_cards(mesh, divs, frac_type)
  
-    return "{0}\n{1}\n{2}\n{3}\n".format(title_card, cell_cards, 
+    return "{0}\n{1}\n{2}\n{3}".format(title_card, cell_cards, 
                                               surf_cards, mat_cards)
 
 def _mesh_to_cell_cards(mesh, divs):

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -1096,6 +1096,6 @@ def test_mesh_to_geom():
     "     6012 -1.0000E+00\n"
     "C density = 5.0\n"
     "m6\n"
-    "     1002 -1.0000E+00\n\n")
+    "     1002 -1.0000E+00\n")
 
     assert_equal(geom, exp_geom)


### PR DESCRIPTION
There are 3 sections of an MCNP input file that are each delimited by a blank new line. Previously, `mesh_to_geom` added a blank new line at the end of the material specifications. When creating a full input file, the rest of the data cards need to follow immediately after the material cards in this case, without a new line interruption. This PR removes this interruption.
