### PR TITLE
Add a threshold capability for uniform biasing.

### DIFF
--- a/docs/theorymanual/source_sampling.rst
+++ b/docs/theorymanual/source_sampling.rst
@@ -67,7 +67,10 @@ uniform and user-specified sampling modes, an alias table is created from
 the uniform sampling mode, :math:`\hat{q}` is created by assigning a total
 source density of 1 to each mesh volume element, so that all space is sampled
 equally. Within each mesh volume element, a normalized PDF is created on the
-basis of source densities at each energy.
+basis of source densities at each energy.  An optional threshold can be provided
+such that all mesh volume elements with a total source below that threshold will
+remain unbiased under the uniform sampling mode.  The default threshold is 0 so
+that all mesh elements are biased.  
 
 The method for uniformly sampling within a mesh volume element of Cartesian mesh
 is straightforward. A vertex of the hexahedron (:math:`O`) is chosen and three
@@ -99,21 +102,26 @@ Sample Calculations
 This section provides the sample calculations to justify the results in the
 nosetests: test_uniform, test_bias, test_bias_spatial.
 
-Consider a mesh with two mesh volume elements with volumes (3, 0.5). The
+Consider a mesh with three mesh volume elements with volumes (3, 0.5, 2). The
 source on the mesh has two energy groups. The source density distribution is:
 
 .. math::
-     q' = ((2, 1), (9, 3))
+     q' = ((2000, 1000), (9000, 3000), (1, 2))
 
 The source intensity is found by multiplying by the volumes:
 
 .. math::
-     q = ((6, 3), (4.5, 1.5))
+     q = ((6000, 3000), (4500, 1500), (2, 4))
 
 Normalizing yields the analog PDF:
 
 .. math::
-     p = ((0.4, 0.2), (0.3, 0.1)
+     p = ((1000/2501, 500/2501), (750/2501, 250/2501) (1/7503, 2/7503) )
+
+or approximately:
+
+.. math::
+     p = ((0.39984, 0.199920), (0.29988, 0.09996), (0.0001333, 0.0002666) )
 
 Case 1: Uniform Sampling
 ------------------------
@@ -122,25 +130,61 @@ For uniform sampling the biased source density distribution is created by
 normalizing the source density to 1 within each mesh volume element:
 
 .. math::
-     \hat{q}' = ((2/3, 1/3), (3/4, 1/4))
+     \hat{q}' = ((2/3, 1/3), (3/4, 1/4), (1/3, 2/3))
 
 The biased source intensity is found by multiplying by the volumes:
 
 .. math::
-     \hat{q} = ((2, 1), (3/8, 1/8))
+     \hat{q} = ((2, 1), (3/8, 1/8), (2/3, 4/3))
 
 Normalizing yields the biased PDF:
 
 .. math::
-     \hat{p} = ((4/7, 2/7), (3/28, 1/28))
+     \hat{p} = ((4/11, 2/11), (3/44, 1/44), (4/33, 8/33) )
+
+or appoximately:
+
+.. math::
+     \hat{p} = ((0.363636, 0.181818), (0.0681818, 0.0227272), (0.121212, 0.242424) )
 
 The weights of particle born from these phase space bins should then be the
 ratio of the unbiased to biased PDF values:
 
 .. math::
-     w = ((0.7, 0.7), (2.8, 2.8))
+     w = ((1.09956, 1.09956), (4.3982, 4.3982), (0.0010996, 0.0010996))
 
-Case 2: User-Specified Biasing
+Case 2: Uniform Sampling with Threshold
+---------------------------------------
+
+If a threshold of 5 is added to uniform sampling, the biased source density
+distribution is created by normalizing the source density to 1 within each
+mesh volume element that has a total strength above that threshold:
+
+.. math::
+     \hat{q}' = ((2/3, 1/3), (3/4, 1/4), (1 , 2))  hmmmm
+
+The biased source intensity is found by multiplying by the volumes:
+
+.. math::
+     \hat{q} = ((2, 1), (3/8, 1/8), (2, 4))
+
+Normalizing yields the biased PDF:
+
+.. math::
+     \hat{p} = ((4/11, 2/11), (3/44, 1/44), (4/33, 8/33) )
+
+or appoximately:
+
+.. math::
+     \hat{p} = ((0.363636, 0.181818), (0.0681818, 0.0227272), (0.121212, 0.242424) )
+
+The weights of particle born from these phase space bins should then be the
+ratio of the unbiased to biased PDF values:
+
+.. math::
+     w = ((1.09956, 1.09956), (4.3982, 4.3982), (0.0010996, 0.0010996))
+
+Case 3: User-Specified Biasing
 ------------------------------
 Now consider some user-specified bias source density distribution:
 
@@ -162,6 +206,9 @@ ratio of the unbiased to biased PDF values:
 
 .. math::
      w = ((1.6, 0.4), (2.4, 0.8))
+
+
+
 
 **********
 References

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -311,7 +311,7 @@ cdef class Sampler:
         self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, std_string(<char *> bias_tag_name_bytes))
     
     
-    def _sampler_sampler_1(self, filename, src_tag_name, e_bounds, uniform):
+    def _sampler_sampler_1(self, filename, src_tag_name, e_bounds, uniform, threshold=0):
         """Sampler(self, filename, src_tag_name, e_bounds, uniform)
          This method was overloaded in the C-based source. To overcome
         this we ill put the relevant docstring for each version below.
@@ -344,6 +344,8 @@ cdef class Sampler:
         src_tag_name : std::string
         
         uniform : bool
+
+        threshold : double
         
         filename : std::string
         
@@ -371,7 +373,7 @@ cdef class Sampler:
             e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
             for ie_bounds in range(e_bounds_size):
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
-        self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, <bint> uniform)
+        self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, <bint> uniform, threshold)
     
     
     _sampler_sampler_0_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, str), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("bias_tag_name", str)))

--- a/share/source.F90
+++ b/share/source.F90
@@ -57,7 +57,7 @@ subroutine source
     integer :: tries
   
     if (first_run .eqv. .true.) then
-        call sampling_setup(idum(1))
+        call sampling_setup(idum(1),rdum(1))
         first_run = .false.
     endif
  

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -230,7 +230,7 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
           }
         } else {
           for (j=0; j<num_e_groups; ++j) {
-            bias_pdf[i*num_e_groups + j] = 0.0;
+            bias_pdf[i*num_e_groups + j] = pdf[i*num_e_groups + j];
           }
         }
       }

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -230,7 +230,7 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
           }
         } else {
           for (j=0; j<num_e_groups; ++j) {
-            bias_pdf[i*num_e_groups + j] = pdf[i*num_e_groups + j];
+            bias_pdf[i*num_e_groups + j] = max(pdf[i*num_e_groups + j],0.0);
           }
         }
       }

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -230,7 +230,7 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
           }
         } else {
           for (j=0; j<num_e_groups; ++j) {
-            bias_pdf[i*num_e_groups + j] = max(pdf[i*num_e_groups + j],0.0);
+            bias_pdf[i*num_e_groups + j] = volumes[i]*pdf[i*num_e_groups + j];
           }
         }
       }

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -47,7 +47,8 @@ namespace pyne {
 
   /// MCNP interface for source sampling setup
   /// \param mode The sampling mode: 1 = analog, 2 = uniform, 3 = user-specified
-  void sampling_setup_(int* mode);
+  /// \param threshold The threshold below which a voxel will not be adjusted for uniform sampling
+  void sampling_setup_(int* mode, double* threshold=0);
   /// MCNP interface to sample particle birth parameters after sampling setup
   /// \param rands Six pseudo-random numbers supplied from the Fortran side.
   /// \param x The sampled x position returned by this function
@@ -142,6 +143,7 @@ namespace pyne {
     int num_e_groups; ///< Number of groups in tag \a _src_tag_name
     int num_bias_groups; ///< Number of groups tag \a _bias_tag_name
     Mode mode; ///< Problem mode: analog, uniform, user
+    double threshold;
     // mesh
     moab::Interface* mesh; ///< MOAB mesh
     int num_ves; ///< Number of mesh volume elements on \a mesh.

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -107,7 +107,8 @@ namespace pyne {
     Sampler(std::string filename, 
             std::string src_tag_name, 
             std::vector<double> e_bounds, 
-            bool uniform);
+            bool uniform,
+            double threshold=0);
     /// Constuctor for analog and uniform sampling
     /// \param filename The path to the MOAB mesh (.h5m) file
     /// \param src_tag_name The name of the tag with the unbiased source density


### PR DESCRIPTION
When using uniform sampling of source meshes, it is possible that some voxels with negligible source (e.g. 10^40) density will be sampled often.  One reason for a very low source density is a very small volume fraction of non-void material, in which case such a volume be selected undergo a lot of void rejection, and then ultimately be rejected for another voxel.  In some cases this can slow down a sampling process beyond reasonable use.

This adds a threshold that removes voxels that have a density the threshold from being sampled.  The user supplies the threshold in the rdum input card.
