### PR TITLE
Improve mcnp mat

### DIFF
--- a/tests/mcnp_inp_comments.txt
+++ b/tests/mcnp_inp_comments.txt
@@ -1,0 +1,30 @@
+TEST MCNP INPUT FILE -- This is NOT valid MCNP input
+C  cells 
+  1  1  -19.1  -2323   $ These are just random surface numbers
+C 4  2  -2.7 $ Testing comment out capability
+C  materials 
+C
+C name: leu
+C source: Some http://URL.com
+C comments: first line of comments
+C second comments
+c third line of comments
+c forth line of comments
+m1
+     92235.15c -4.0000E-02 $ herere
+     92238     -9.4000E-01
+C    92233.45C -0.01 $ Testing comment out capability
+C sometimes, for some bizzare mcnp readability reason
+c people will put comments halfway through a material
+c and expect everything to be ok
+     92238     -0.1000E-1
+C and we should of course keep on reading, perhaps 
+c for a very long time
+c maybe
+c or not
+     92238     -0.1000E-1
+C      
+c    
+c    
+
+

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -597,7 +597,7 @@ def test_read_mcnp_wcomments():
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
 
     read_materials = mats_from_inp('mcnp_inp_comments.txt')
-    assert_equal(expected_material, read_materials[0])
+    assert_equal(expected_material, read_materials[1])
 
 # Test PtracReader class
 def test_read_headers():

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -577,6 +577,27 @@ def test_read_mcnp():
         list(expected_multimaterial._mats.keys())[1].metadata,
         list(read_materials[2]._mats.keys())[1].metadata)
 
+# test to ensure the mats_from_inp function can read repeated mcnp
+# materials like
+# m1  1001.21c 0.1
+#     1002.21c 0.3
+#     1001.21c 0.5
+def test_read_mcnp_wcomments():
+    expected_material = Material(nucvec={922350000: 0.04, 922380000: 0.96},
+                                 mass=-1.0,
+                                 density=19.1,
+                                 metadata={"comments": (
+                                     " first line of comments second line of "
+                                     "comments third line of comments forth "
+                                     "line of comments"),
+                                           "mat_number": "1",
+                                           "name": " leu",
+                                           "source": " Some http://URL.com",
+                                           "table_ids": {'922350': "15c"}})
+    expected_material.mass = -1.0  # to avoid reassignment to +1.0
+
+    read_materials = mats_from_inp('mcnp_inp_comments.txt')
+    assert_equal(expected_material, read_materials[0])
 
 # Test PtracReader class
 def test_read_headers():


### PR DESCRIPTION
This PR improves the existing capabilities of mats_from_inp in the mcnp.py file. Previous to this PR the function would fail on materials like

```
M1  1001.21c   1.0
    26056.21c  0.1
C I LIKE PUTTING COMMENTS IN THE MIDDLE OF MATERIALS
    28058.21c  0.1
```

It would only read part of the material and stop at the first 'C'.

This PR also addresses the shortcoming (in the reader) that MCNP allows the user to have the same nuclide multiple times, like

```
M1  1001.21c   1.0
    26056.21c  0.1
C I LIKE PUTTING COMMENTS IN THE MIDDLE OF MATERIALS
    26056.21c  0.1
C I JUST CANT GET ENOUGH IRON
    28058.21c  0.1
C srsly I love it
    26056.21c  0.1
```

The added test ensures that:
1. The routine continues to read data even if it encounters a 'c' or 'C'
2. That multiple entries of the same nuclide are summed rather than overwritten.

The tests pass on my machine.
