### PR TITLE
Fixed errors in alara module functions.

### DIFF
--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -241,6 +241,7 @@ def mesh_to_geom(mesh, geom_file, matlib_file):
     # single mesh iteration.
     volume = "volume\n" # volume input block
     mat_loading = "mat_loading\n" # material loading input block
+    mixture = "" # mixture blocks
     matlib = "" # ALARA material library string
 
     if mesh.structured:
@@ -250,20 +251,22 @@ def mesh_to_geom(mesh, geom_file, matlib_file):
 
     for i, ve in enumerate(ves):
         volume += "    {0: 1.6E}    zone_{1}\n".format(mesh.elem_volume(ve), i)
-        mat_loading += "    zone_{0}    mat_{1}\n".format(i, i)
+        mat_loading += "    zone_{0}    mix_{0}\n".format(i)
         matlib += "mat_{0}    {1: 1.6E}    {2}\n".format(i, mesh.density[i], 
                                                          len(mesh.comp[i]))
+        mixture += ("mixture mix_{0}\n"
+                    "    material mat_{0} 1 1\nend\n\n".format(i))
+
         for nuc, comp in mesh.comp[i].iteritems():
             matlib += "{0}    {1: 1.6E}    {2}\n".format(alara(nuc), comp, 
                                                          znum(nuc))
- 
         matlib += "\n"
 
     volume += "end\n\n"
     mat_loading += "end\n\n"
 
     with open(geom_file, 'w') as f:
-        f.write(geometry + volume + mat_loading)
+        f.write(geometry + volume + mat_loading + mixture)
     
     with open(matlib_file, 'w') as f:
         f.write(matlib)
@@ -335,11 +338,11 @@ def num_density_to_mesh(lines, time, m):
 
 
 def irradiation_blocks(material_lib, element_lib, data_library, cooling, 
-                       flux_file, irr_time, output = "constituent",
+                       flux_file, irr_time, output = "number_density",
                        truncation=1E-12, impurity = (5E-6, 1E-3), 
                        dump_file = "dump_file"):
     """irradiation_blocks(material_lib, element_lib, data_library, cooling, 
-                       flux_file, irr_time, output = "constituent",
+                       flux_file, irr_time, output = "number_density",
                        truncation=1E-12, impurity = (5E-6, 1E-3), 
                        dump_file = "dump_file")
 

--- a/tests/files_test_alara/alara_geom.txt
+++ b/tests/files_test_alara/alara_geom.txt
@@ -8,9 +8,25 @@ volume
 end
 
 mat_loading
-    zone_0    mat_0
-    zone_1    mat_1
-    zone_2    mat_2
-    zone_3    mat_3
+    zone_0    mix_0
+    zone_1    mix_1
+    zone_2    mix_2
+    zone_3    mix_3
+end
+
+mixture mix_0
+    material mat_0 1 1
+end
+
+mixture mix_1
+    material mat_1 1 1
+end
+
+mixture mix_2
+    material mat_2 1 1
+end
+
+mixture mix_3
+    material mat_3 1 1
 end
 

--- a/tests/test_alara.py
+++ b/tests/test_alara.py
@@ -302,7 +302,7 @@ def test_irradiation_blocks():
     act = irradiation_blocks("matlib", "isolib", 
                              "FEINDlib CINDER CINDER90 THERMAL", 
                              ["1 h", "0.5 y"], "fluxin.out", "1 y", 
-                             output = "constituant")
+                             output = "number_density")
 
     exp = ("material_lib matlib\n"
           "element_lib isolib\n"
@@ -324,7 +324,7 @@ def test_irradiation_blocks():
           "\n"
           "output zone\n"
           "    units Ci cm3\n"
-          "    constituant\n"
+          "    number_density\n"
           "end\n"
           "\n"
           "truncation 1e-12\n"


### PR DESCRIPTION
Discovered while writing iterative burnup script:
1) Materials cannot be assigned to zones. Only mixtures can be assigned to zones.
2) "number_density" is, unsurprisingly the keyword to output number density, not "constituent".
