### PR TITLE
Hack-a-thon dummy page creation

### DIFF
--- a/docs/hackathon_2014Nov.rst
+++ b/docs/hackathon_2014Nov.rst
@@ -4,9 +4,12 @@ PyNE Development Hack-a-thon
 =============================
 Schedule of Events
 =============================
-University of California-Berkeley
 
 November 14-16, 2014
+
+UC Berkeley
+
+(add building/room/location/etc here)
 
 ---------------------------------
 Day 1: Friday, November 14, 2014


### PR DESCRIPTION
This is the initial starting page for the Berkeley Hack-a-thon in November. Schedule needs content added to it still. It is just a dummy page so it is not accessible online.
