### PR TITLE
fix isnan compiler errors for newer clang,gcc

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -24,14 +24,12 @@
 #include <vector>
 #include <algorithm>
 
-#if defined __APPLE__ || defined __WIN_GNUC__
 #if (__GNUC__ >= 4)
   #include <cmath>
   #define isnan(x) std::isnan(x)
 #else
   #include <math.h>
   #define isnan(x) __isnand((double)x)
-#endif
 #endif
 
 #ifdef __WIN_MSVC__


### PR DESCRIPTION
Newer compiler versions (at least clang 3.7.1, gcc 5.3) change their stdlib
shenanigans a bit causing compiler errors like this:

```
    /home/r/src/cyclus/cyclus/src/pyne.cc:7975:8: error: use of undeclared identifier 'isnan'
      if (!isnan(k_conv)) {
```

So isnan calls need to be explicitly std:: prefixed - so the pre-existing
macro for apple+win systems was just scoped to include all systems (linux
too).
