### PR TITLE
structured_coords

### DIFF
--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -664,8 +664,6 @@ class Mesh(object):
                     raise MeshError("Found {0} structured meshes."
                                     " Instantiate individually using"
                                     " from_ent_set()".format(count))
-
-
             # from coordinates
             elif (mesh is None) and structured_coords and not structured_set:
                 extents = [0, 0, 0] + [len(x) - 1 for x in structured_coords]
@@ -776,7 +774,6 @@ class Mesh(object):
                 doc = "see Material.{0}() for more information".format(name)
                 setattr(self, name, MaterialMethodTag(mesh=self, name=name,
                         doc=doc))
-
 
     def __len__(self):
         return self._len

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -664,6 +664,8 @@ class Mesh(object):
                     raise MeshError("Found {0} structured meshes."
                                     " Instantiate individually using"
                                     " from_ent_set()".format(count))
+
+
             # from coordinates
             elif (mesh is None) and structured_coords and not structured_set:
                 extents = [0, 0, 0] + [len(x) - 1 for x in structured_coords]
@@ -691,6 +693,11 @@ class Mesh(object):
             self.dims = self.mesh.getTagHandle("BOX_DIMS")[self.structured_set]
             self.vertex_dims = list(self.dims[0:3]) \
                                + [x + 1 for x in self.dims[3:6]]
+ 
+            if self.structured_coords is None:
+                self.structured_coords = [self.structured_get_divisions("x"),
+                                          self.structured_get_divisions("y"),
+                                          self.structured_get_divisions("z")]
         else:
             # Unstructured mesh cases
             # Error if structured arguments are passed
@@ -769,6 +776,7 @@ class Mesh(object):
                 doc = "see Material.{0}() for more information".format(name)
                 setattr(self, name, MaterialMethodTag(mesh=self, name=name,
                         doc=doc))
+
 
     def __len__(self):
         return self._len

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -111,6 +111,10 @@ def test_create_by_file():
     assert_equal(sm.structured_get_divisions("y"), [1.0, 5.0, 10.0, 15.0] )
     assert_equal(sm.structured_get_divisions("z"), [-10.0, 2.0, 12.0] )
 
+    assert_equal(sm.structured_coords[0], range(1,6))
+    assert_equal(sm.structured_coords[1], [1.0, 5.0, 10.0, 15.0] )
+    assert_equal(sm.structured_coords[2], [-10.0, 2.0, 12.0] )
+
     # loading a test file without structured mesh metadata should raise an 
     # error
     filename2 = os.path.join(os.path.dirname(__file__), 


### PR DESCRIPTION
Previously, if instantiating a structured `Mesh` object from an .h5m file, the `structured_coords` attribute was not populated. This PR fixes this and adds a corresponding test. 
