### PR TITLE
Fixes for finding f2py when many copies may be on the PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,27 @@ IF(NOT ${BUILD_TYPE} STREQUAL "release")
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0")
 ENDIF()
 
+
+#
+# Allow for dependnecies to exist in non-install location
+#
+if (NOT DEPS_ROOT_DIR)
+  get_filename_component(compdir ${CMAKE_CXX_COMPILER} DIRECTORY)
+  get_filename_component(DEPS_ROOT_DIR ${compdir} DIRECTORY)
+endif (NOT DEPS_ROOT_DIR)
+SET(DEPS_HINTS HINTS "${DEPS_ROOT_DIR}")
+SET(DEPS_BIN_HINTS ${DEPS_HINTS} "${DEPS_ROOT_DIR}/bin")
+SET(DEPS_LIB_HINTS ${DEPS_HINTS} "${DEPS_ROOT_DIR}/lib")
+SET(DEPS_INCLUDE_HINTS HINTS "${DEPS_ROOT_DIR}/include")
+MESSAGE("-- Dependency Root Dir (DEPS_ROOT_DIR): ${DEPS_ROOT_DIR}")
+MESSAGE("-- Dependency Hints (DEPS_HINTS): ${DEPS_HINTS}")
+MESSAGE("-- Dependency Binary Hints (DEPS_BIN_HINTS): ${DEPS_BIN_HINTS}")
+MESSAGE("-- Dependency Library Hints (DEPS_LIB_HINTS): ${DEPS_LIB_HINTS}")
+MESSAGE("-- Dependency Include Hints (DEPS_INCLUDE_HINTS): ${DEPS_INCLUDE_HINTS}")
+
+
 # Include the HDF5 library and c++ headers
-find_package( HDF5 COMPONENTS C REQUIRED)
+find_package(HDF5 COMPONENTS C REQUIRED)
 include_directories(${HDF5_INCLUDE_DIRS})
 if(WIN32)
     # FindHDF5 finds the includes but not the libraries on Windows (MSYS).  Annoying!

--- a/pyne/CMakeLists.txt
+++ b/pyne/CMakeLists.txt
@@ -120,19 +120,24 @@ cython_add_module(bins bins.pyx)
 target_link_libraries(bins pyne)
 
 # figure out which f2py to use
-find_program(F2PY_C f2py)
-if(${PYTHON_VERSION_MAJOR} GREATER 2)
-  find_program(F2PY_C2 f2py3)
-  if(F2PY_C2)
-    set(F2PY_C ${F2PY_C2})
-  endif(F2PY_C2)
-elseif(${PYTHON_VERSION_MAJOR} LESS 3)
-  #because arch is dumb
-  find_program(F2PY_C2 f2py2)
-  if(F2PY_C2)
-    set(F2PY_C ${F2PY_C2})
-  endif(F2PY_C2)
-endif(${PYTHON_VERSION_MAJOR} GREATER 2)
+find_program(F2PY_C f2py ${DEPS_BIN_HINTS})
+if(NOT F2PY_C)
+  if(${PYTHON_VERSION_MAJOR} GREATER 2)
+    find_program(F2PY_C2 f2py3 ${DEPS_BIN_HINTS})
+    if(F2PY_C2)
+      set(F2PY_C ${F2PY_C2})
+    endif(F2PY_C2)
+  elseif(${PYTHON_VERSION_MAJOR} LESS 3)
+    # because arch is dumb
+    find_program(F2PY_C2 f2py2 ${DEPS_BIN_HINTS})
+    if(F2PY_C2)
+      set(F2PY_C ${F2PY_C2})
+    endif(F2PY_C2)
+  endif(${PYTHON_VERSION_MAJOR} GREATER 2)
+endif(NOT F2PY_C)
+
+message("-- F2PY Executable: ${F2PY_C}")
+message("-- F2PY F90 FLAGS: ${F2PY_F90FLAGS}")
 
 
 


### PR DESCRIPTION
Otherwise CMake can pick up the wrong versions of f2py, which may not match the Python version you are using.