### PR TITLE
Changed the tag naming convention for MeshTally creation to be more cons...

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -2053,9 +2053,9 @@ class MeshTally(StatMesh):
 
         if tag_names is None:
             self.tag_names = ("{0}_result".format(self.particle),
-                              "{0}_rel_error".format(self.particle),
+                              "{0}_result_rel_error".format(self.particle),
                               "{0}_result_total".format(self.particle),
-                              "{0}_rel_error_total".format(self.particle))
+                              "{0}_result_total_rel_error".format(self.particle))
         else:
             self.tag_names = tag_names
 

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -1298,7 +1298,9 @@ class StatMesh(Mesh):
         # Exclude error tags because result and error tags are treated
         # simultaneously so there is not need to include both in the tag
         # list to iterate through.
-        tags = set(tag for tag in tags if not tag.endswith('_error'))
+        error_suffix = "_rel_error"
+
+        tags = set(tag for tag in tags if not tag.endswith(error_suffix))
 
         if in_place:
             mesh_1 = self
@@ -1312,11 +1314,11 @@ class StatMesh(Mesh):
                     zip(iter(other.mesh.iterate(iBase.Type.region,
                                                 iMesh.Topology.all)))):
 
-                mesh_1.mesh.getTagHandle(tag + "_error")[ve_1] = err__ops[op](
+                mesh_1.mesh.getTagHandle(tag + error_suffix)[ve_1] = err__ops[op](
                     mesh_1.mesh.getTagHandle(tag)[ve_1],
                     other.mesh.getTagHandle(tag)[ve_2],
-                    mesh_1.mesh.getTagHandle(tag + "_error")[ve_1],
-                    other.mesh.getTagHandle(tag + "_error")[ve_2])
+                    mesh_1.mesh.getTagHandle(tag + error_suffix)[ve_1],
+                    other.mesh.getTagHandle(tag + error_suffix)[ve_2])
 
                 mesh_1.mesh.getTagHandle(tag)[ve_1] = \
                     _ops[op](mesh_1.mesh.getTagHandle(tag)[ve_1],

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -211,7 +211,7 @@ class TestArithmetic():
         volumes1 = list(self.statmesh_1.structured_iterate_hex("xyz"))
         volumes2 = list(self.statmesh_1.structured_iterate_hex("xyz"))
         flux_tag = self.statmesh_1.mesh.createTag("flux", 1, float)
-        error_tag = self.statmesh_1.mesh.createTag("flux_error", 1, float)
+        error_tag = self.statmesh_1.mesh.createTag("flux_rel_error", 1, float)
         flux_data = [1.0, 2.0, 3.0, 4.0]
         error_data = [0.1, 0.2, 0.3, 0.4]
         flux_tag[volumes1] = flux_data
@@ -221,7 +221,7 @@ class TestArithmetic():
         volumes1 = list(self.statmesh_2.structured_iterate_hex("xyz"))
         volumes2 = list(self.statmesh_2.structured_iterate_hex("xyz"))
         flux_tag = self.statmesh_2.mesh.createTag("flux", 1, float)
-        error_tag = self.statmesh_2.mesh.createTag("flux_error", 1, float)
+        error_tag = self.statmesh_2.mesh.createTag("flux_rel_error", 1, float)
         flux_data = [1.1, 2.2, 3.3, 4.4]
         error_data = [0.1, 0.2, 0.3, 0.4]
         flux_tag[volumes1] = flux_data
@@ -267,7 +267,7 @@ class TestArithmetic():
                    0.21237241067597862, 0.28316321423463819]
         obs_res = [self.statmesh_1.mesh.getTagHandle("flux")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
-        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_error")[vol] 
+        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_rel_error")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
         assert_array_almost_equal(exp_res, obs_res)
         assert_array_almost_equal(exp_err, obs_err)
@@ -279,7 +279,7 @@ class TestArithmetic():
         exp_err = [-1.4866068747, -2.9732137495, -4.4598206242, -5.9464274989]
         obs_res = [self.statmesh_1.mesh.getTagHandle("flux")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
-        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_error")[vol] 
+        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_rel_error")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
         assert_array_almost_equal(exp_res, obs_res)
         assert_array_almost_equal(exp_err, obs_err)
@@ -291,7 +291,7 @@ class TestArithmetic():
         exp_err = [0.1414213562, 0.2828427125, 0.4242640687, 0.5656854249,]
         obs_res = [self.statmesh_1.mesh.getTagHandle("flux")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
-        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_error")[vol] 
+        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_rel_error")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
         assert_array_almost_equal(exp_res, obs_res)
         assert_array_almost_equal(exp_err, obs_err)
@@ -303,7 +303,7 @@ class TestArithmetic():
         exp_err = [0.1414213562, 0.2828427125, 0.4242640687, 0.5656854249]
         obs_res = [self.statmesh_1.mesh.getTagHandle("flux")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
-        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_error")[vol] 
+        obs_err = [self.statmesh_1.mesh.getTagHandle("flux_rel_error")[vol] 
                    for vol in self.statmesh_1.structured_iterate_hex("xyz")]
         assert_array_almost_equal(exp_res, obs_res)
         assert_array_almost_equal(exp_err, obs_err)


### PR DESCRIPTION
...istent with the error suffix used in the mesh operator. Also updated said error suffix to be more accurate about what is contained in that tag value.