### PR TITLE
R2S fix

### DIFF
--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -52,7 +52,9 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
     tag_flux = flux_mesh.mesh.getTagHandle(flux_tag)
 
     # find number of e_groups
-    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(flux_mesh.mesh.iterate(iBase.Type.region,iMesh.Topology.all))[0]]
+    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(
+        flux_mesh.mesh.iterate(iBase.Type.region,
+                               iMesh.Topology.all))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
     

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -52,12 +52,10 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
     tag_flux = flux_mesh.mesh.getTagHandle(flux_tag)
 
     # find number of e_groups
-    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(
-        flux_mesh.mesh.iterate(iBase.Type.region,
-                               iMesh.Topology.all))[0]]
+    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(flux_mesh.mesh.iterate(iBase.Type.region,iMesh.Topology.all))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
-
+    
     # Establish for loop bounds based on if forward or backward printing
     # is requested
     if not reverse:

--- a/scripts/expand_tags.py
+++ b/scripts/expand_tags.py
@@ -18,7 +18,11 @@ def main():
                               "be seperated by commas without spaces.\n"))
     args = parser.parse_args()
 
-    m = Mesh(structured=True, mesh=args.mesh_file)
+    try:
+        m = Mesh(structured=True, mesh=args.mesh_file)
+    except:
+        print ("Structured mesh not found, trying unstructured mesh")
+        m = Mesh(structured=False, mesh=args.mesh_file)
 
     if args.tags is not None:
         tags = args.tags.split(',')

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -114,6 +114,7 @@ def step1():
     meshtal = config.get('step1', 'meshtal')
     tally_num = config.getint('step1', 'tally_num')
     flux_tag = config.get('step1', 'flux_tag')
+    
     if structured:
         meshtal = Meshtal(meshtal,
                         {tally_num: (flux_tag, flux_tag + '_err',
@@ -132,7 +133,11 @@ def step1():
                       flux_tag=flux_tag)
 
     # create a blank mesh for step 2:
-    mesh = meshtal.tally[tally_num]
+    if structured:
+        mesh = meshtal.tally[tally_num]
+    else:
+        mesh = Mesh(structured=False, mesh=meshtal)
+        
     ves = list(mesh.iter_ve())
     for tag in mesh.mesh.getAllTags(ves[0]):
         mesh.mesh.destroyTag(tag, True)

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -128,7 +128,8 @@ def step1():
     load(geom)
     cell_mats = cell_materials(geom)
     irradiation_setup(meshtal, cell_mats, alara_params_filename, tally_num,
-                      num_rays=num_rays, grid=grid, reverse=reverse)
+                      num_rays=num_rays, grid=grid, reverse=reverse,
+                      flux_tag=flux_tag)
 
     # create a blank mesh for step 2:
     mesh = meshtal.tally[tally_num]

--- a/tests/test_r2s.py
+++ b/tests/test_r2s.py
@@ -27,9 +27,9 @@ from pyne.mcnp import Meshtal
 
 thisdir = os.path.dirname(__file__)
 
-def irradiation_setup_structured():
+def irradiation_setup_structured(flux_tag = "n_flux", meshtal_file = "meshtal_2x2x1"):
 
-    meshtal = os.path.join(thisdir, "files_test_r2s", "meshtal_2x2x1")
+    meshtal = os.path.join(thisdir, "files_test_r2s", meshtal_file)
     tally_num = 4
     cell_mats = {2: Material({2004: 1.0}, density=1.0, metadata={'name': 'mat_11'}),
                  3: Material({3007: 0.4, 3006: 0.6}, density=2.0, metadata={'name': 'mat_12'})}
@@ -37,7 +37,6 @@ def irradiation_setup_structured():
     geom = os.path.join(thisdir, "unitbox.h5m")
     num_rays = 9
     grid = True
-    flux_tag = "n_flux"
     fluxin = os.path.join(os.getcwd(), "alara_fluxin")
     reverse = True
     alara_inp = os.path.join(os.getcwd(), "alara_inp")
@@ -147,24 +146,41 @@ def test_photon_sampling_setup_structured():
         assert_array_equal(m.tag2[i], exp_tag2[i])
 
 
-def irradiation_setup_unstructured():
+def irradiation_setup_unstructured(flux_tag = "n_flux", meshtal_filename = "meshtal_2x2x1"):
+    meshtal_file = os.path.join(thisdir, "files_test_r2s", meshtal_filename
+    )
+    if flux_tag is "n_flux":
+        meshtal = Meshtal(meshtal_file, {4: (flux_tag, flux_tag + "_err",
+                                             flux_tag + "_total",
+                                             flux_tag + "_err_total")})
+        #  Explicitly make this mesh unstructured, it will now iterate in yxz
+        #  order which is MOAB structured mesh creation order.
+        meshtal = Mesh(structured=False, mesh=meshtal.tally[4].mesh)
+        meshtal_mesh_file = os.path.join(thisdir, "meshtal.h5m")
+        meshtal.mesh.save(meshtal_mesh_file)
+    else:
+        # if not using n_flux makes a mesh containing n_flux tag, and then
+        # makes a new tag called flux_tag, to use later in the test
+        flux_tag_name = "n_flux"
+        meshtal = Meshtal(meshtal_file, {4: (flux_tag_name, flux_tag_name + "_err",
+                                             flux_tag_name + "_total",
+                                             flux_tag_name + "_err_total")})
+        #  Explicitly make this mesh unstructured, it will now iterate in yxz
+        #  order which is MOAB structured mesh creation order.
+        meshtal = Mesh(structured=False, mesh=meshtal.tally[4].mesh)
+        meshtal_mesh_file = os.path.join(thisdir, "meshtal.h5m")
+        meshtal.mesh.save(meshtal_mesh_file)
+        new_mesh = Mesh(structured=False, mesh="meshtal.h5m")
+        new_mesh.TALLY_TAG = IMeshTag(2,float) # 2 egroups
+        new_mesh.TALLY_TAG = meshtal.n_flux[:]
+        # overwrite the mesh file
+        new_mesh.mesh.save(meshtal_mesh_file) 
 
-    flux_tag = "n_flux"
-    meshtal_file = os.path.join(thisdir, "files_test_r2s", "meshtal_2x2x1")
-    meshtal = Meshtal(meshtal_file, {4: (flux_tag, flux_tag + "_err",
-                                         flux_tag + "_total",
-                                         flux_tag + "_err_total")})
-    #  Explicitly make this mesh unstructured, it will now iterate in yxz
-    #  order which is MOAB structured mesh creation order.
-    meshtal = Mesh(structured=False, mesh=meshtal.tally[4].mesh)
-    meshtal_mesh_file = os.path.join(thisdir, "meshtal.h5m")
-    meshtal.mesh.save(meshtal_mesh_file)
-
+        
     cell_mats = {2: Material({2004: 1.0}, density=1.0, metadata={'name':'mat_11'}),
                  3: Material({3007: 0.4, 3006: 0.6}, density=2.0, metadata={'name':'mat_12'})}
     alara_params = "Bogus line for testing\n" 
     geom = os.path.join(thisdir, "unitbox.h5m")
-    flux_tag = "n_flux"
     fluxin = os.path.join(os.getcwd(), "alara_fluxin")
     reverse = True
     alara_inp = os.path.join(os.getcwd(), "alara_inp")
@@ -202,9 +218,13 @@ def irradiation_setup_unstructured():
     os.remove(output_mesh)
     
     return [m_out, f1, f2, f3]
+
     
 
 def test_irradiation_setup_unstructured():
+
+    # make new file with non default tag
+    
     p = multiprocessing.Pool()
     r = p.apply_async(irradiation_setup_unstructured)
     p.close()
@@ -286,3 +306,49 @@ def test_total_photon_source_intensity():
     intensity = total_photon_source_intensity(m, "source_density")
     assert_equal(intensity, 58)
 
+def test_irradiation_setup_unstructured_nondef_tag():
+    p = multiprocessing.Pool()
+    r = p.apply_async(irradiation_setup_unstructured(flux_tag="TALLY_TAG"))
+    p.close()
+    p.join()
+    results = r.get()
+    
+    # unpack return values
+    f1 = results[1]
+    f2 = results[2]
+    f3 = results[3]
+    
+    out = results[0]
+    n_flux = out[0]
+    n_flux_total = out[2]
+    densities = out[5]
+    
+    comps = np.zeros(shape=(len(out[4])), dtype=dict)
+    for i, comp in enumerate(out[4]):
+        comps[i] = {}
+        for nucid in comp:
+            comps[i][nucid[0]] = nucid[1]
+    
+    # test r2s step 1 output mesh
+    fluxes = [[6.93088E-07, 1.04838E-06], [6.36368E-07, 9.78475E-07], 
+              [5.16309E-07, 9.86586E-07], [6.36887E-07, 9.29879E-07]]
+    tot_fluxes = [1.74147E-06, 1.61484E-06, 1.50290E-06, 1.56677E-06] 
+ 
+    
+    i = 0
+    for nf, nfe, nft, nfte, comp, density in izip(n_flux, n_flux_err, 
+                                                n_flux_total, n_flux_err_total, 
+                                                comps, densities):
+        assert_almost_equal(density, 2.0)
+        assert_equal(len(comp), 2)
+        assert_almost_equal(comp[30060000], 0.6)
+        assert_almost_equal(comp[30070000], 0.4)
+        assert_array_equal(nf, fluxes[i])
+        i+=1
+    
+    # test that files match
+    assert(f1 == True)
+    assert(f2 == True)
+    assert(f3 == True)
+    
+    # load a file without the default tag


### PR DESCRIPTION
This fixes an issue discovered where the r2s routines were not being passed appropriate information from tags in meshes to irradiation setup routines, tet meshes were the only ones affected by this. Changes have also been made in the DAGMC repository such that unstructured meshes will produce the vector tag information expected by r2s.py