### PR TITLE
Complete quoting for parameters of some CMake commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project( pyne )
 
 # Make the scripts available in the 'cmake' directory available for the
 # 'include()' command, 'find_package()' command.
-set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake )
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 #Default to release build type
 set(CMAKE_BUILD_TYPE Release)
@@ -79,7 +79,7 @@ message("-- RPATH: ${CMAKE_INSTALL_RPATH}")
 
 # find numpy and include the numpy headers
 find_package(Numpy REQUIRED)
-include_directories(${NUMPY_INCLUDE_DIR})
+include_directories("${NUMPY_INCLUDE_DIR}")
 
 # Add JsonCpp Flag
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJSON_IS_AMALGAMATION")
@@ -95,10 +95,10 @@ endif(${IS_CI})
 # no-longer needed in the build tree.  However, with pure *.py source, the
 # source is processed directly.  To handle this, we reproduce the availability
 # of the source files in the build tree.
-add_custom_target( ReplicatePythonSourceTree ALL ${CMAKE_COMMAND} -P
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ReplicatePythonSourceTree.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
+add_custom_target(ReplicatePythonSourceTree ALL "${CMAKE_COMMAND}" -P
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ReplicatePythonSourceTree.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_subdirectory(cpp)
 add_subdirectory(pyne)
@@ -109,21 +109,21 @@ get_property(inc_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
 message("-- C_INCLUDE_PATH for ${CMAKE_CURRENT_SOURCE_DIR}: ${inc_dirs}")
 
 message("-- Copying C/C++ header files.")
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ DESTINATION
-    ${CMAKE_BINARY_DIR}/pyne/include/ FILES_MATCHING PATTERN "*.h")
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/cpp/" DESTINATION
+    "${CMAKE_BINARY_DIR}/pyne/include/" FILES_MATCHING PATTERN "*.h")
 
 message("-- Copying Cython header files.")
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/pyne/ 
-    DESTINATION ${CMAKE_BINARY_DIR}/pyne/
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/pyne/"
+    DESTINATION "${CMAKE_BINARY_DIR}/pyne/"
     FILES_MATCHING PATTERN "*.pxd"
                    PATTERN "lib" EXCLUDE
                    PATTERN "include" EXCLUDE)
 
 message("-- Copying scripts.")
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/scripts DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/scripts" DESTINATION "${CMAKE_BINARY_DIR}")
 
 # Add cython version info to source tree
 message("-- Making Metadata.")
-execute_process(COMMAND ${PYTHON_EXECUTABLE} 
-                        ${CMAKE_CURRENT_SOURCE_DIR}/configure.py metadata)
+execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+                        "${CMAKE_CURRENT_SOURCE_DIR}/configure.py" metadata)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
-set(PYNE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${PYNE_INCLUDE_DIRS} PARENT_SCOPE)
+set(PYNE_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}" ${PYNE_INCLUDE_DIRS} PARENT_SCOPE)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
 # pyne
 add_library(pyne jsoncpp.cpp pyne.cpp)
@@ -48,5 +48,5 @@ install_lib(pyne_enrichment)
 get_property(inc_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
 message("-- C_INCLUDE_PATH for ${CMAKE_CURRENT_SOURCE_DIR}: ${inc_dirs}")
 
-#file(COPY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION 
-#    ${CMAKE_BINARY_DIR}/pyne/includes/ FILES_MATCHING PATTERN "*.h")
+#file(COPY "${CMAKE_CURRENT_SOURCE_DIR}" DESTINATION 
+#    "${CMAKE_BINARY_DIR}/pyne/includes/" FILES_MATCHING PATTERN "*.h")

--- a/pyne/CMakeLists.txt
+++ b/pyne/CMakeLists.txt
@@ -6,82 +6,82 @@ get_property(inc_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
 message("-- C_INCLUDE_PATH for ${CMAKE_CURRENT_SOURCE_DIR}: ${inc_dirs}")
 
 # extra_types
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/extra_types.pyx
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/extra_types.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(extra_types extra_types.pyx)
 
 # STL containers
 # If the pyx file is a C++ file, we should specify that here.
 # then, add the module
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/stlcontainers.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/stlcontainers.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(stlcontainers stlcontainers.pyx)
                             
 # jsoncpp
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/jsoncpp.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/jsoncpp.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(jsoncpp jsoncpp.pyx)
 target_link_libraries(jsoncpp pyne)
 
 # pyne_config
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/pyne_config.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/pyne_config.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(pyne_config pyne_config.pyx)
 target_link_libraries(pyne_config pyne)
 
 # _utils
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/_utils.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/_utils.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(_utils _utils.pyx)
 target_link_libraries(_utils pyne)
 
 # dagmc
 if (MOAB_FOUND)
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/dagmc.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/dagmc.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
-cython_add_module(_dagmc dagmc.pyx ${PROJECT_SOURCE_DIR}/cpp/dagmc_bridge.cpp)
+cython_add_module(_dagmc dagmc.pyx "${PROJECT_SOURCE_DIR}/cpp/dagmc_bridge.cpp")
 target_link_libraries(_dagmc dagmc MOAB pyne)
 set_target_properties(_dagmc PROPERTIES OUTPUT_NAME dagmc)
 endif (MOAB_FOUND)
 
 # endf
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/endf.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/endf.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(endf endf.pyx)
 target_link_libraries(endf pyne_nucname)
 
 # nucname
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/nucname.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/nucname.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(nucname nucname.pyx)
 target_link_libraries(nucname pyne pyne_nucname)
 
 # rxname
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/rxname.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/rxname.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(rxname rxname.pyx)
 target_link_libraries(rxname pyne pyne_rxname)
 
 # data
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/data.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/data.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(data data.pyx)
 target_link_libraries(data pyne pyne_nucname pyne_data hdf5)
 
 # material
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/material.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/material.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(material  material.pyx)
 target_link_libraries(material pyne pyne_nucname pyne_data pyne_material hdf5)
 
 # ace
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/ace.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/ace.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(ace ace.pyx)
 target_link_libraries(ace pyne pyne_nucname)
 
 # enrichment
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/enrichment.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/enrichment.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(enrichment enrichment.pyx)
 target_link_libraries(enrichment pyne_enrichment pyne_material)

--- a/pyne/xs/CMakeLists.txt
+++ b/pyne/xs/CMakeLists.txt
@@ -2,7 +2,7 @@
 include_directories(${PYNE_INCLUDE_DIRS})
 
 # xs
-set_source_files_properties(${PROJECT_SOURCE_DIR}/pyne/xs/models.pyx 
+set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/xs/models.pyx"
                             PROPERTIES CYTHON_IS_CXX TRUE)
 cython_add_module(models models.pyx)
 target_link_libraries(models pyne pyne_nucname)


### PR DESCRIPTION
[A Wiki article pointed out](http://cmake.org/Wiki/CMake/Language_Syntax#CMake_splits_arguments_unless_you_use_quotation_marks_or_escapes.) that whitespace will only be preserved for parameters in CMake commands if passed strings will be appropriately quoted or escaped.

Quoting can be added so that more places should also handle file names correctly which contain space characters eventually.
