### PR TITLE
fixed cmake debug issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,10 @@ message(STATUS
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Default to release build type
-set(CMAKE_BUILD_TYPE Release CACHE STRING "The build type" FORCE)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "The build type" FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
 
 # quiets fortify_source warnings when not compiling with optimizations
 # in linux distros where compilers were compiled with fortify_source enabled by


### PR DESCRIPTION
Anthony pushed this to my branch. We were telling CMake to do a release build in all situations, even if the user specified debug mode. This should be fixed now.
