### PR TITLE
fix pyne build with gcc on macports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,17 @@ cmake_minimum_required( VERSION 2.8.5 )
 # Set the project name
 project( pyne Fortran CXX)
 
+
+#determine if spatial solver module should be built
+IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  IF(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.6" AND NOT APPLE)
+    SET(BUILD_SPATIAL_SOLVER true)
+  ELSE()
+    SET(BUILD_SPATIAL_SOLVER false)
+  ENDIF()
+ENDIF()
+
+IF(BUILD_SPATIAL_SOLVER)
 # languages
 enable_language(Fortran)
 
@@ -43,6 +54,7 @@ if (APPLE)
 endif ()
 message(STATUS
   "CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES = ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
+ENDIF(BUILD_SPATIAL_SOLVER)
 
 # Make the scripts available in the 'cmake' directory available for the
 # 'include()' command, 'find_package()' command.
@@ -96,15 +108,6 @@ if(${MOAB_FOUND})
     get_filename_component(MOAB_LIBRARY_DIRS ${MOAB_LIBRARY} PATH)
     link_directories(${MOAB_LIBRARY_DIRS})
 endif(${MOAB_FOUND})
-
-#determine if spatial solver module should be built
-IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  IF(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.6")
-    SET(BUILD_SPATIAL_SOLVER true)
-  ELSE()
-    SET(BUILD_SPATIAL_SOLVER false)
-  ENDIF()
-ENDIF()
 
 # Include the CMake script UseCython.cmake.  This defines add_cython_module().
 # Instruction for use can be found at the top of cmake/UseCython.cmake.

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -20,8 +20,8 @@ get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 
 if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
   # gfortran
-  set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -O3 -c -fpic -fdefault-real-8")
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-fno-f2c -O0 -g -fdefault-real-8")
+  set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -O3 -c -fpic -fdefault-real-8 -fdefault-double-8")
+  set (CMAKE_Fortran_FLAGS_DEBUG   "-fno-f2c -O0 -g -fdefault-real-8 -fdefault-double-8")
 elseif (Fortran_COMPILER_NAME MATCHES "ifort.*")
   # ifort (untested)
   set (CMAKE_Fortran_FLAGS_RELEASE "-f77rtl -O3 -r8")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,10 @@ endif (MOAB_FOUND)
 
 # compile and link library
 add_library(pyne ${PYNE_SRCS})
-target_link_libraries(pyne hdf5 blas lapack)
+target_link_libraries(pyne hdf5)
+IF(BUILD_SPATIAL_SOLVER)
+    target_link_libraries(pyne hdf5 blas lapack)
+ENDIF(BUILD_SPATIAL_SOLVER)
 if (MOAB_FOUND)
     target_link_libraries(pyne dagmc MOAB)
 endif (MOAB_FOUND)


### PR DESCRIPTION
This closes issue #558 by not linking against `libgcc_s` on mac. It also fixes issues with gfortran/c compatibility with the default compiler options on mac (pre-empting #668) 