### PR TITLE
Tutorial updates (intro and outro)

### DIFF
--- a/tutorial/00-intro.ipynb
+++ b/tutorial/00-intro.ipynb
@@ -24,10 +24,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "# Good Morning!\n",
-      "* Introductions\n",
-      "* Hopefully you've installed the virtual machine. \n",
-      "    - If not, go sit in the back and follow the directions in the email that we sent now...\n",
+      "# Before you begin\n",
+      "* Hopefully you've installed the virtual machine if necessary. \n",
+      "    - If not, please go to http://pyne.io/install/vb.html#vb to install a virtual machine.\n",
       "    - If so, open it now and open Accessories -> LXTerminal"
      ]
     },

--- a/tutorial/00-intro.ipynb
+++ b/tutorial/00-intro.ipynb
@@ -71,7 +71,7 @@
       "$ ipython notebook --matplotlib\n",
       "```\n",
       "\n",
-      "This should open the tutorial in a web browser. We'll start with `00-intro`. This isn't the most up-to-date version, but it's pretty close. You can update it later today or when you get home.\n"
+      "This should open the tutorial in a web browser. We'll start with `00-intro`. This isn't the most up-to-date version, but it's pretty close.\n"
      ]
     },
     {

--- a/tutorial/09-outro.ipynb
+++ b/tutorial/09-outro.ipynb
@@ -11,11 +11,11 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "# Thanks for Coming! \n",
+      "# You've successfully completed the tutorial!\n",
       "\n",
       "![PyNE Tree](https://raw.github.com/pyne/pyne/staging/img/pyne_icon_big.png)\n",
       "\n",
-      "There are a variety of other things in PyNE that we are not showing you today because they are impractical in this kind of tutorial:\n",
+      "There are a variety of other things in PyNE that are not covered in this tutorial because they are impractical in this kind of tutorial but they do exist:\n",
       "\n",
       "* Enrichment\n",
       "* Material Libraries\n",


### PR DESCRIPTION
I changed the wording in the introduction and outroduction of the tutorial so that it didn't sound like you are actually in a session but can work through it on your own. 

I also tried to play around with (but couldn't figure it out) the PyNE Tree image that doesn't render in the intro and outro. The rendered html just has "PyNE Tree PyNE Tree" and the ipynb has an empty image. There are no changes to reflect that here but I was wondering if anyone else knew how to fix it?