### PR TITLE
float -> int

### DIFF
--- a/share/source.F90
+++ b/share/source.F90
@@ -27,7 +27,7 @@ function find_cell() result(icl_tmp)
     icl_tmp = -1
 
     do i = 1, mxa
-      call chkcel(i, 2., j)
+      call chkcel(i, 2, j)
       if (j .eq. 0) then
          ! valid cel set
          icl_tmp = i


### PR DESCRIPTION
This is a minor change to the `source.F90` provided for use with the `source_sampling` module. The second argument to `chkcel()` should be an `int`. Thanks @makeclean for figuring this out.
