### PR TITLE
adds deepcopy() capability to pyne materials

### DIFF
--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1201,7 +1201,6 @@ cdef class _Material:
         return id(self)
 
 
-
 class Material(_Material, collections.MutableMapping):
     """Material composed of nuclides.
 
@@ -1241,7 +1240,7 @@ class Material(_Material, collections.MutableMapping):
     def __str__(self):
         header = ["Material:"]
         header += ["mass = {0}".format(self.mass)]
-        header += ["density= {0}".format(self.density)]
+        header += ["density = {0}".format(self.density)]
         header += ["atoms per molecule = {0}".format(self.atoms_per_molecule)]
         if self.attrs.isobject():
             for key, value in self.attrs.items():
@@ -1257,6 +1256,18 @@ class Material(_Material, collections.MutableMapping):
         return "pyne.material.Material({0}, {1}, {2}, {3}, {4})".format(
                 repr(self.comp), self.mass, self.density, self.atoms_per_molecule, repr(self.attrs))
 
+    def __deepcopy__(self, memo):
+        cdef _Material other = Material(free_mat=False)
+        cdef cpp_material.Material * self_ptr = (<_Material> self).mat_pointer
+        cdef cpp_material.Material * other_ptr = new cpp_material.Material()
+        other_ptr.comp = self_ptr.comp
+        other_ptr.mass = self_ptr.mass
+        other_ptr.density = self_ptr.density
+        other_ptr.atoms_per_molecule = self_ptr.atoms_per_molecule
+        other_ptr.attrs = self_ptr.attrs
+        other.mat_pointer = other_ptr
+        other._free_mat = True
+        return other
 
     def mcnp(self, frac_type='mass'):
         """mcnp(self, frac_type='mass')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,4 +1,6 @@
 """Material tests"""
+import os
+from copy import deepcopy
 
 from unittest import TestCase
 import nose 
@@ -6,7 +8,6 @@ import nose
 from nose.tools import assert_equal, assert_not_equal, assert_raises, raises, \
     assert_almost_equal, assert_true, assert_false, assert_in
 
-import os
 from pyne import nuc_data
 from pyne.material import Material, from_atom_frac, from_hdf5, from_text, \
     MapStrMaterial, MultiMaterial, MaterialLibrary
@@ -994,6 +995,22 @@ def test_multimaterial_mix_density():
     assert_equal(mat4.density, 1.5)
 
     assert_equal(mat3.density, mat4.density)
+
+def test_deepcopy():
+    x = Material({'H1': 1.0}, mass=2.0, density=3.0, atoms_per_molecule=4.0, 
+                 attrs={'name': 'loki'})
+    y = deepcopy(x)
+    assert_equal(x, y)
+    y.comp[10010000] = 42.0
+    y[80160000] = 21.0
+    y.density = 65.0
+    y.atoms_per_molecule = 28.0
+    y.attrs['wakka'] = 'jawaka'
+    y.mass = 48.0
+    y.attrs['name'] = 'odin'
+    assert_not_equal(x, y)
+    assert_equal(x, Material({'H1': 1.0}, mass=2.0, density=3.0, atoms_per_molecule=4.0, 
+                             attrs={'name': 'loki'}))
 
 def test_mcnp():
 


### PR DESCRIPTION
by popular demand.  You should now be able to do the following

``` python
from copy import deepcopy

new_mat = deepcopy(mat)
```
