### PR TITLE
Fixing ALARA matlib error

### DIFF
--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1615,9 +1615,10 @@ class Material(_Material, collections.MutableMapping):
         s += '{0} {1} {2}\n'\
                     .format(mat_name, density, len(self.comp))
 
+        # Multiply frac by 100 because ALARA uses mass percent for matlib files
         for iso, frac in self.comp.items():
             s += '     {0} {1:.4E} {2}\n'.format(nucname.alara(iso),
-                                                 frac, str(nucname.znum(iso)))
+                                                 frac*100, str(nucname.znum(iso)))
 
         return s
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1181,15 +1181,15 @@ def test_alara():
                 '# comments: this is a long comment that will definitly go over the 80 character\n'
                 '#  limit, for science\n'
                 'LEU 19.1 2\n'
-                '     u:235 4.0000E-02 92\n'
-                '     u:238 9.6000E-01 92\n'
+                '     u:235 4.0000E+00 92\n'
+                '     u:238 9.6000E+01 92\n'
                 '# mat number: 2\n'
                 'mat2_rho-19.1 19.1 2\n'
-                '     u:235 4.0000E-02 92\n'
-                '     u:238 9.6000E-01 92\n'
+                '     u:235 4.0000E+00 92\n'
+                '     u:238 9.6000E+01 92\n'
                 'mat<mat_num>_rho-<rho> <rho> 2\n'
-                '     u:235 4.0000E-02 92\n'
-                '     u:238 9.6000E-01 92\n')
+                '     u:235 4.0000E+00 92\n'
+                '     u:238 9.6000E+01 92\n')
     assert_equal(written, expected)
 
 def test_write_mcnp():
@@ -1343,15 +1343,15 @@ def test_write_alara():
                 '# comments: this is a long comment that will definitly go over the 80 character\n'
                 '#  limit, for science\n'
                 'LEU 19.1 2\n'
-                '     u:235 4.0000E-02 92\n'
-                '     u:238 9.6000E-01 92\n'
+                '     u:235 4.0000E+00 92\n'
+                '     u:238 9.6000E+01 92\n'
                 '# mat number: 2\n'
                 'mat2_rho-19.1 19.1 2\n'
-                '     u:235 4.0000E-02 92\n'
-                '     u:238 9.6000E-01 92\n'
+                '     u:235 4.0000E+00 92\n'
+                '     u:238 9.6000E+01 92\n'
                 'mat<mat_num>_rho-<rho> <rho> 2\n'
-                '     u:235 4.0000E-02 92\n'
-                '     u:238 9.6000E-01 92\n')
+                '     u:235 4.0000E+00 92\n'
+                '     u:238 9.6000E+01 92\n')
     assert_equal(written, expected)
     os.remove('alara.txt')
 


### PR DESCRIPTION
In ALARA matlib files, compositions are specified in mass percent, not mass density.
http://alara.engr.wisc.edu/users.guide.html/support.htm#ml
