### PR TITLE
Fix fortran compiler errors when using a source build of GCC

### DIFF
--- a/src/ensdf_processing/ALPHAD/alphad.f
+++ b/src/ensdf_processing/ALPHAD/alphad.f
@@ -179,7 +179,6 @@
       INTEGER(KIND=4), INTRINSIC :: INDEX, INT, LEN, MIN0, NINT,        &       
      &                              LEN_TRIM
       INTEGER(KIND=4), EXTERNAL :: INDEXF, IVLSTR, TYPSTR
-      REAL(KIND=4), INTRINSIC :: ALOG10
       REAL(KIND=4), EXTERNAL :: VALSTR
       REAL(KIND=8), INTRINSIC :: DABS, DBLE, DMOD, DSQRT
       REAL(KIND=8), EXTERNAL :: DVALST
@@ -931,7 +930,7 @@
      &                  ' HF for alpha to', enxit(l), ' not saved.'
                   ihf = ihf - 1
                ELSE
-                  sigdig = INT(ALOG10(hf(l)))
+                  sigdig = INT(LOG10(hf(l)))
                   IF(sigdig.GT.0) THEN
                      sigdig = sigdig + 1
                   ELSE IF(sigdig.LE.0) THEN

--- a/src/ensdf_processing/GTOL/gtol.f
+++ b/src/ensdf_processing/GTOL/gtol.f
@@ -4093,7 +4093,8 @@ c         END IF
 !
 !     FUNCTIONS USED
 !
-      REAL(KIND=8), INTRINSIC :: DBLE, REAL
+      REAL(KIND=4), INTRINSIC :: REAL
+      REAL(KIND=8), INTRINSIC :: DBLE
 !
 !     Local variables
 !

--- a/src/ensdf_processing/GTOL/gtol.f
+++ b/src/ensdf_processing/GTOL/gtol.f
@@ -3945,6 +3945,7 @@ c         END IF
 !     Functions used
 !
       REAL(KIND=4), INTRINSIC :: ABS
+      REAL(KIND=4), EXTERNAL :: REAL
 !
 !     Dummy arguments
 !
@@ -3959,12 +3960,12 @@ c         END IF
       SIGma = Dx
       b2 = MU + 1.28*SIGma
       high = MU + 10.0*SIGma
-      CALL QROMB(0.0,high,denom)
+      CALL QROMB(REAL(0.0),high,denom)
       low = MU + 1.28*SIGma
       IF(low.LE.0.0) low = 5.0*SIGma
       counts = 1
       DO WHILE (.TRUE.)
-         CALL QROMB(0.0,low,area)
+         CALL QROMB(REAL(0.0),low,area)
          prob = area/denom
          IF((prob.GE.0.899.AND.prob.LE.0.901).OR.counts.GT.100) THEN
             b1 = low
@@ -4041,6 +4042,7 @@ c         END IF
       INTEGER(KIND=4), INTRINSIC :: INT
       REAL(KIND=4), INTRINSIC :: ABS, ALOG10
       REAL(KIND=8), INTRINSIC :: DABS, DBLE
+      REAL(KIND=4), EXTERNAL :: REAL
 !
 !     Local variables
 !
@@ -4059,7 +4061,7 @@ c         END IF
          jj = j
          CALL TRAPZD(A,B,s(j),jj)
          IF(j.GE.k) THEN
-            CALL POLINT(h(j-km),s(j-km),k,0.,Ss,dss)
+            CALL POLINT(h(j-km),s(j-km),k,REAL(0.),Ss,dss)
 !           Add check for when integral is zero
             IF(Ss.EQ.0..AND.dss.EQ.0.) RETURN
 !           IF(ABS(DSS) .LE. EPS*ABS(SS))RETURN
@@ -4093,7 +4095,7 @@ c         END IF
 !
 !     FUNCTIONS USED
 !
-      REAL(KIND=4), INTRINSIC :: REAL
+      REAL(KIND=4), EXTERNAL :: REAL
       REAL(KIND=8), INTRINSIC :: DBLE
 !
 !     Local variables
@@ -4140,7 +4142,7 @@ c         END IF
 !     Functions used
 !
       INTEGER(KIND=4), INTRINSIC :: INT
-      REAL(KIND=4), INTRINSIC :: ABS, ALOG10, AMAX1, AMIN1
+      REAL(KIND=4), INTRINSIC :: ABS, AMAX1, AMIN1
 !
 !     Local variables
 !
@@ -4169,8 +4171,8 @@ c         END IF
          c(i) = Ya(i)
          d(i) = Ya(i)
          IF(Ya(i).NE.0.) THEN
-            maxyval = AMAX1(maxyval,ALOG10(ABS(Ya(i))))
-            minyval = AMIN1(minyval,ALOG10(ABS(Ya(i))))
+            maxyval = AMAX1(maxyval,LOG10(ABS(Ya(i))))
+            minyval = AMIN1(minyval,LOG10(ABS(Ya(i))))
          END IF
       END DO
       Y = Ya(ns)

--- a/src/ensdf_processing/GTOL/gtol.f
+++ b/src/ensdf_processing/GTOL/gtol.f
@@ -3944,8 +3944,7 @@ c         END IF
 !
 !     Functions used
 !
-      REAL(KIND=4), INTRINSIC :: ABS
-      REAL(KIND=4), EXTERNAL :: REAL
+      REAL(KIND=4), INTRINSIC :: ABS, REAL
 !
 !     Dummy arguments
 !
@@ -3960,12 +3959,12 @@ c         END IF
       SIGma = Dx
       b2 = MU + 1.28*SIGma
       high = MU + 10.0*SIGma
-      CALL QROMB(REAL(0.0),high,denom)
+      CALL QROMB(REAL(0.0,4),high,denom)
       low = MU + 1.28*SIGma
       IF(low.LE.0.0) low = 5.0*SIGma
       counts = 1
       DO WHILE (.TRUE.)
-         CALL QROMB(REAL(0.0),low,area)
+         CALL QROMB(REAL(0.0,4),low,area)
          prob = area/denom
          IF((prob.GE.0.899.AND.prob.LE.0.901).OR.counts.GT.100) THEN
             b1 = low
@@ -4040,9 +4039,8 @@ c         END IF
 !     Functions used
 !
       INTEGER(KIND=4), INTRINSIC :: INT
-      REAL(KIND=4), INTRINSIC :: ABS, ALOG10
+      REAL(KIND=4), INTRINSIC :: ABS, ALOG10, REAL
       REAL(KIND=8), INTRINSIC :: DABS, DBLE
-      REAL(KIND=4), EXTERNAL :: REAL
 !
 !     Local variables
 !
@@ -4061,7 +4059,7 @@ c         END IF
          jj = j
          CALL TRAPZD(A,B,s(j),jj)
          IF(j.GE.k) THEN
-            CALL POLINT(h(j-km),s(j-km),k,REAL(0.),Ss,dss)
+            CALL POLINT(h(j-km),s(j-km),k,REAL(0.,4),Ss,dss)
 !           Add check for when integral is zero
             IF(Ss.EQ.0..AND.dss.EQ.0.) RETURN
 !           IF(ABS(DSS) .LE. EPS*ABS(SS))RETURN
@@ -4095,8 +4093,7 @@ c         END IF
 !
 !     FUNCTIONS USED
 !
-      REAL(KIND=4), EXTERNAL :: REAL
-      REAL(KIND=8), INTRINSIC :: DBLE
+      REAL(KIND=8), INTRINSIC :: DBLE, REAL
 !
 !     Local variables
 !
@@ -4112,7 +4109,7 @@ c         END IF
          x = A + 0.5D+0*del
          dsum = 0.D+0
          DO j = 1, it
-            dsum = dsum + DBLE(NORMFUNC(REAL(x)))
+            dsum = dsum + DBLE(NORMFUNC(REAL(x,4)))
             x = x + del
          END DO
          S = 0.5D+0*(S+(DBLE(B)-DBLE(A))*dsum/tnm)

--- a/src/ensdf_processing/nsdflib95.f
+++ b/src/ensdf_processing/nsdflib95.f
@@ -2457,7 +2457,7 @@
 !
 !     Local variables
 !
-      REAL(KIND=4),INTRINSIC :: AIMAG,ALOG,REAL
+      REAL(KIND=4),INTRINSIC :: AIMAG,REAL
       COMPLEX(KIND=4) :: c,xt,xtmp,z1,z2
       COMPLEX(KIND=4),INTRINSIC :: CMPLX
       REAL(KIND=4) :: f1n,fn,pi,s,t
@@ -2488,7 +2488,7 @@
             z1 = z1*z2
          END DO
          s = (fn**(REAL(X)-0.5))/(pi**m)
-         t = AIMAG(X)*ALOG(fn)
+         t = AIMAG(X)*LOG(fn)
          c = s*CMPLX(COS(t),SIN(t))
          GAMZ = c*z1
       END IF
@@ -2600,7 +2600,6 @@
 !     Local variables
 !
       COMPLEX(KIND=4) :: apn,bpn,fn,t,test
-      REAL(KIND=4),INTRINSIC :: CABS
       INTEGER(KIND=4) :: n
       REAL(KIND=4),PARAMETER :: PREC = 1.0E-6
 !
@@ -2622,7 +2621,7 @@
          bpn = bpn + 1.0
          test = t/HYPERG
          HYPERG = HYPERG + t
-         IF(CABS(test).LT.PREC)RETURN
+         IF(ABS(test).LT.PREC)RETURN
       END DO
       WRITE(6,1010) A,B,X,HYPERG,n
  1010 FORMAT(' ERROR IN HYPERG'/4(5X,'(',E20.10,',',E20.10,')'/),I10)


### PR DESCRIPTION
I was originally trying to install PyNE and all its dependencies, including GCC, from source. I was able to get it to work just fine if I used the default version of GCC present on the machine, but when using my own build of GCC, I got a few errors like this:

```
                   sigdig = INT(ALOG10(hf(l)))
                                      1
Error: Type of argument 'x' in call to 'alog10' at (1) should be REAL(8), not REAL(4)

                   sigdig = INT(ALOG10(hf(l)))
                               1
Error: Function 'alog10' at (1) is INTRINSIC but is not compatible with an intrinsic
```

and a few like this:

```
             dsum = dsum + DBLE(NORMFUNC(REAL(x)))
                                        1
Error: Type mismatch in argument ‘x’ at (1); passed REAL(8) to REAL(4)
```

and a few like this:

```
             CALL POLINT(h(j-km),s(j-km),k,0.,Ss,dss)
                                          1
Error: Type mismatch in argument ‘x’ at (1); passed REAL(8) to REAL(4)
```

This PR fixes the errors. I was able to build PyNE successfully with these changes.
