### PR TITLE
Only compile source sampling if MOAB is found.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,11 +14,9 @@ set(PYNE_SRCS
     "rxname.cpp"
     "tally.cpp"
     "utils.cpp"
-    "source_sampling.cpp"
-    "measure.cpp"
     )
 if (MOAB_FOUND)
-    set(PYNE_SRCS "${PYNE_SRCS}" "dagmc_bridge.cpp")    
+    set(PYNE_SRCS "${PYNE_SRCS}" "dagmc_bridge.cpp" "source_sampling.cpp" "measure.cpp")    
 endif (MOAB_FOUND)
 
 # compile and link library


### PR DESCRIPTION
Addressing #493. I think this should fix it but I have not tested this. I can confirm tonight.
