### PR TITLE
Added CRAM to alara.py

### DIFF
--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -1,4 +1,4 @@
-"""This module contains functions relevant to the ALARA activation code.
+"""This module contains functions relevant to the ALARA activation code and the Chebyshev Rational Approximation Method
 """
 from __future__ import print_function
 import os
@@ -25,7 +25,8 @@ except ImportError:
 
 from pyne.mesh import Mesh, MeshError
 from pyne.material import Material, from_atom_frac
-from pyne.nucname import serpent, alara, znum, anum, id
+from pyne import nucname
+from pyne.nucname import serpent, alara, znum, anum
 from pyne.data import N_A, decay_const, decay_children
 from pyne.xs.data_source import SimpleDataSource
 
@@ -520,9 +521,6 @@ def irradiation_blocks(material_lib, element_lib, data_library, cooling,
 
     return s
 
-""" Chebyshev Rational Approximation Method functions
-"""
-
 def _build_matrix(N):
     """ This function  builds burnup matrix, A. Decay only.
     """
@@ -532,7 +530,7 @@ def _build_matrix(N):
     # convert N to id form
     N_id = []
     for i in xrange(len(N)):
-        ID = id(N[i])
+        ID = nucname.id(N[i])
         N_id.append(ID)
         
     sds = SimpleDataSource()
@@ -553,7 +551,6 @@ def _rat_apprx_14(A, t, n_0):
 
     Parameters
     ---------
-
     A : numpy array
 	Burnup matrix
     t : float
@@ -562,23 +559,23 @@ def _rat_apprx_14(A, t, n_0):
 	Inital composition vector
     """
 	
-    theta = np.array([ complex(-8.8977731864688888199, 16.630982619902085304), 
-                   complex(-3.7032750494234480603, 13.656371871483268171), 
-                   complex(-.2087586382501301251, 10.991260561901260913), 
-                   complex(3.9933697105785685194, 6.0048316422350373178), 
-                   complex(5.0893450605806245066, 3.5888240290270065102), 
-                   complex(5.6231425727459771248, 1.1940690463439669766), 
-                   complex(2.2697838292311127097, 8.4617379730402214019)])
+    theta = np.array([ -8.8977731864688888199 + 16.630982619902085304j,
+                   -3.7032750494234480603 + 13.656371871483268171j,
+                   -.2087586382501301251 + 10.991260561901260913j,
+                   3.9933697105785685194 + 6.0048316422350373178j,
+                   5.0893450605806245066 + 3.5888240290270065102j,
+                   5.6231425727459771248 + 1.1940690463439669766j,
+                   2.2697838292311127097 + 8.4617379730402214019j])
     
-    alpha = np.array([ complex( -.000071542880635890672853, .00014361043349541300111), 
-                   complex(.0094390253107361688779, -.01784791958483017511), 
-                   complex(-.37636003878226968717, .33518347029450104214), 
-                   complex(-23.498232091082701191, -5.8083591297142074004), 
-                   complex(46.933274488831293047, 45.643649768827760791), 
-                   complex(-27.875161940145646468, -102.14733999056451434), 
-                   complex(4.8071120988325088907, -1.3209793837428723881)])
+    alpha = np.array([-.000071542880635890672853 + .00014361043349541300111j,
+                   .0094390253107361688779 - .01784791958483017511j,
+                   -.37636003878226968717 + .33518347029450104214j,
+                   -23.498232091082701191 - 5.8083591297142074004j,
+                   46.933274488831293047 + 45.643649768827760791j,
+                   -27.875161940145646468 - 102.14733999056451434j,
+                   4.8071120988325088907 - 1.3209793837428723881j])
     
-    alpha_0 = np.array([1.8321743782540412751*10**(-14)])
+    alpha_0 = np.array([1.8321743782540412751e-14])
 
     s = 7
     A = A*t
@@ -597,7 +594,6 @@ def _rat_apprx_16(A, t, n_0):
 
     Parameters
     ---------
-
     A : numpy array
         Burnup matrix
     t : float
@@ -605,25 +601,25 @@ def _rat_apprx_16(A, t, n_0):
     n_0: numpy array
         Inital composition vector
     """
-    theta = np.array([ complex(-10.843917078696988026, 19.277446167181652284), 
-                   complex(-5.2649713434426468895, 16.220221473167927305), 
-                   complex(5.9481522689511774808, 3.5874573620183222829), 
-                   complex(3.5091036084149180974, 8.4361989858843750826), 
-                   complex(6.4161776990994341923, 1.1941223933701386874), 
-                   complex(1.4193758971856659786, 10.925363484496722585), 
-                   complex(4.9931747377179963991, 5.9968817136039422260), 
-                   complex(-1.4139284624888862114, 13.497725698892745389)])
+    theta = np.array([ -10.843917078696988026 + 19.277446167181652284j,
+                   -5.2649713434426468895 + 16.220221473167927305j,
+                   5.9481522689511774808 + 3.5874573620183222829j,
+                   3.5091036084149180974 + 8.4361989858843750826j,
+                   6.4161776990994341923 + 1.1941223933701386874j,
+                   1.4193758971856659786 + 10.925363484496722585j,
+                   4.9931747377179963991 + 5.9968817136039422260j,
+                   -1.4139284624888862114 + 13.497725698892745389j])
     
-    alpha = np.array([ complex(-.0000005090152186522491565, -.00002422001765285228797), 
-                   complex(.00021151742182466030907, .0043892969647380673918), 
-                   complex(113.39775178483930527, 101.9472170421585645), 
-                   complex(15.059585270023467528, -5.7514052776421819979), 
-                   complex(-64.500878025539646595, -224.59440762652096056), 
-                   complex(-1.4793007113557999718, 1.7686588323782937906), 
-                   complex(-62.518392463207918892, -11.19039109428322848), 
-                   complex(.041023136835410021273, -.15743466173455468191)])
+    alpha = np.array([ -.0000005090152186522491565 - .00002422001765285228797j,
+                      .00021151742182466030907 + .0043892969647380673918j,
+                      113.39775178483930527 + 101.9472170421585645j,
+                      15.059585270023467528 - 5.7514052776421819979j,
+                      -64.500878025539646595 - 224.59440762652096056j,
+                      -1.4793007113557999718 + 1.7686588323782937906j,
+                      -62.518392463207918892 - 11.19039109428322848j,
+                      .041023136835410021273 - .15743466173455468191j])
     
-    alpha_0 = np.array([2.1248537104952237488*10**(-16)])
+    alpha_0 = np.array([2.1248537104952237488e-16])
     
 
     s = 8
@@ -637,12 +633,11 @@ def _rat_apprx_16(A, t, n_0):
     n = n + alpha_0*n_0
     return n
 
-def CRAM(N, t, n_0, order):
+def cram(N, t, n_0, order):
     """ This function returns matrix exponential solution n using CRAM14 or CRAM16
 
     Parameters
     ----------
-
     N : list or array
 	Array of nuclides under consideration
     t : float
@@ -659,9 +654,10 @@ def CRAM(N, t, n_0, order):
     if order == 14:
         return rat_apprx_14(A, t, n_0)
     
-    if order == 16:
+    elif order == 16:
         return rat_apprx_16(A, t, n_0)
     
     else:
-        return 'Rational approximation of degree %d is not supported.' % order
+        msg = 'Rational approximation of degree {0} is not supported.'.format(order)
+        raise ValueError(msg)
     

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -25,8 +25,10 @@ except ImportError:
 
 from pyne.mesh import Mesh, MeshError
 from pyne.material import Material, from_atom_frac
-from pyne.nucname import serpent, alara, znum, anum
-from pyne.data import N_A
+from pyne.nucname import serpent, alara, znum, anum, id
+from pyne.data import N_A, decay_const, decay_children
+from pyne.xs.data_source import SimpleDataSource
+
 
 def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
                    reverse=False):
@@ -517,3 +519,149 @@ def irradiation_blocks(material_lib, element_lib, data_library, cooling,
     s += "dump_file {0}\n".format(dump_file)
 
     return s
+
+""" Chebyshev Rational Approximation Method functions
+"""
+
+def _build_matrix(N):
+    """ This function  builds burnup matrix, A. Decay only.
+    """
+    
+    A = np.zeros((len(N), len(N)))
+    
+    # convert N to id form
+    N_id = []
+    for i in xrange(len(N)):
+        ID = id(N[i])
+        N_id.append(ID)
+        
+    sds = SimpleDataSource()
+
+    # Decay
+    for i in xrange(len(N)):
+        A[i, i] -= decay_const(N_id[i])
+        
+        # Find decay parents
+        for k in xrange(len(N)):
+            if N_id[i] in decay_children(N_id[k]):
+                A[k, i] += decay_const(N_id[k])
+            
+    return A
+
+def _rat_apprx_14(A, t, n_0):
+    """ CRAM of order 14
+
+    Parameters
+    ---------
+
+    A : numpy array
+	Burnup matrix
+    t : float
+	Time step
+    n_0: numpy array
+	Inital composition vector
+    """
+	
+    theta = np.array([ complex(-8.8977731864688888199, 16.630982619902085304), 
+                   complex(-3.7032750494234480603, 13.656371871483268171), 
+                   complex(-.2087586382501301251, 10.991260561901260913), 
+                   complex(3.9933697105785685194, 6.0048316422350373178), 
+                   complex(5.0893450605806245066, 3.5888240290270065102), 
+                   complex(5.6231425727459771248, 1.1940690463439669766), 
+                   complex(2.2697838292311127097, 8.4617379730402214019)])
+    
+    alpha = np.array([ complex( -.000071542880635890672853, .00014361043349541300111), 
+                   complex(.0094390253107361688779, -.01784791958483017511), 
+                   complex(-.37636003878226968717, .33518347029450104214), 
+                   complex(-23.498232091082701191, -5.8083591297142074004), 
+                   complex(46.933274488831293047, 45.643649768827760791), 
+                   complex(-27.875161940145646468, -102.14733999056451434), 
+                   complex(4.8071120988325088907, -1.3209793837428723881)])
+    
+    alpha_0 = np.array([1.8321743782540412751*10**(-14)])
+
+    s = 7
+    A = A*t
+    n = 0*n_0
+
+    for j in range(7):
+        n = n + np.dot(alpha[j]*n_0, np.linalg.inv(A - theta[j] * np.identity(np.shape(A)[0])))
+
+    n = 2*n.real
+    n = n + alpha_0*n_0
+    
+    return n
+
+def _rat_apprx_16(A, t, n_0):
+    """ CRAM of order 16
+
+    Parameters
+    ---------
+
+    A : numpy array
+        Burnup matrix
+    t : float
+        Time step
+    n_0: numpy array
+        Inital composition vector
+    """
+    theta = np.array([ complex(-10.843917078696988026, 19.277446167181652284), 
+                   complex(-5.2649713434426468895, 16.220221473167927305), 
+                   complex(5.9481522689511774808, 3.5874573620183222829), 
+                   complex(3.5091036084149180974, 8.4361989858843750826), 
+                   complex(6.4161776990994341923, 1.1941223933701386874), 
+                   complex(1.4193758971856659786, 10.925363484496722585), 
+                   complex(4.9931747377179963991, 5.9968817136039422260), 
+                   complex(-1.4139284624888862114, 13.497725698892745389)])
+    
+    alpha = np.array([ complex(-.0000005090152186522491565, -.00002422001765285228797), 
+                   complex(.00021151742182466030907, .0043892969647380673918), 
+                   complex(113.39775178483930527, 101.9472170421585645), 
+                   complex(15.059585270023467528, -5.7514052776421819979), 
+                   complex(-64.500878025539646595, -224.59440762652096056), 
+                   complex(-1.4793007113557999718, 1.7686588323782937906), 
+                   complex(-62.518392463207918892, -11.19039109428322848), 
+                   complex(.041023136835410021273, -.15743466173455468191)])
+    
+    alpha_0 = np.array([2.1248537104952237488*10**(-16)])
+    
+
+    s = 8
+    A = A*t
+    n = 0*n_0
+
+    for j in range(8):
+        n = n + np.dot(alpha[j]*n_0, np.linalg.inv(A - theta[j] * np.identity(np.shape(A)[0])))
+
+    n = 2*n.real
+    n = n + alpha_0*n_0
+    return n
+
+def CRAM(N, t, n_0, order):
+    """ This function returns matrix exponential solution n using CRAM14 or CRAM16
+
+    Parameters
+    ----------
+
+    N : list or array
+	Array of nuclides under consideration
+    t : float
+	Time step
+    n_0 : list or array
+	Nuclide concentration vector
+    order : int
+	Order of method. Only 14 and 16 are supported.
+    """
+
+    n_0 = np.array(n_0)
+    A = build_matrix(N)
+    
+    if order == 14:
+        return rat_apprx_14(A, t, n_0)
+    
+    if order == 16:
+        return rat_apprx_16(A, t, n_0)
+    
+    else:
+        return 'Rational approximation of degree %d is not supported.' % order
+    


### PR DESCRIPTION
I added CRAM to alara. I have done some testing myself (results are below). The exponential method seems to be good, but there are a few issues with the last test. 

Testing:

""" Testing the exponentiation part of CRAM. The rat_apprx functions give n(t) = (e^At)*n_0, setting t to 1.0 and 
n_0 to the identity gives e^A """
# Test 1, I = the identity matrix, e^I

IN: 
A = np.eye(3)
print "CRAM: "
print rat_apprx_16(A, 1.0, np.eye(3))
print "e^I: "
print np.e \* np.eye(3)

OUT: 
CRAM: 
[[ 2.71828183  0.          0.        ]
 [ 0.          2.71828183  0.        ]
 [ 0.          0.          2.71828183]]
e^I: 
[[ 2.71828183  0.          0.        ]
 [ 0.          2.71828183  0.        ]
 [ 0.          0.          2.71828183]]
# Test 2, random 3x3 matrix compared to Pade approximation and Taylor

IN:
A = np.random.rand(3, 3)
CRAM_test2 = rat_apprx_16(A, 1.0, np.eye(3))
Pade_test2 = scipy.linalg.expm(A)
Taylor_test2 = scipy.linalg.expm3(A)
print "CRAM: "
print CRAM_test2
print "Pade: "
print Pade_test2
print "Taylor: "
print Taylor_test2
print "Errors: "
print np.linalg.norm(CRAM_test2 - Pade_test2)
print np.linalg.norm(CRAM_test2 - Taylor_test2)

OUT:
CRAM: 
[[ 1.47736655  0.65559436  0.22226281]
 [ 1.85166701  3.1315016   0.7647304 ]
 [ 1.35744556  1.71593956  1.57244038]]
Pade: 
[[ 1.47736655  0.65559437  0.22226282]
 [ 1.85166704  3.13150163  0.76473041]
 [ 1.35744558  1.71593958  1.57244038]]
Taylor: 
[[ 1.47736655  0.65559437  0.22226282]
 [ 1.85166704  3.13150163  0.76473041]
 [ 1.35744558  1.71593958  1.57244038]]
Errors: 
4.85973599949e-08
4.85973601684e-08
# Test 3 Carbon14 decay
# PyNE decay

IN:
from pyne.material import Material
c14_0 = Material({'C14': 1.0})
c14_hl = data.half_life('C14')
c14_1 = c14_0.decay(8*c14_hl)
print(c14_1)

OUT:
Material:
mass = 0.99998805078
density = -1.0
## atoms per molecule = 1.0

C14    0.00390629531964
N14    0.99609370468
# CRAM

IN: CRAM(['C14', 'N14'], c14_hl \* 8.0, [1.0, 0], 16)

OUT: array([ 0.00390625,  0.99609375])
# Test 4 Thorium 232 Decay
# PyNE decay

IN:
th232_0 = Material({'Th232' : 1.0})
th232_hl = data.half_life('Th232')
th232_1 = th232_0.decay(th232_hl)
print th232_1

OUT:
Material:
mass = 0.948152030025
density = -1.0
## atoms per molecule = 1.00000000029

Hg206  4.01984011444e-34
Tl206  1.4307557741e-32
Tl208  7.04340618772e-17
Pb206  1.87243515228e-11
Pb208  0.472658433937
Pb210  3.02694341042e-20
Pb212  4.17699719613e-14
Bi210  1.87099228895e-23
Bi212  3.96172387083e-15
Po210  5.16558236955e-22
Po212  2.08868049467e-25
Po216  1.61111466519e-19
Rn220  6.2924652605e-17
Ra224  3.64403721206e-13
Ra228  2.12846560755e-10
Ac228  2.59700242554e-14
Th228  7.07605987179e-11
Th232  0.52734156576
# CRAM (note values for Pb208 and Pb206, among others, are off)

IN:
nuclides = ['Th232', 'Th228', 'Ac228', 'Ra228', 'Ra224', 'Rn220', 
            'Po216', 'Po212', 'Po210', 'Bi212', 'Bi210', 'Pb212',
            'Pb210', 'Pb208', 'Pb206', 'Tl208', 'Tl206', 'Hg206']
n_0 = np.zeros((18))
n_0[0] = 1.0
CRAM(nuclides, th232_hl, n_0, 16)

OUT:
array([  5.00000000e-01,   6.82714286e-11,   2.50562237e-14,
         2.05357143e-10,   3.57876210e-13,   6.29234887e-17,
         1.64099026e-19,   3.38383509e-25,   1.35304586e-11,
         4.11152940e-15,   4.90075292e-13,   4.33493042e-14,
         7.92857145e-10,   9.99999999e-01,   1.50000000e+00,
         2.07307997e-16,   5.70657194e-16,   5.64953338e-16])
