### PR TITLE
Fixes #360

### DIFF
--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -336,7 +336,7 @@ class IMeshTag(Tag):
         m = self.mesh.mesh
         size = len(self.mesh)
         mtag = self.tag
-        miter = m.iterate(iBase.Type.region, iMesh.Topology.all)
+        miter = self.mesh.iter_ve()
         if isinstance(key, _INTEGRAL_TYPES):
             if key >= size:
                 raise IndexError("key index {0} greater than the size of the "
@@ -366,7 +366,7 @@ class IMeshTag(Tag):
         m = self.mesh.mesh
         msize = len(self.mesh)
         mtag = self.tag
-        miter = m.iterate(iBase.Type.region, iMesh.Topology.all)
+        miter = self.mesh.iter_ve()
         if isinstance(key, _INTEGRAL_TYPES):
             if key >= msize:
                 raise IndexError("key index {0} greater than the size of the "
@@ -399,7 +399,7 @@ class IMeshTag(Tag):
         m = self.mesh.mesh
         size = len(self.mesh)
         mtag = self.tag
-        miter = m.iterate(iBase.Type.region, iMesh.Topology.all)
+        miter = self.mesh.iter_ve()
         if isinstance(key, _INTEGRAL_TYPES):
             if key >= size:
                 raise IndexError("key index {0} greater than the size of the "
@@ -662,11 +662,7 @@ class Mesh(object):
         self.mats = mats
 
         # tag with volume id and ensure mats exist.
-        if self.structured:
-            ves = list(self.structured_iterate_hex(self.structured_ordering))
-        else:
-            ves = list(self.mesh.iterate(iBase.Type.region, iMesh.Topology.all))
-
+        ves = list(self.iter_ve())
         tags = self.mesh.getAllTags(ves[0])
         tags = set(tag.name for tag in tags)
         if 'idx' in tags:
@@ -725,6 +721,14 @@ class Mesh(object):
         for i, ve in enumerate(self.mesh.iterate(iBase.Type.region, 
                                                  iMesh.Topology.all)):
             yield i, mats[i], ve
+
+    def iter_ve(self):
+        """Returns an iterator that yields on the volume elements.
+        """
+        if self.structured:
+            return self.structured_iterate_hex(self.structured_ordering)
+        else:
+            return self.mesh.iterate(iBase.Type.region, iMesh.Topology.all)
 
     def __contains__(self, i):
         return i < len(self)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -735,6 +735,12 @@ def test_lazytaginit():
     m.cactus[:] = x
     assert_array_equal(m.cactus[2], x[2])
 
+def test_issue360():
+    a = Mesh(structured=True, structured_coords=[[0,1,2],[0,1],[0,1]])
+    a.cat = IMeshTag(3, float)
+    a.cat[:] = [[0.11, 0.22, 0.33],[0.44, 0.55, 0.66]]
+    a.cat[:] = np.array([[0.11, 0.22, 0.33],[0.44, 0.55, 0.66]])
+
 def test_iter():
     mats = {
         0: Material({'H1': 1.0, 'K39': 1.0}, density=42.0), 
@@ -750,6 +756,17 @@ def test_iter():
         assert_is(mats[i], mat)
         assert_equal(j, idx_tag[ve])
         j += 1
+
+def test_iter_ve():
+    mats = {
+        0: Material({'H1': 1.0, 'K39': 1.0}, density=42.0), 
+        1: Material({'H1': 0.1, 'O16': 1.0}, density=43.0), 
+        2: Material({'He4': 42.0}, density=44.0), 
+        3: Material({'Tm171': 171.0}, density=45.0), 
+        }
+    m = gen_mesh(mats=mats)
+    ves1 = set(ve for _, _, ve in m)
+    ves2 = set(m.iter_ve())
         
 
 def test_contains():


### PR DESCRIPTION
This issue fixes #360 and will hopefully put a lot of our IMesh Tag woes behind us.  This also adds an iteration methods for Mesh that only yields the volume element (`iter_ve()`).  This is useful for abstracting whether it is a structured mesh or not.
