### PR TITLE
Fixed atom density mistake

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1495,7 +1495,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
             if den <= 0:
                 converted_densities.append(-1*float(den))
             else:
-                converted_densities.append(mat.mass_density(float(den)))
+                converted_densities.append(mat.mass_density(float(den)*1E24))
 
         # check to see how many densities are associated with this material.
         # if there is more than one, create a multimaterial"""

--- a/tests/mcnp_inp.txt
+++ b/tests/mcnp_inp.txt
@@ -2,7 +2,7 @@ TEST MCNP INPUT FILE -- This is NOT valid MCNP input
 C  cells 
   1  1  -19.1  -2323   $ These are just random surface numbers
   2  2  -0.9  -1222 1002 -4002                  
-  3  2   1.005e+23 $ atom density of water (not molecule density)                           
+  3  2   1.005E-01 $ atom density of water (not molecule density)                           
   4  2   -1.1 -1 -2 3 4
 C 4  2  -2.7 $ Testing comment out capability
 c

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -562,7 +562,7 @@ def test_read_mcnp():
     assert_equal(
         list(expected_multimaterial._mats.keys())[0].mass,
         list(read_materials[2]._mats.keys())[0].mass)
-    assert_equal(
+    assert_almost_equal(
         list(expected_multimaterial._mats.keys())[0].density,
         list(read_materials[2]._mats.keys())[0].density)
     assert_equal(
@@ -586,7 +586,7 @@ def test_read_mcnp():
     assert_equal(
         list(expected_multimaterial._mats.keys())[1].metadata,
         list(read_materials[2]._mats.keys())[1].metadata)
-    assert_equal(
+    assert_almost_equal(
         list(expected_multimaterial._mats.keys())[2].density,
         list(read_materials[2]._mats.keys())[2].density)
 


### PR DESCRIPTION
In MCNP, if the density of a cell is specified by a number >0, it is interpreted as an atom density in units of 1E24 atoms/cm^3, (MCNP Manual Vol II, page 3.9). The function `mats_from_mcnp` neglected this factor of 1E24. This PR fixes this and updates the unit tests accordingly.
