### PR TITLE
Fixed atomic mass/weight problem.

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -731,7 +731,7 @@ class Xsdir(object):
         words = line.split()
         assert len(words) == 3
         assert words[0].lower() == 'atomic'
-        assert words[1].lower() == 'mass'
+        assert words[1].lower() == 'weight'
         assert words[2].lower() == 'ratios'
 
         while True:


### PR DESCRIPTION
Reverted change from #284 that breaks Xsdir. The terminology used by MCNP is "atomic weight ratios".
