### PR TITLE
Dagmc tests moved assert statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ rs.cred
 src/decay.h
 src/decay.cpp
 tests/fort.8
+tests/endftape.100

--- a/pyne/dagmc.pyx
+++ b/pyne/dagmc.pyx
@@ -322,11 +322,11 @@ def load(filename):
 
 def get_surface_list():
     """return a list of valid surface IDs"""
-    return surf_id_to_handle.keys()
+    return list(surf_id_to_handle.keys())
 
 def get_volume_list():
     """return a list of valid volume IDs"""
-    return vol_id_to_handle.keys()
+    return list(vol_id_to_handle.keys())
 
 
 def volume_is_graveyard(vol_id):

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -45,16 +45,11 @@ def metadata():
     from pyne import dagmc
     dagmc.load(path)
     
-    rets = [dagmc.volume_is_graveyard(x) for x in range(1, 5)]
-    assert_equal(rets, [True, False, False, False])
-
-    rets = [dagmc.volume_is_implicit_complement(x) for x in range(1, 5)]
-    assert_equal(rets, [False, False, False, True])
-
+    rets1 = [dagmc.volume_is_graveyard(x) for x in range(1, 5)]
+    rets2 = [dagmc.volume_is_implicit_complement(x) for x in range(1, 5)]
     md = dagmc.volume_metadata(2)
-    assert_equal(md['material'], 5)
-    assert_equal(md['rho'], 0.5)
-    assert_true(all(x in md for x in ['material', 'rho', 'imp']))
+    
+    return [rets1, rets2, md]
 
 def versions():
     from pyne import dagmc
@@ -316,6 +311,16 @@ def test_metadata():
     p = multiprocessing.Pool()
     results = p.apply_async(metadata)
     r = results.get()
+    
+    rets1 = r[0]
+    rets2 = r[1]
+    md = r[2]
+    
+    assert_equal(rets1, [True, False, False, False])
+    assert_equal(rets2, [False, False, False, True])
+    assert_equal(md['material'], 5)
+    assert_equal(md['rho'], 0.5)
+    assert_true(all(x in md for x in ['material', 'rho', 'imp']))
 
 def test_versions():
     p = multiprocessing.Pool()

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -56,95 +56,112 @@ def versions():
     dagmc.load(path)
     
     returned = dagmc.versions()
-    assert_equal(len(returned), 2)
-    assert_true(isinstance(returned[0], STRING_TYPES))
-    assert_true(isinstance(returned[1], int))
+    #assert_equal(len(returned), 2)
+    #assert_true(isinstance(returned[0], STRING_TYPES))
+    #assert_true(isinstance(returned[1], int))
+    
+    return returned
 
 def list_functions():
     from pyne import dagmc
     dagmc.load(path)
     
     surfs = dagmc.get_surface_list()
-    assert_equal(set(surfs), set(range(1, 19)))
+    #assert_equal(set(surfs), set(range(1, 19)))
 
     vols = dagmc.get_volume_list()
-    assert_equal(set(vols), set(range(1, 5)))
+    #assert_equal(set(vols), set(range(1, 5)))
+    
+    return [surfs, vols]
 
 def boundary():
     from pyne import dagmc
     dagmc.load(path)
     
     low, high = dagmc.volume_boundary(2)
-    for i in range(0, 3):
-        assert_true(low[i] <= -1.0)
-        assert_true(high[i] >= 1.0)
+    #for i in range(0, 3):
+    #    assert_true(low[i] <= -1.0)
+    #    assert_true(high[i] >= 1.0)
+        
+    return [low, high]
 
 def pt_in_vol():
     from pyne import dagmc
     dagmc.load(path)
     
     # there are 4 volumes; (0,0,.2) is in volume 2
-    rets = [dagmc.point_in_volume(x, [0, 0, .2]) for x in range(1, 5)]
-    assert_equal(rets, [False, True, False, False])
+    rets1 = [dagmc.point_in_volume(x, [0, 0, .2]) for x in range(1, 5)]
+    #assert_equal(rets1, [False, True, False, False])
 
     # (1.1,0,0) is in volume 3
-    rets = [dagmc.point_in_volume(x, [1.1, 0, 0]) for x in range(1, 5)]
-    assert_equal(rets, [False, False, True, False])
+    rets2 = [dagmc.point_in_volume(x, [1.1, 0, 0]) for x in range(1, 5)]
+    #assert_equal(rets2, [False, False, True, False])
+    
+    return [rets1, rets2]
 
 def find_volume():
     from pyne import dagmc
     dagmc.load(path)
     
-    vol = dagmc.find_volume([0, 0, 0])
-    assert_equal(vol, 2)
+    vol1 = dagmc.find_volume([0, 0, 0])
+    #assert_equal(vol1, 2)
 
-    vol = dagmc.find_volume([.9, .9, .9])
-    assert_equal(vol, 2)
+    vol2 = dagmc.find_volume([.9, .9, .9])
+    #assert_equal(vol2, 2)
 
     # boundary case -- point [1,.1,.1] is on surface between vols 2 and 3
     # the behavior on boundaries will vary with uvw, but ensure that
     # only the two volumes the touch the location are ever returned.
+    vols = []
     for uvw in [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0)]:
-        vol = dagmc.find_volume([1, .1, .1], uvw)
-        assert_true(vol in (2, 3))
+        vols.append(dagmc.find_volume([1, .1, .1], uvw))
+        #assert_true(vol in (2, 3))
 
     # boundary case-- exiting volume 3 => in volume 3
-    vol = dagmc.find_volume([1, .1, .1], [-1, 0, 0])
-    assert_equal(vol, 3)
+    vol3 = dagmc.find_volume([1, .1, .1], [-1, 0, 0])
+    #assert_equal(vol3, 3)
 
-    vol = dagmc.find_volume([1.1, 0, 0])
-    assert_equal(vol, 3)
+    vol4 = dagmc.find_volume([1.1, 0, 0])
+    #assert_equal(vol4, 3)
+    
+    return [vol1, vol2, vol3, vol4, vols]
 
 def one_ray():
     from pyne import dagmc
     dagmc.load(path)
     
     fromcenter = dagmc.fire_one_ray(2, [0, 0, 0], [1, 0, 0])
-    assert_almost_equal(fromcenter[1], 1.0)
+    #assert_almost_equal(fromcenter[1], 1.0)
 
     fromhalf = dagmc.fire_one_ray(2, [.5, .5, .5], [0, -1, 0])
-    assert_almost_equal(fromhalf[1], 1.5)
+    #assert_almost_equal(fromhalf[1], 1.5)
 
     # the following is actually a misuse of ray_fire because it should only
     # be called from inside a volume, but at least verify that a ray is
     # lost if it 1) starts outside a volume and 2) does not intersect the
     # volume
     fromoutside = dagmc.fire_one_ray(2, [0, 1.1, 0], [-1, 0, 0])
-    assert_equal(fromoutside, None)
+    #assert_equal(fromoutside, None)
 
-    fromvol3 = dagmc.fire_one_ray(3, [0, 1.1, 0], [0, -1, 0])
-    assert_almost_equal(fromvol3[1], 0.1)
+    fromvol3a = dagmc.fire_one_ray(3, [0, 1.1, 0], [0, -1, 0])
+    #assert_almost_equal(fromvol3a[1], 0.1)
 
-    fromvol3 = dagmc.fire_one_ray(3, [0, 1.1, 0], [0, 1, 0])
-    assert_almost_equal(fromvol3[1], 3.056921938)
+    fromvol3b = dagmc.fire_one_ray(3, [0, 1.1, 0], [0, 1, 0])
+    #assert_almost_equal(fromvol3b[1], 3.056921938)
+    
+    return [fromcenter, fromhalf, fromoutside, fromvol3a, fromvol3b]
 
 def failures():
     from pyne import dagmc
     dagmc.load(path)
     
-    assert_raises(Exception, dagmc.point_in_volume, [100, (0, 0, 0)])
-    assert_raises(Exception, dagmc.point_in_volume, [1, (0, 0, 0, 0)])
-    assert_raises(Exception, dagmc.fire_one_ray, [2, (0, 0, 0), 1])
+    # if Exception is raised, then None is returned, else nothing is returned
+    # and test will fail
+    i = assert_raises(Exception, dagmc.point_in_volume, [100, (0, 0, 0)])
+    j = assert_raises(Exception, dagmc.point_in_volume, [1, (0, 0, 0, 0)])
+    k = assert_raises(Exception, dagmc.fire_one_ray, [2, (0, 0, 0), 1])
+    
+    return [i, j, k]
 
 def ray_iterator():
     from pyne import dagmc
@@ -152,25 +169,47 @@ def ray_iterator():
     
     start = [-2, 0, 0]
     startvol = dagmc.find_volume(start)
-    assert_equal(startvol, 3)
+    #assert_equal(startvol, 3)
     direction = [1, 0, 0]
 
     expected_vols = [2, 3, 1, 4]
     expected_dists = [1, 2, 3.156921938, 0]
+    
+    vols1 = []
+    dists1 = []
+    surfs1 = []
 
     for i, (vol, dist, surf) in enumerate(
             dagmc.ray_iterator(startvol, start, direction)):
-        assert_equal(expected_vols[i], vol)
+        
+        vols1.append(vol)
+        dists1.append(dist)
+        surfs1.append(surf)
+        
+        #assert_equal(expected_vols[i], vol)
         if expected_dists[i] != 0:
-            assert_almost_equal(expected_dists[i], dist)
-    assert_equal(i, 3)
-
-    for i, (vol, dist, surf) in enumerate(
+            pass
+            #assert_almost_equal(expected_dists[i], dist)
+    #assert_equal(i, 3)
+    
+    vols2 = []
+    dists2 = []
+    surfs2 = []
+    
+    for j, (vol, dist, surf) in enumerate(
             dagmc.ray_iterator(startvol, start, direction, dist_limit=4)):
-        assert_equal(expected_vols[i], vol)
-        if expected_dists[i] != 0:
-            assert_almost_equal(expected_dists[i], dist)
-    assert_equal(i, 1)
+        vols2.append(vol)
+        dists2.append(dist)
+        surfs2.append(surf)
+        
+        #assert_equal(expected_vols[j], vol)
+        if expected_dists[j] != 0:
+            pass
+            #assert_almost_equal(expected_dists[j], dist)
+    #assert_equal(j, 1)
+    
+    #return [startvol, list1, list2, i, j]
+    return [startvol, vols1, dists1, surfs1, i, vols2, dists2, surfs2, j]
 
 def ray_story():
     from pyne import dagmc
@@ -189,20 +228,24 @@ def util_graveyard_bound():
     
     lo, hi = dagmc.find_graveyard_inner_box()
 
-    grave_diam = 4.15692194
-    for i in range(0, 3):
-        assert_almost_equal(lo[i], -grave_diam)
-        assert_almost_equal(hi[i], grave_diam)
+    #grave_diam = 4.15692194
+    #for i in range(0, 3):
+    #    assert_almost_equal(lo[i], -grave_diam)
+    #    assert_almost_equal(hi[i], grave_diam)
+        
+    return [lo, hi]
 
 def util_matlist():
     from pyne import dagmc
     dagmc.load(path)
     
-    mats = dagmc.get_material_set()
-    assert_equal(set((0, 5)), mats)
+    mats1 = dagmc.get_material_set()
+    #assert_equal(set((0, 5)), mats1)
 
-    mats = dagmc.get_material_set(with_rho=True)
-    assert_equal(set([(0, 0.0), (5, 0.5)]), mats)
+    mats2 = dagmc.get_material_set(with_rho=True)
+    #assert_equal(set([(0, 0.0), (5, 0.5)]), mats2)
+    
+    return [mats1, mats2]
 
 def discretize_geom_rand():
     from pyne import dagmc
@@ -212,15 +255,17 @@ def discretize_geom_rand():
     mesh = Mesh(structured=True, structured_coords=[coords, coords, coords])
     results = dagmc.discretize_geom(mesh, num_rays=50)
     
-    assert_equal(len(results), (len(coords) - 1)**3)
-
-    for res in results:
-        if res['idx'] != 13:
-            assert_equal(res['cell'], 3)
-        else:
-            assert_equal(res['cell'], 2)
-
-        assert_almost_equal(res['vol_frac'], 1.0)
+    #assert_equal(len(results), (len(coords) - 1)**3)
+    #
+    #for res in results:
+    #    if res['idx'] != 13:
+    #        assert_equal(res['cell'], 3)
+    #    else:
+    #        assert_equal(res['cell'], 2)
+    #
+    #    assert_almost_equal(res['vol_frac'], 1.0)
+        
+    return [results, coords]
 
 def discretize_geom_grid():
     from pyne import dagmc
@@ -230,15 +275,17 @@ def discretize_geom_grid():
     mesh = Mesh(structured=True, structured_coords=[coords, coords, coords])
     results = dagmc.discretize_geom(mesh, num_rays=49, grid=True)
     
-    assert_equal(len(results), (len(coords) - 1)**3)
-
-    for res in results:
-        if res['idx'] != 13:
-            assert_equal(res['cell'], 3)
-        else:
-            assert_equal(res['cell'], 2)
-
-        assert_almost_equal(res['vol_frac'], 1.0)
+    #assert_equal(len(results), (len(coords) - 1)**3)
+    #
+    #for res in results:
+    #    if res['idx'] != 13:
+    #        assert_equal(res['cell'], 3)
+    #    else:
+    #        assert_equal(res['cell'], 2)
+    #
+    #    assert_almost_equal(res['vol_frac'], 1.0)
+        
+    return [results, coords]
 
 def discretize_geom_mix():
     from pyne import dagmc
@@ -250,17 +297,19 @@ def discretize_geom_mix():
                 structured_coords=[coords2, coords, coords])
     results1 = dagmc.discretize_geom(mesh, num_rays=100, grid=True)
 
-    assert_equal(results1[0]['cell'], 2)
-    assert_almost_equal(results1[0]['vol_frac'], 0.5)
-
-    assert_equal(results1[1]['cell'], 3)
-    assert_almost_equal(results1[1]['vol_frac'], 0.5)
+    #assert_equal(results1[0]['cell'], 2)
+    #assert_almost_equal(results1[0]['vol_frac'], 0.5)
+    #
+    #assert_equal(results1[1]['cell'], 3)
+    #assert_almost_equal(results1[1]['vol_frac'], 0.5)
 
     
     # To to make sure standard error decreases with increasing rays
     results2 = dagmc.discretize_geom(mesh, num_rays=625, grid=True)
-    assert(results2[0]['rel_error'] < results1[0]['rel_error'])
-    assert(results2[1]['rel_error'] < results1[1]['rel_error'])
+    #assert(results2[0]['rel_error'] < results1[0]['rel_error'])
+    #assert(results2[1]['rel_error'] < results1[1]['rel_error'])
+    
+    return [results1, results2]
 
 def discretize_non_square():
     from pyne import dagmc
@@ -269,7 +318,10 @@ def discretize_non_square():
     coords = [0, 1]
     mesh = Mesh(structured=True, 
                 structured_coords=[coords, coords, coords])
-    assert_raises(ValueError, dagmc.discretize_geom, mesh, num_rays=3, grid=True)
+    # if assert_raises is True, then k will be None, else a fail will occur
+    k = assert_raises(ValueError, dagmc.discretize_geom, mesh, num_rays=3, grid=True)
+    
+    return k
 
 def discretize_geom_centers():
     from pyne import dagmc
@@ -283,13 +335,16 @@ def discretize_geom_centers():
     #  method
     mesh.structured = False
     res = dagmc.discretize_geom(mesh)
-    assert_array_equal(res["idx"], [0, 1])
-    assert_array_equal(res["cell"], [2, 3])
-    assert_array_equal(res["vol_frac"], [1.0, 1.0])
-    assert_array_equal(res["rel_error"], [1.0, 1.0])
+    #assert_array_equal(res["idx"], [0, 1])
+    #assert_array_equal(res["cell"], [2, 3])
+    #assert_array_equal(res["vol_frac"], [1.0, 1.0])
+    #assert_array_equal(res["rel_error"], [1.0, 1.0])
 
     #  ensure kwargs are not accepted for unstructured mesh
-    assert_raises(ValueError, dagmc.discretize_geom, mesh, num_rays=3, grid=True)
+    # if assert_raises is True, then k will be None, else a fail will occur
+    k = assert_raises(ValueError, dagmc.discretize_geom, mesh, num_rays=3, grid=True)
+    
+    return [res, k]
 
 def cells_at_ve_centers():
     from pyne import dagmc
@@ -300,7 +355,9 @@ def cells_at_ve_centers():
     mesh = Mesh(structured=True, 
                 structured_coords=[coords2, coords, coords])
     cells = dagmc.cells_at_ve_centers(mesh)
-    assert_array_equal(cells, [2, 3])
+    #assert_array_equal(cells, [2, 3])
+    
+    return cells
 
 def test__load():
     p = multiprocessing.Pool()
@@ -325,48 +382,121 @@ def test_metadata():
 def test_versions():
     p = multiprocessing.Pool()
     results = p.apply_async(versions)
-    r = results.get()
-
-def test_versions():
-    p = multiprocessing.Pool()
-    results = p.apply_async(versions)
-    r = results.get()
+    returned = results.get()
+    
+    assert_equal(len(returned), 2)
+    assert_true(isinstance(returned[0], STRING_TYPES))
+    assert_true(isinstance(returned[1], int))
 
 def test_list_functions():
     p = multiprocessing.Pool()
     results = p.apply_async(list_functions)
     r = results.get()
+    surfs = r[0]
+    vols = r[1]
+    assert_equal(set(surfs), set(range(1, 19)))
+    assert_equal(set(vols), set(range(1, 5)))
 
 def test_boundary():
     p = multiprocessing.Pool()
     results = p.apply_async(boundary)
     r = results.get()
+    low = r[0]
+    high = r[1]
+    for i in range(0, 3):
+        assert_true(low[i] <= -1.0)
+        assert_true(high[i] >= 1.0)
 
 def test_pt_in_vol():
     p = multiprocessing.Pool()
     results = p.apply_async(pt_in_vol)
     r = results.get()
+    rets1 = r[0]
+    rets2 = r[1]
+    assert_equal(rets1, [False, True, False, False])
+    assert_equal(rets2, [False, False, True, False])
 
 def test_find_volume():
     p = multiprocessing.Pool()
     results = p.apply_async(find_volume)
     r = results.get()
-
+    
+    vol1 = r[0]
+    vol2 = r[1]
+    vol3 = r[2]
+    vol4 = r[3]
+    vols = r[4]
+    
+    assert_equal(vol1, 2)
+    assert_equal(vol2, 2)
+    assert_equal(vol3, 3)
+    assert_equal(vol4, 3)
+    
+    for vol in vols:
+        assert_true(vol in (2, 3))
+        
 def test_one_ray():
     p = multiprocessing.Pool()
     results = p.apply_async(one_ray)
     r = results.get()
+    
+    fromcenter = r[0]
+    fromhalf = r[1]
+    fromoutside = r[2]
+    fromvol3a = r[3]
+    fromvol3b = r[4]
+    
+    assert_almost_equal(fromcenter[1], 1.0)
+    assert_almost_equal(fromhalf[1], 1.5)
+    assert_equal(fromoutside, None)
+    assert_almost_equal(fromvol3a[1], 0.1)
+    assert_almost_equal(fromvol3b[1], 3.056921938)
 
 def test_failures():
     p = multiprocessing.Pool()
     results = p.apply_async(failures)
     r = results.get()
+    
+    i = r[0]
+    j = r[1]
+    k = r[2]
+    
+    assert_equal(i, None)
+    assert_equal(j, None)
+    assert_equal(k, None)
 
 def test_ray_iterator():
     p = multiprocessing.Pool()
     results = p.apply_async(ray_iterator)
     r = results.get()
-
+    
+    startvol = r[0]
+    vols1 = r[1]
+    dists1 = r[2]
+    surfs1 = r[3]
+    i = r[4]
+    vols2 = r[5]
+    dists2 = r[6]
+    surfs2 = r[7]
+    j = r[8]
+        
+    expected_vols = [2, 3, 1, 4]
+    expected_dists = [1, 2, 3.156921938, 0]
+    
+    assert_equal(startvol, 3)
+    
+    for k, vol in enumerate(vols1):       
+        assert_equal(expected_vols[k], vol)
+        if expected_dists[k] != 0:
+            assert_almost_equal(expected_dists[k], dists1[k])
+    assert_equal(i, 3)
+    
+    for k, vol in enumerate(vols2):
+        assert_equal(expected_vols[k], vol)
+        if expected_dists[k] != 0:
+            assert_almost_equal(expected_dists[k], dists2[k])
+    assert_equal(j, 1)
+    
 def test_ray_story():
     p = multiprocessing.Pool()
     results = p.apply_async(ray_story)
@@ -376,11 +506,24 @@ def test_util_graveyard_bounds():
     p = multiprocessing.Pool()
     results = p.apply_async(util_graveyard_bound)
     r = results.get()
+    
+    lo = r[0]
+    hi = r[1]
+    
+    grave_diam = 4.15692194
+    for i in range(0, 3):
+        assert_almost_equal(lo[i], -grave_diam)
+        assert_almost_equal(hi[i], grave_diam)
 
 def test_util_matlist():
     p = multiprocessing.Pool()
     results = p.apply_async(util_matlist)
     r = results.get()
+    
+    mats1 = r[0]
+    mats2 = r[1]
+    assert_equal(set((0, 5)), mats1)
+    assert_equal(set([(0, 0.0), (5, 0.5)]), mats2)
 
 def test_discretize_geom_rand():
     """The 14th (index 13) mesh volume element fully contains volume 2. Use 
@@ -390,9 +533,22 @@ def test_discretize_geom_rand():
         raise SkipTest
         
     p = multiprocessing.Pool()
-    results = p.apply_async(discretize_geom_rand)
-    r = results.get()
+    r = p.apply_async(discretize_geom_rand)
+    rr = r.get()
+    
+    results = rr[0]
+    coords = rr[1]
+        
+    assert_equal(len(results), (len(coords) - 1)**3)
 
+    for res in results:
+        if res['idx'] != 13:
+            assert_equal(res['cell'], 3)
+        else:
+            assert_equal(res['cell'], 2)
+
+        assert_almost_equal(res['vol_frac'], 1.0)
+    
 def test_discretize_geom_grid():
     """The 14th (index 13) mesh volume element fully contains volume 2. Use 
     grid sampling.
@@ -401,9 +557,22 @@ def test_discretize_geom_grid():
         raise SkipTest
         
     p = multiprocessing.Pool()
-    results = p.apply_async(discretize_geom_grid)
-    r = results.get()
+    rr = p.apply_async(discretize_geom_grid)
+    r = rr.get()
+    
+    results = r[0]
+    coords = r[1]
+    
+    assert_equal(len(results), (len(coords) - 1)**3)
 
+    for res in results:
+        if res['idx'] != 13:
+            assert_equal(res['cell'], 3)
+        else:
+            assert_equal(res['cell'], 2)
+
+        assert_almost_equal(res['vol_frac'], 1.0)
+    
 def test_discretize_geom_mix():
     """Single mesh volume element that is a 50:50 split of geometry volumes
     2 and 3.
@@ -414,6 +583,18 @@ def test_discretize_geom_mix():
     p = multiprocessing.Pool()
     results = p.apply_async(discretize_geom_mix)
     r = results.get()
+    
+    results1 = r[0]
+    results2 = r[1]
+    
+    assert_equal(results1[0]['cell'], 2)
+    assert_almost_equal(results1[0]['vol_frac'], 0.5)
+    assert_equal(results1[1]['cell'], 3)
+    assert_almost_equal(results1[1]['vol_frac'], 0.5)
+
+    # To to make sure standard error decreases with increasing rays
+    assert(results2[0]['rel_error'] < results1[0]['rel_error'])
+    assert(results2[1]['rel_error'] < results1[1]['rel_error'])
 
 def test_descritize_non_square():
     """Test to make sure requesting a grid with a num_rays that is not a
@@ -425,7 +606,8 @@ def test_descritize_non_square():
     p = multiprocessing.Pool()
     results = p.apply_async(discretize_non_square)
     r = results.get()
-
+    assert_equal(r, None)
+    
 def test_discretize_geom_centers():
     """Test that unstructured mesh is sampled by mesh ve centers.
     """
@@ -435,6 +617,15 @@ def test_discretize_geom_centers():
     p = multiprocessing.Pool()
     results = p.apply_async(discretize_geom_centers)
     r = results.get()
+    
+    res = r[0]
+    k = r[1]
+    
+    assert_array_equal(res["idx"], [0, 1])
+    assert_array_equal(res["cell"], [2, 3])
+    assert_array_equal(res["vol_frac"], [1.0, 1.0])
+    assert_array_equal(res["rel_error"], [1.0, 1.0])
+    assert_equal(k, None)
 
 def test_cells_at_ve_centers():
     """Test that a mesh with one ve in cell 2 and one ve in cell 3 produces
@@ -445,5 +636,6 @@ def test_cells_at_ve_centers():
         
     p = multiprocessing.Pool()
     results = p.apply_async(cells_at_ve_centers)
-    r = results.get()
+    cells = results.get()
 
+    assert_array_equal(cells, [2, 3])

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -55,11 +55,7 @@ def versions():
     from pyne import dagmc
     dagmc.load(path)
     
-    returned = dagmc.versions()
-    #assert_equal(len(returned), 2)
-    #assert_true(isinstance(returned[0], STRING_TYPES))
-    #assert_true(isinstance(returned[1], int))
-    
+    returned = dagmc.versions()   
     return returned
 
 def list_functions():
@@ -67,11 +63,8 @@ def list_functions():
     dagmc.load(path)
     
     surfs = dagmc.get_surface_list()
-    #assert_equal(set(surfs), set(range(1, 19)))
-
     vols = dagmc.get_volume_list()
-    #assert_equal(set(vols), set(range(1, 5)))
-    
+   
     return [surfs, vols]
 
 def boundary():
@@ -79,10 +72,6 @@ def boundary():
     dagmc.load(path)
     
     low, high = dagmc.volume_boundary(2)
-    #for i in range(0, 3):
-    #    assert_true(low[i] <= -1.0)
-    #    assert_true(high[i] >= 1.0)
-        
     return [low, high]
 
 def pt_in_vol():
@@ -91,11 +80,9 @@ def pt_in_vol():
     
     # there are 4 volumes; (0,0,.2) is in volume 2
     rets1 = [dagmc.point_in_volume(x, [0, 0, .2]) for x in range(1, 5)]
-    #assert_equal(rets1, [False, True, False, False])
 
     # (1.1,0,0) is in volume 3
     rets2 = [dagmc.point_in_volume(x, [1.1, 0, 0]) for x in range(1, 5)]
-    #assert_equal(rets2, [False, False, True, False])
     
     return [rets1, rets2]
 
@@ -104,10 +91,7 @@ def find_volume():
     dagmc.load(path)
     
     vol1 = dagmc.find_volume([0, 0, 0])
-    #assert_equal(vol1, 2)
-
     vol2 = dagmc.find_volume([.9, .9, .9])
-    #assert_equal(vol2, 2)
 
     # boundary case -- point [1,.1,.1] is on surface between vols 2 and 3
     # the behavior on boundaries will vary with uvw, but ensure that
@@ -115,14 +99,10 @@ def find_volume():
     vols = []
     for uvw in [(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0)]:
         vols.append(dagmc.find_volume([1, .1, .1], uvw))
-        #assert_true(vol in (2, 3))
 
     # boundary case-- exiting volume 3 => in volume 3
     vol3 = dagmc.find_volume([1, .1, .1], [-1, 0, 0])
-    #assert_equal(vol3, 3)
-
     vol4 = dagmc.find_volume([1.1, 0, 0])
-    #assert_equal(vol4, 3)
     
     return [vol1, vol2, vol3, vol4, vols]
 
@@ -131,23 +111,16 @@ def one_ray():
     dagmc.load(path)
     
     fromcenter = dagmc.fire_one_ray(2, [0, 0, 0], [1, 0, 0])
-    #assert_almost_equal(fromcenter[1], 1.0)
-
     fromhalf = dagmc.fire_one_ray(2, [.5, .5, .5], [0, -1, 0])
-    #assert_almost_equal(fromhalf[1], 1.5)
 
     # the following is actually a misuse of ray_fire because it should only
     # be called from inside a volume, but at least verify that a ray is
     # lost if it 1) starts outside a volume and 2) does not intersect the
     # volume
     fromoutside = dagmc.fire_one_ray(2, [0, 1.1, 0], [-1, 0, 0])
-    #assert_equal(fromoutside, None)
 
     fromvol3a = dagmc.fire_one_ray(3, [0, 1.1, 0], [0, -1, 0])
-    #assert_almost_equal(fromvol3a[1], 0.1)
-
     fromvol3b = dagmc.fire_one_ray(3, [0, 1.1, 0], [0, 1, 0])
-    #assert_almost_equal(fromvol3b[1], 3.056921938)
     
     return [fromcenter, fromhalf, fromoutside, fromvol3a, fromvol3b]
 
@@ -169,7 +142,6 @@ def ray_iterator():
     
     start = [-2, 0, 0]
     startvol = dagmc.find_volume(start)
-    #assert_equal(startvol, 3)
     direction = [1, 0, 0]
 
     expected_vols = [2, 3, 1, 4]
@@ -178,37 +150,21 @@ def ray_iterator():
     vols1 = []
     dists1 = []
     surfs1 = []
-
     for i, (vol, dist, surf) in enumerate(
             dagmc.ray_iterator(startvol, start, direction)):
-        
         vols1.append(vol)
         dists1.append(dist)
         surfs1.append(surf)
-        
-        #assert_equal(expected_vols[i], vol)
-        if expected_dists[i] != 0:
-            pass
-            #assert_almost_equal(expected_dists[i], dist)
-    #assert_equal(i, 3)
     
     vols2 = []
     dists2 = []
     surfs2 = []
-    
     for j, (vol, dist, surf) in enumerate(
             dagmc.ray_iterator(startvol, start, direction, dist_limit=4)):
         vols2.append(vol)
         dists2.append(dist)
         surfs2.append(surf)
-        
-        #assert_equal(expected_vols[j], vol)
-        if expected_dists[j] != 0:
-            pass
-            #assert_almost_equal(expected_dists[j], dist)
-    #assert_equal(j, 1)
     
-    #return [startvol, list1, list2, i, j]
     return [startvol, vols1, dists1, surfs1, i, vols2, dists2, surfs2, j]
 
 def ray_story():
@@ -227,12 +183,6 @@ def util_graveyard_bound():
     dagmc.load(path)
     
     lo, hi = dagmc.find_graveyard_inner_box()
-
-    #grave_diam = 4.15692194
-    #for i in range(0, 3):
-    #    assert_almost_equal(lo[i], -grave_diam)
-    #    assert_almost_equal(hi[i], grave_diam)
-        
     return [lo, hi]
 
 def util_matlist():
@@ -240,10 +190,7 @@ def util_matlist():
     dagmc.load(path)
     
     mats1 = dagmc.get_material_set()
-    #assert_equal(set((0, 5)), mats1)
-
     mats2 = dagmc.get_material_set(with_rho=True)
-    #assert_equal(set([(0, 0.0), (5, 0.5)]), mats2)
     
     return [mats1, mats2]
 
@@ -254,16 +201,6 @@ def discretize_geom_rand():
     coords = [-4, -1, 1, 4]
     mesh = Mesh(structured=True, structured_coords=[coords, coords, coords])
     results = dagmc.discretize_geom(mesh, num_rays=50)
-    
-    #assert_equal(len(results), (len(coords) - 1)**3)
-    #
-    #for res in results:
-    #    if res['idx'] != 13:
-    #        assert_equal(res['cell'], 3)
-    #    else:
-    #        assert_equal(res['cell'], 2)
-    #
-    #    assert_almost_equal(res['vol_frac'], 1.0)
         
     return [results, coords]
 
@@ -274,17 +211,7 @@ def discretize_geom_grid():
     coords = [-4, -1, 1, 4]
     mesh = Mesh(structured=True, structured_coords=[coords, coords, coords])
     results = dagmc.discretize_geom(mesh, num_rays=49, grid=True)
-    
-    #assert_equal(len(results), (len(coords) - 1)**3)
-    #
-    #for res in results:
-    #    if res['idx'] != 13:
-    #        assert_equal(res['cell'], 3)
-    #    else:
-    #        assert_equal(res['cell'], 2)
-    #
-    #    assert_almost_equal(res['vol_frac'], 1.0)
-        
+
     return [results, coords]
 
 def discretize_geom_mix():
@@ -297,18 +224,9 @@ def discretize_geom_mix():
                 structured_coords=[coords2, coords, coords])
     results1 = dagmc.discretize_geom(mesh, num_rays=100, grid=True)
 
-    #assert_equal(results1[0]['cell'], 2)
-    #assert_almost_equal(results1[0]['vol_frac'], 0.5)
-    #
-    #assert_equal(results1[1]['cell'], 3)
-    #assert_almost_equal(results1[1]['vol_frac'], 0.5)
-
-    
     # To to make sure standard error decreases with increasing rays
     results2 = dagmc.discretize_geom(mesh, num_rays=625, grid=True)
-    #assert(results2[0]['rel_error'] < results1[0]['rel_error'])
-    #assert(results2[1]['rel_error'] < results1[1]['rel_error'])
-    
+
     return [results1, results2]
 
 def discretize_non_square():
@@ -335,10 +253,6 @@ def discretize_geom_centers():
     #  method
     mesh.structured = False
     res = dagmc.discretize_geom(mesh)
-    #assert_array_equal(res["idx"], [0, 1])
-    #assert_array_equal(res["cell"], [2, 3])
-    #assert_array_equal(res["vol_frac"], [1.0, 1.0])
-    #assert_array_equal(res["rel_error"], [1.0, 1.0])
 
     #  ensure kwargs are not accepted for unstructured mesh
     # if assert_raises is True, then k will be None, else a fail will occur
@@ -355,7 +269,6 @@ def cells_at_ve_centers():
     mesh = Mesh(structured=True, 
                 structured_coords=[coords2, coords, coords])
     cells = dagmc.cells_at_ve_centers(mesh)
-    #assert_array_equal(cells, [2, 3])
     
     return cells
 


### PR DESCRIPTION
I realized as I was making a presentation about nosetests with multiprocessing that if you have assert statements in the function you are calling (not the function test_X), that you can receive false positives, meaning the test will return a pass even if it shouldn't. I changed all the dagmc tests that were set up like that originally so now all assert statements are made in the outermost function. Luckily, no false positives were occurring before.

I also added one file to the .gitignore