### PR TITLE
Added nuc listing method to mcnp Xsdir

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -806,13 +806,13 @@ class Xsdir(object):
 
         Returns
         -------
-        nuc : set
-            The set of nuclide ids.
+        valid_nucs : set
+            The valid nuclide ids.
         """
          
-        nucs = set(nucname.id(nuc) for nuc in self.awr.keys() 
+        valid_nucs = set(nucname.id(nuc) for nuc in self.awr.keys() 
                    if nucname.isnuclide(nuc))
-        return nucs
+        return valid_nucs
 
 
 class XsdirTable(object):


### PR DESCRIPTION
Closes #318. There are no tests for the entire `Xsdir` class. I presume this was done due to nuclear data redtape. Likewise, I have not (yet?) written tests for this method.
