### PR TITLE
PARTISN SOURCF

### DIFF
--- a/pyne/partisn.py
+++ b/pyne/partisn.py
@@ -830,3 +830,37 @@ def strip_mat_name(mat_name):
         tmp1 = ''.join(tmp2)
     
     return tmp1
+
+def mesh_to_isotropic_source(m, tag):
+    """This function reads an isotropic source definition from a supplied mesh
+    and creates a corresponding PARTISN SOURCF input card.
+
+    Parameters:
+    m : PyNE Mesh
+        The mesh tagged with the source distribution:
+    tag : str
+        The tag on the mesh with the source information:
+    """
+
+    # get data
+    temp = m.structured_ordering
+    m.structured_ordering = "zyx"
+    m.src = IMeshTag(name=tag)
+    data = m.src[:].transpose()
+    m.structured_ordering = temp
+    ninti = len(m.structured_coords[0]) - 1
+
+    # format output
+    s = "sourcf=\n"
+    count = 1
+    for e_row in data:
+        for src in e_row:
+           s += " {0:9.5E}".format(src)
+           if count % ninti == 0:
+               s += ";"
+           if count % 6 == 0:
+               s += "\n"
+           count += 1
+
+    return s
+        

--- a/tests/test_partisn.py
+++ b/tests/test_partisn.py
@@ -21,7 +21,7 @@ except ImportError:
     raise SkipTest
 
 if HAVE_PYTAPS:
-    from pyne.mesh import Mesh
+    from pyne.mesh import Mesh, IMeshTag
 
 warnings.simplefilter("ignore", QAWarning)
 
@@ -495,3 +495,35 @@ def test_strip_mat_name():
     
     assert(mat_name_expected == mat_name)
 
+
+def test_mesh_to_isotropic_source():
+    """Test isotropic SOURCF generation.
+    """
+    m = Mesh(structured=True, structured_coords=[range(5), range(5), range(5)])
+    m.src = IMeshTag(4, float)
+    # These source values were carefully choosen so that:
+    # 1. The iteration order could be visually checked based on RTFLUX output using 
+    #    the resulting SOURCF card.
+    # 2. The repeation capability (i.e. 3R 0 = 0 0 0) could be tested.
+    m.src[:] = [[100,0,0,0], [0,0,0,0], [6,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0],
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], 
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0],
+                [0,100,0,0], [5,0,0,0], [6,0,0,0], [0,0,0,0], [8,0,0,0], [0,0,0,0],
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], 
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0],
+                [0,0,100,0], [5,0,0,0], [0,0,0,0], [7,0,0,0], [0,0,0,0], [0,0,0,0],
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], 
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0],
+                [0,0,0,100], [0,0,0,0], [0,0,0,0], [7,0,0,0], [8,0,0,0], [0,0,0,0],
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0], 
+                  [0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,0]]
+    out = partisn.mesh_to_isotropic_source(m, "src")
+    exp = ("sourcf= 1.00000E+02 3R 0; 0 8.00000E+00 0 8.00000E+00; 4R 0; 4R 0; 0 5.00000E+00\n"
+           "5.00000E+00 0; 4R 0; 4R 0; 4R 0; 6.00000E+00 6.00000E+00 2R 0; 4R 0; 4R 0; 4R 0;\n"
+           "2R 0 7.00000E+00 7.00000E+00; 4R 0; 4R 0; 4R 0; 0 1.00000E+02 2R 0; 4R 0; 4R 0;\n"
+           "4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 2R\n"
+           "0 1.00000E+02 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R\n"
+           "0; 4R 0; 4R 0; 4R 0; 4R 0; 3R 0 1.00000E+02; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0;\n"
+           "4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0; 4R 0;")
+
+    assert(out == exp)


### PR DESCRIPTION
This PR adds the capability of generating isotropic sources for PARTISN from a supplied PyNE `Mesh`. This is done via the PARTISN SOURCF card. Outputted cards are wrapped to 80 characters and make use of the repeated value shorthand format for zero entries (e.g. 3R 0 = 0 0 0).

The SOURCF card produced in the nosetest was confirmed work with PARTISN. I checked the resulting RTFLUX output in VISIT and was able to determine the the position/energy iteration order was all correct. An example of one such visual confirmation is shown below.

![image](https://cloud.githubusercontent.com/assets/1749283/9282071/718eec8c-428f-11e5-92c2-f52b5d21b1cf.png)
