### PR TITLE
fix typo in tutorial re: HIPAA

### DIFF
--- a/tutorial/00-intro.ipynb
+++ b/tutorial/00-intro.ipynb
@@ -187,7 +187,7 @@
      "source": [
       "# What goes into PyNE?\n",
       "\n",
-      "Anything that is not export controllable, proprietary, or under HIPPA restrictions!  (If you have questions, ask.)"
+      "Anything that is not export controllable, proprietary, or under HIPAA restrictions!  (If you have questions, ask.)"
      ]
     },
     {


### PR DESCRIPTION
HIPPA -> HIPAA

["What IS **HIPAA**? HIPAA stands for Health Insurance Portability and Accountability Act."](http://www.subr.edu/assets/docs/HealthCenter/What_IS_HIPPA.pdf)
