### PR TITLE
mesh.write_hdf5() fix

### DIFF
--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -1150,7 +1150,8 @@ class Mesh(object):
     def write_hdf5(self, filename):
         """Writes the mesh to an hdf5 file."""
         self.mesh.save(filename)
-        self.mats.write_hdf5(filename)
+        if self.mats is not None:
+            self.mats.write_hdf5(filename)
 
     def cell_fracs_to_mats(self, cell_fracs, cell_mats):
         """This function uses the output from dagmc.discretize_geom() and 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -571,6 +571,10 @@ def test_matlib():
         assert_equal(mat.density, mats[i].density)
         assert_equal(m2.idx[i], i)
 
+@with_setup(None, try_rm_file('test_no_matlib.h5m'))
+def test_no_matlib():
+    m = gen_mesh(mats=None)
+    m.write_hdf5('test_no_matlib.h5m')
     
 def test_matproptag():
     mats = {


### PR DESCRIPTION
Previously failed for case when `mats=None`.
