### PR TITLE
Added OpenMC nuclide naming convention

### DIFF
--- a/pyne/cpp_nucname.pxd
+++ b/pyne/cpp_nucname.pxd
@@ -92,6 +92,13 @@ cdef extern from "nucname.h" namespace "pyne::nucname":
     int serpent_to_id(char *) except +
     int serpent_to_id(std_string) except +
 
+    # OpenMC Functions
+    std_string openmc(int) except +
+    std_string openmc(char *) except +
+    std_string openmc(std_string) except +
+    int openmc_to_id(char *) except +
+    int openmc_to_id(std_string) except +
+
     # NIST Functions
     std_string nist(int) except +
     std_string nist(char *) except +

--- a/pyne/nucname.pyx
+++ b/pyne/nucname.pyx
@@ -453,7 +453,7 @@ def zzllaaam_to_id(nuc):
 
 
 def serpent(nuc):
-    """Converts a nuclide to its Serepnt form ('Am-242m'). 
+    """Converts a nuclide to its Serpent form ('Am-242m'). 
 
     Parameters
     ----------
@@ -499,6 +499,56 @@ def serpent_to_id(nuc):
         newnuc = cpp_nucname.serpent_to_id(<char *> nuc_bytes)
     #elif isinstance(nuc, int) or isinstance(nuc, long):
     #    newnuc = cpp_nucname.serpent_to_id(<int> nuc)
+    else:
+        raise NucTypeError(nuc)
+    return newnuc
+
+
+def openmc(nuc):
+    """Converts a nuclide to its OpenMC form ('Am-242m'). 
+
+    Parameters
+    ----------
+    nuc : int or str 
+        Input nuclide.
+
+    Returns
+    -------
+    newnuc : str 
+        Output nuclide in OpenMC form.
+
+    """
+    cdef std_string newnuc
+
+    if isinstance(nuc, basestring):
+        nuc_bytes = nuc.encode()
+        newnuc = cpp_nucname.openmc(<char *> nuc_bytes)
+    elif isinstance(nuc, int):
+        newnuc = cpp_nucname.openmc(<int> nuc)
+    else:
+        raise NucTypeError(nuc)
+
+    return bytes(<char *> newnuc.c_str()).decode()
+
+
+def openmc_to_id(nuc):
+    """Converts a nuclide directly from OpenMC form ('Am-242m') to
+    the canonical identifier form. 
+
+    Parameters
+    ----------
+    nuc : int or str 
+        Input nuclide in OpenMC form.
+
+    Returns
+    -------
+    newnuc : int 
+        Output nuclide in identifier form.
+
+    """
+    if isinstance(nuc, basestring):
+        nuc_bytes = nuc.encode()
+        newnuc = cpp_nucname.openmc_to_id(<char *> nuc_bytes)
     else:
         raise NucTypeError(nuc)
     return newnuc

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -810,11 +810,6 @@ std::string pyne::nucname::serpent(std::string nuc) {
 //
 // Serpent -> id
 //
-//int pyne::nucname::serpent_to_id(int nuc)
-//{
-// Should be ZAID
-//};
-
 
 int pyne::nucname::serpent_to_id(char * nuc) {
   return serpent_to_id(std::string(nuc));
@@ -861,6 +856,73 @@ int pyne::nucname::serpent_to_id(std::string nuc) {
     throw NotANuclide(nucstr, nucid);
   return nucid;
 };
+
+
+/*************************/
+/*** openmc functions ***/
+/*************************/
+std::string pyne::nucname::openmc(int nuc) {
+  int nucid = id(nuc);
+  std::string newnuc = "";
+
+  int ssss = nucid % 10000;
+  int aaassss = nucid % 10000000;
+  int zzz = nucid / 10000000;
+  int aaa = aaassss / 10000;
+
+  // Make sure the LL value is correct
+  if (0 == zz_name.count(zzz))
+    throw NotANuclide(nuc, nucid);
+
+  // Add LL
+  std::string llupper = pyne::to_upper(zz_name[zzz]);
+  std::string lllower = pyne::to_lower(zz_name[zzz]);
+  newnuc += llupper[0];
+  for (int l = 1; l < lllower.size(); l++)
+    newnuc += lllower[l];  
+
+  // Add required dash
+  newnuc += "-";
+
+  // Add A-number
+  if (0 < aaassss)
+    newnuc += pyne::to_str(aaa);
+  else if (0 == aaassss)
+    newnuc += "Nat";
+
+  // Add meta-stable flag
+  if (0 < ssss)
+    newnuc += "m";
+
+  return newnuc;
+};
+
+
+std::string pyne::nucname::openmc(char * nuc) {
+  std::string newnuc (nuc);
+  return openmc(newnuc);
+};
+
+
+std::string pyne::nucname::openmc(std::string nuc) {
+  return openmc(id(nuc));
+};
+
+//
+// OpenMC -> id
+//
+
+int pyne::nucname::openmc_to_id(char * nuc) {
+  return openmc_to_id(std::string(nuc));
+};
+
+
+int pyne::nucname::openmc_to_id(std::string nuc) {
+  // Cheating a bit here since the serpent version is implemented such that
+  // it should work for openmc, too.
+  return serpent_to_id(nuc);
+};
+
 
 
 /**********************/

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -404,9 +404,30 @@ namespace nucname
   /// to the id canonical form  for nuclides in PyNE. 
   /// \param nuc a nuclide in Serpent form.
   /// \return an integer id nuclide identifier.
-  //int serpent_to_id(int nuc);  Should be ZAID
   int serpent_to_id(char * nuc);
   int serpent_to_id(std::string nuc);
+  /// \}
+
+  /// \name OpenMC Form Functions
+  /// \{
+  /// This is the string-based naming convention used by OpenMC.
+  /// This is very similar to the serpent naming convention. However, 
+  /// in the case of natural elements, the 'Nat' is capitalized.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  std::string openmc(int nuc);
+  std::string openmc(char * nuc);
+  std::string openmc(std::string nuc);
+  /// \}
+
+  /// \name OpenMC Form to Identifier Form Functions
+  /// \{
+  /// This converts from the OpenMC nuclide naming convention 
+  /// to the id canonical form  for nuclides in PyNE. 
+  /// \param nuc a nuclide in OpenMC form.
+  /// \return an integer id nuclide identifier.
+  int openmc_to_id(char * nuc);
+  int openmc_to_id(std::string nuc);
   /// \}
 
   /// \name NIST Form Functions

--- a/tests/test_nucname.py
+++ b/tests/test_nucname.py
@@ -324,6 +324,34 @@ def test_serpent_to_id():
             continue
         yield check_cases, nucname.serpent_to_id, val, id
 
+
+def test_openmc():
+    assert_equal(nucname.openmc(942390), "Pu-239")
+    assert_equal(nucname.openmc(952421), "Am-242m")
+
+    assert_equal(nucname.openmc("Pu-239"), "Pu-239")
+
+    assert_equal(nucname.openmc(94239), "Pu-239")
+    assert_equal(nucname.openmc(95642), "Am-242")
+    assert_equal(nucname.openmc(95242), "Am-242m")
+    assert_equal(nucname.openmc(92636), "U-236m")
+
+    assert_equal(nucname.openmc(2390940), "Pu-239")
+    assert_equal(nucname.openmc(2420951), "Am-242m")
+
+    assert_equal(nucname.openmc("C"), "C-Nat")
+
+def test_openmc_to_id():
+    # use None for impossible forms
+    vals = ["He-4", "He-4", "Cm-244", "Pu-239", "Am-242m", "He-4", "Am-242", 
+            "Am-242m", "U-236m", None, "Am-242m", "He-Nat", "U-Nat", 
+            "Np-Nat", "He-4", "Cm-244", "Pu-239", "Am-242", "He-4", "Cm-244m", 
+            "Pu-239", "Am-242", "U-Nat"]
+    for val, id in set(zip(vals, caseids)):
+        if val is None:
+            continue
+        yield check_cases, nucname.openmc_to_id, val, id
+
 def test_nist():
     assert_equal(nucname.nist(942390), "239Pu")
     assert_equal(nucname.nist(952421), "242Am")


### PR DESCRIPTION
I believe that the only difference between OpenMC and Serpent's names are for natural elements.  Serpent uses 'C-nat' while OpenMC uses 'C-Nat'.  Maybe @paulromano can confirm.
