### PR TITLE
mats_from_inp

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1344,7 +1344,7 @@ def mats_from_inp(inp):
            else:
                same_bool = False
                for j in range(0, len(densities[mat_num])):
-                   if abs(den - densities[mat_num][j])/den < 1E-4:
+                   if abs(den - densities[mat_num][j]/den) < 1E-4:
                        same_bool = True
 
                if same_bool is False:

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1344,7 +1344,7 @@ def mats_from_inp(inp):
            else:
                same_bool = False
                for j in range(0, len(densities[mat_num])):
-                   if abs(den - densities[mat_num][j]/den) < 1E-4:
+                   if abs((den - densities[mat_num][j])/den) < 1E-4:
                        same_bool = True
 
                if same_bool is False:

--- a/tests/mcnp_inp.txt
+++ b/tests/mcnp_inp.txt
@@ -3,6 +3,7 @@ C  cells
   1  1  -19.1  -2323   $ These are just random surface numbers
   2  2  -0.9  -1222 1002 -4002                  
   3  2   1.005e+23 $ atom density of water (not molecule density)                           
+  4  2   -1.1 -1 -2 3 4
 C 4  2  -2.7 $ Testing comment out capability
 c
 c Check to make sure surface cards with transformations are not

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -542,6 +542,16 @@ def test_read_mcnp():
              "mat_number": "2",
              "name": " water",
              "source": " internet",
+             "table_ids": {'10000': "05c"}}): 1,
+        Material(
+            {10000000: 0.11189838783149784, 80000000: 0.8881016121685023},
+            -1.0, 1.1, 3,
+            {"comments":
+                 (" Here are comments the comments "
+                  "continue here are more even more"),
+             "mat_number": "2",
+             "name": " water",
+             "source": " internet",
              "table_ids": {'10000': "05c"}}): 1})
 
     read_materials = mats_from_inp('mcnp_inp.txt')
@@ -576,6 +586,9 @@ def test_read_mcnp():
     assert_equal(
         list(expected_multimaterial._mats.keys())[1].metadata,
         list(read_materials[2]._mats.keys())[1].metadata)
+    assert_equal(
+        list(expected_multimaterial._mats.keys())[2].density,
+        list(read_materials[2]._mats.keys())[2].density)
 
 # test to ensure the mats_from_inp function can read repeated mcnp
 # materials like


### PR DESCRIPTION
This PR fixes a bug that affected the way `mcnp.mats_from_inp` read in materials with multiple densities in order to create `MultiMaterials`.  A test was added to ensure this is fixed.
