### PR TITLE
Fixing ipython notebooks on website

### DIFF
--- a/docs/devsguide/website.rst
+++ b/docs/devsguide/website.rst
@@ -12,6 +12,8 @@ Building the website/documentation requires the following:
    #. `sphinxcontrib-bibtex <https://pypi.python.org/pypi/sphinxcontrib-bibtex/>`_
    #. `PrettyTable <https://code.google.com/p/prettytable/>`_
    #. `Cloud Sphinx Theme <https://pythonhosted.org/cloud_sptheme/cloud_theme.html>`_
+   #. `jupyter <http://jupyter.org/>`_
+
 
 -----------------------------------
 Procedure for modifying the website

--- a/docs/sphinxext/notebook_sphinxext.py
+++ b/docs/sphinxext/notebook_sphinxext.py
@@ -12,11 +12,7 @@ from docutils.parsers.rst import directives, roles, states
 from docutils.parsers.rst.roles import set_classes
 from docutils.transforms import misc
 
-try:
-    from IPython.nbconver.exporters import html
-except ImportError:
-    from IPython.nbconvert import html
-
+from nbconvert import HTMLExporter
 
 class Notebook(Directive):
     """Use nbconvert to insert a notebook into the environment.
@@ -47,7 +43,7 @@ class Notebook(Directive):
         nb_path = utils.relative_path(None, nb_path)
 
         # convert notebook to html
-        exporter = html.HTMLExporter(template_file='full')
+        exporter = HTMLExporter(template_file='full')
         output, resources = exporter.from_filename(nb_path)
         header = output.split('<head>', 1)[1].split('</head>',1)[0]
         body = output.split('<body>', 1)[1].split('</body>',1)[0]

--- a/docs/usersguide/index.rst
+++ b/docs/usersguide/index.rst
@@ -21,4 +21,5 @@ essential aspects of using PyNE to do nuclear engineering.
     stlcontainers
     jsoncpp
     spatialsolver
+    r2s
     source_sampling

--- a/readme.rst
+++ b/readme.rst
@@ -49,6 +49,7 @@ Additionally, building the documentation requires the following:
    #. `sphinxcontrib-bibtex <https://pypi.python.org/pypi/sphinxcontrib-bibtex/>`_
    #. `PrettyTable <https://code.google.com/p/prettytable/>`_
    #. `numpydoc <https://pypi.python.org/pypi/numpydoc>`_
+   #. `jupyter <http://jupyter.org/>`_
 
 Most of the dependencies are readily available through package managers. 
 


### PR DESCRIPTION
The ipython notebook -> HTML capabilities now seem to live in Jupyter. I have made modifications accordingly and I can now successfully build the site.
