### PR TITLE
Detector size for Serpent 2.

### DIFF
--- a/pyne/serpent.py
+++ b/pyne/serpent.py
@@ -1,14 +1,10 @@
 import re
 import sys
-from warnings import warn
-from pyne.utils import QAWarning
 
 import numpy as np
 
 if sys.version_info[0] > 2:
     basestring = str
-
-warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 _if_idx_str_serpent1 = (
     'if (exist("idx", "var"));\n'
@@ -331,8 +327,10 @@ def parse_det(detfile, write_py=False):
                 f += '{name}.shape = ({name_min_E}_EBINS, 3)\n'.format(name=dn,
                                                             name_min_E=dn[:-1])
         else:
-            if (dn + 'E' in det_names) or (dn + 'T' in det_names):
+            if (dn + 'T' in det_names):
                 f += '{name}.shape = (len({name})//13, 13)\n'.format(name=dn)
+            elif (dn + 'E' in det_names):
+                f += '{name}.shape = (len({name})//12, 12)\n'.format(name=dn)
             else:
                 f += '{name}.shape = (len({name})//3, 3)\n'.format(name=dn)
 

--- a/pyne/serpent.py
+++ b/pyne/serpent.py
@@ -1,10 +1,14 @@
 import re
 import sys
-
+from warnings import warn
+from pyne.utils import QAWarning
+ 
 import numpy as np
 
 if sys.version_info[0] > 2:
     basestring = str
+    
+warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 _if_idx_str_serpent1 = (
     'if (exist("idx", "var"));\n'


### PR DESCRIPTION
The detector size for Serpent 2 changes depending on whether time bins are used or not.  I had removed the QA warnings for my own purposes, so please add them back when merging.
