### PR TITLE
Fix build on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,10 @@ find_package(Numpy REQUIRED)
 include_directories("${NUMPY_INCLUDE_DIR}")
 
 
+pyne_setup_fortran()
+
 # Find f2py, if building spatial solver
 IF(BUILD_SPATIAL_SOLVER)
-  pyne_setup_fortran()
   find_package(F2py REQUIRED)
   message("-- F2PY Executable: ${F2PY_EXECUTABLE}")
   message("-- F2PY Version: ${F2PY_VERSION}")

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -39,6 +39,7 @@ macro(pyne_setup_fortran)
       find_library(LIBGCC_S_PATH gcc_s.${gcc_s_ver}
         PATHS ${CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES}
         NODEFAULTPATH
+        ${DEPS_LIB_HINTS}
       )
       if (LIBGCC_S_PATH)
         break()
@@ -167,4 +168,3 @@ macro(pyne_configure_rpath)
   ENDIF("${isSystemDir}" STREQUAL "-1")
   MESSAGE("-- CMAKE_INSTALL_RPATH: ${CMAKE_INSTALL_RPATH}")
 endmacro()
-


### PR DESCRIPTION
The spatial solver isn't build on Mac, but it still needs to set up Fortran
for ensdf_processing stuff.

And fix finding of conda Fortran libraries.

Fixes https://github.com/pyne/pyne/issues/911.