### PR TITLE
Get cell number from bit array

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -457,6 +457,7 @@ class SurfSrc(_BinaryReader):
             track_data.record = track_info.get_double(abs(self.ncrd))
             track_data.nps = track_data.record[0]
             track_data.bitarray = track_data.record[1]
+            track_data.cell = int(abs(track_data.bitarray) / 8 % 1e8)
             track_data.wgt = track_data.record[2]
             track_data.erg = track_data.record[3]
             track_data.tme = track_data.record[4]

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -457,7 +457,7 @@ class SurfSrc(_BinaryReader):
             track_data.record = track_info.get_double(abs(self.ncrd))
             track_data.nps = track_data.record[0]
             track_data.bitarray = track_data.record[1]
-            track_data.cell = int(abs(track_data.bitarray) / 8 % 1e8)
+            track_data.cell = abs(track_data.bitarray) // 8 % 100000000
             track_data.wgt = track_data.record[2]
             track_data.erg = track_data.record[3]
             track_data.tme = track_data.record[4]


### PR DESCRIPTION
- Figured out how the MCNP cell number is stored in the bit
  array in the Surface Source file
