### PR TITLE
Fix to numpy version fix #775

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ def cleanpypath(path):
 
 
 def assert_np_version():
-    low = (1, 8, 0)
+    low = (1, 8)
     v = np.version.short_version
     cur = tuple(map(int, v.split('.')[:2]))
     if cur < low:


### PR DESCRIPTION
#775 introduced a problem while installing with numpy 1.8.2 (see my issue #783, created before thinking it through).

This should fix it.

However: I don't know which numpy version is intended to be used and if this fix keeps that intention.
