### PR TITLE
Small correction to location of r2s source.F90 file.

### DIFF
--- a/docs/usersguide/source_sampling.rst
+++ b/docs/usersguide/source_sampling.rst
@@ -199,7 +199,7 @@ The simplest way to compile MCNP5 with the source subroutine is as follows:
      d. pyne/src/measure.h
 
   #. Remove the pre-existing empty source.F90 file.
-  #. Soft-link pyne/src/source.F90.
+  #. Soft-link pyne/share/source.F90.
   #. Open the file MCNP/Source/src/FILE.list.
   #. Edit line 78 to include the additional source files. It should look like "CXX_SRC := measure.cpp source_sampling.cpp".
   #. Compile MCNP5 using the standard build method.


### PR DESCRIPTION
Small correction to the location of the `source.F90` file in the  MCNP5 source sampling install instructions. File is located in `pyne/share` rather than `pyne/src`.