### PR TITLE
Adding check for atomic mass = 0

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -73,10 +73,12 @@ void pyne::_load_atomic_mass_map() {
   H5Dclose(atomic_mass_set);
   H5Fclose(nuc_data_h5);
 
-  // Ok now that we have the array of stucts, put it in the map
+  // Ok now that we have the array of structs, put it in the map
   for(int n = 0; n < atomic_mass_length; n++) {
-    atomic_mass_map[atomic_mass_array[n].nuc] = atomic_mass_array[n].mass;
-    natural_abund_map[atomic_mass_array[n].nuc] = atomic_mass_array[n].abund;
+    atomic_mass_map.insert(std::pair<int, double>(atomic_mass_array[n].nuc, \
+                                                  atomic_mass_array[n].mass));
+    natural_abund_map.insert(std::pair<int, double>(atomic_mass_array[n].nuc, \
+                                                    atomic_mass_array[n].abund));
   }
 
   delete[] atomic_mass_array;
@@ -91,12 +93,8 @@ double pyne::atomic_mass(int nuc) {
   nuc_end = atomic_mass_map.end();
 
   // First check if we already have the nuc mass in the map
-  double aw;
   if (nuc_iter != nuc_end) {
-    aw = nuc_iter->second;
-    if (aw != 0.0) {
-      return (*nuc_iter).second;
-    }
+    return (*nuc_iter).second;
   }
 
   // Next, fill up the map with values from the
@@ -107,13 +105,16 @@ double pyne::atomic_mass(int nuc) {
     return atomic_mass(nuc);
   }
 
+  double aw;
   int nucid = nucname::id(nuc);
 
   // If in an excited state, return the ground
   // state mass...not strictly true, but good guess.
   if (0 < nucid%10000) {
     aw = atomic_mass((nucid/10000)*10000);
-    atomic_mass_map[nuc] = aw;
+    if (atomic_mass_map.count(nuc) != 1) {
+      atomic_mass_map.insert(std::pair<int, double>(nuc, aw));
+    }
     return aw;
   };
 
@@ -121,7 +122,9 @@ double pyne::atomic_mass(int nuc) {
   // take a best guess based on the
   // aaa number.
   aw = (double) ((nucid/10000)%1000);
-  atomic_mass_map[nuc] = aw;
+  if (atomic_mass_map.count(nuc) != 1) {
+    atomic_mass_map.insert(std::pair<int, double>(nuc, aw));
+  }
   return aw;
 };
 
@@ -170,7 +173,7 @@ double pyne::natural_abund(int nuc) {
   // state abundance...not strictly true, but good guess.
   if (0 < nucid%10000) {
     na = natural_abund((nucid/10000)*10000);
-    atomic_mass_map[nuc] = na;
+    natural_abund_map[nuc] = na;
     return na;
   };
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -91,8 +91,13 @@ double pyne::atomic_mass(int nuc) {
   nuc_end = atomic_mass_map.end();
 
   // First check if we already have the nuc mass in the map
-  if (nuc_iter != nuc_end)
-    return (*nuc_iter).second;
+  double aw;
+  if (nuc_iter != nuc_end) {
+    aw = nuc_iter->second;
+    if (aw != 0.0) {
+      return (*nuc_iter).second;
+    }
+  }
 
   // Next, fill up the map with values from the
   // nuc_data.h5, if the map is empty.
@@ -102,7 +107,6 @@ double pyne::atomic_mass(int nuc) {
     return atomic_mass(nuc);
   }
 
-  double aw;
   int nucid = nucname::id(nuc);
 
   // If in an excited state, return the ground

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1151,7 +1151,7 @@ pyne::Material pyne::Material::expand_elements() {
         nabund = (*abund_itr).first;
         if (zabund == znuc && 0 != nucname::anum(nabund) && 0.0 != (*abund_itr).second)
           newcomp[nabund] = (*abund_itr).second * (*nuc).second * \
-                            atomic_mass_map.at(nabund) / atomic_mass_map.at(n);
+                            atomic_mass(nabund) / atomic_mass(n);
         else if (n == nabund && 0.0 == (*abund_itr).second)
           newcomp.insert(*nuc);
         abund_itr++;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1151,7 +1151,7 @@ pyne::Material pyne::Material::expand_elements() {
         nabund = (*abund_itr).first;
         if (zabund == znuc && 0 != nucname::anum(nabund) && 0.0 != (*abund_itr).second)
           newcomp[nabund] = (*abund_itr).second * (*nuc).second * \
-                            atomic_mass_map[nabund] / atomic_mass_map[n];
+                            atomic_mass_map.at(nabund) / atomic_mass_map.at(n);
         else if (n == nabund && 0.0 == (*abund_itr).second)
           newcomp.insert(*nuc);
         abund_itr++;

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,8 +4,7 @@ import math
 import warnings
 
 import nose
-from nose.tools import assert_equal, assert_not_equal, assert_raises, raises, \
-    assert_in, assert_true
+from nose.tools import assert_equal, assert_in, assert_true
 import numpy as np
 import numpy.testing as npt
 
@@ -46,7 +45,6 @@ def test_natural_abund_excited_state():
     assert_equal(data.natural_abund_map.get(excited), None)
     nabund = data.natural_abund(excited)
     assert_equal(nabund, data.natural_abund_map.get(excited))
-    data.natural_abund_map.clear()
 
 
 def test_q_val():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -37,6 +37,18 @@ def test_atomic_mass():
     assert_in(data.atomic_mass(952421), am242m)
 
 
+def test_natural_abund_excited_state():
+    # initialize natural_abund_map
+    gnd = 902320000
+    excited = gnd + 1
+    data.natural_abund(gnd)
+    # excited state should not be in the map yet
+    assert_equal(data.natural_abund_map.get(excited), None)
+    nabund = data.natural_abund(excited)
+    assert_equal(nabund, data.natural_abund_map.get(excited))
+    data.natural_abund_map.clear()
+
+
 def test_q_val():
     assert_equal(data.q_val(110240001), 0.473)
     assert_equal(data.q_val('H1'), 0.0)


### PR DESCRIPTION
Hi folks!

I was running xsgen, and found that after a few minutes of chugging, `Material.molecular_mass()` would return 0. Strangely, this occurence seems to be length-of-runtime-based - it doesn't happen when I just fire up Python and try to run `molecular_mass` on the same material. Eventually I found that sometimes `pyne::atomic_mass(912340001)` would return 0, but other times it would return 234.04... . In `pyne::atomic_mass` we check to see if a nuclide is already in our map. In the 912340001 case it is, but has a value of 0, which is causing it to return 0. So I added a check to ignore the value in the map if the atomic mass value is 0. 

This will slow it down sometimes but I think avoiding invalid results is more important.

Even after this fix, the value in the map for 912340001 is still 0, actually. I'm not sure how to fix this. I assume setting `atomic_mass_map[nuc] = aw` would save it, but I guess that's not working - this may even be the root cause of the bug. In any case, this has fixed the code for my use case. If you all have any suggestions to fix it better I'd love to hear them!

John
