### PR TITLE
Subvoxel read alara fluxout

### DIFF
--- a/news/subvoxel_read_alara_fluxout.rst
+++ b/news/subvoxel_read_alara_fluxout.rst
@@ -1,0 +1,15 @@
+**Added:** 
+* Codes to read ALARA output file under subvoxel R2S condition
+* A function to build up a subvoxel_array from mesh and cell_mats information
+* A test function to test the process of reading ALARA output file 
+
+**Changed:** 
+* Some code clean up
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -258,17 +258,15 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
                     tag_handles[tags[cond]][ve] = [0] * num_e_groups
         else:
             temp_mesh_data = np.empty(
-                shape=(num_vol_elements, num_e_groups * max_num_cells),
+                shape=(num_vol_elements, max_num_cells, num_e_groups),
                 dtype=float)
             temp_mesh_data.fill(0.0)
             for sve, subvoxel in enumerate(subvoxel_array):
-                    # start index of data
-                    d_s = subvoxel['scid'] * num_e_groups
-                    # end index of data
-                    d_e = (subvoxel['scid'] + 1) * num_e_groups
-                    temp_mesh_data[subvoxel['idx'],d_s:d_e] = matched_data[sve][3][:]
+                temp_mesh_data[subvoxel['idx'],subvoxel['scid'],:] = \
+                    matched_data[sve][3][:]
             for i, _, ve in mesh:
-                tag_handles[tags[cond]][ve] = temp_mesh_data[i,:]
+                tag_handles[tags[cond]][ve] = \
+                    temp_mesh_data[i,:].reshape(max_num_cells * num_e_groups)
 
 def record_to_geom(mesh, cell_fracs, cell_mats, geom_file, matlib_file,
                    sig_figs=6, sub_voxel=False):

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -218,12 +218,12 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
     with tb.open_file(filename) as h5f:
         num_e_groups = len(h5f.root.data[0][3])
     max_num_cells = -1
-    ves = list(mesh.iter_ve())
+    ve0 = next(mesh.iter_ve())
     if sub_voxel:
         num_vol_elements = len(mesh)
         subvoxel_array = _get_subvoxel_array(mesh, cell_mats)
         max_num_cells = \
-                len(mesh.mesh.getTagHandle('cell_number')[ves[0]])
+                len(mesh.mesh.getTagHandle('cell_number')[ve0])
     else:
         max_num_cells = 1
 

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -258,9 +258,9 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
                     tag_handles[tags[cond]][ve] = [0] * num_e_groups
         else:
             temp_mesh_data = np.empty(
-                shape=(num_vol_elements, num_e_groups * max_num_cells))
-            for i in range(num_vol_elements):
-                temp_mesh_data[i] = [0.0] * num_e_groups * max_num_cells
+                shape=(num_vol_elements, num_e_groups * max_num_cells),
+                dtype=float)
+            temp_mesh_data.fill(0.0)
             for sve, row in enumerate(subvoxel_array):
                     # start index of data
                     d_s = row['scid'] * num_e_groups

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -261,12 +261,12 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
                 shape=(num_vol_elements, num_e_groups * max_num_cells),
                 dtype=float)
             temp_mesh_data.fill(0.0)
-            for sve, row in enumerate(subvoxel_array):
+            for sve, subvoxel in enumerate(subvoxel_array):
                     # start index of data
-                    d_s = row['scid'] * num_e_groups
+                    d_s = subvoxel['scid'] * num_e_groups
                     # end index of data
-                    d_e = (row['scid'] + 1) * num_e_groups
-                    temp_mesh_data[row['idx'],d_s:d_e] = matched_data[sve][3][:]
+                    d_e = (subvoxel['scid'] + 1) * num_e_groups
+                    temp_mesh_data[subvoxel['idx'],d_s:d_e] = matched_data[sve][3][:]
             for i, _, ve in mesh:
                 tag_handles[tags[cond]][ve] = temp_mesh_data[i,:]
 

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -829,20 +829,19 @@ def _get_subvoxel_array(mesh, cell_mats):
     """
     cell_number_tag = mesh.mesh.getTagHandle('cell_number')
     subvoxel_array = np.zeros(0, dtype=[(b'svid', np.int64),
-                                                      (b'idx', np.int64),
-                                                      (b'scid', np.int64)])
+                                        (b'idx', np.int64),
+                                        (b'scid', np.int64)])
     temp_subvoxel = np.zeros(1, dtype=[(b'svid', np.int64),
-                                                      (b'idx', np.int64),
-                                                      (b'scid', np.int64)])
+                                       (b'idx', np.int64),
+                                       (b'scid', np.int64)])
     # calculate the total number of non-void sub-voxel
     non_void_sv_num = 0
     for i, _, ve in mesh:
         for c, cell in enumerate(cell_number_tag[ve]):
-            if cell > 0:
-                if len(cell_mats[cell].comp):
-                    temp_subvoxel[0] = (non_void_sv_num, i, c)
-                    subvoxel_array = np.append(subvoxel_array, temp_subvoxel)
-                    non_void_sv_num += 1
+            if cell > 0 and len(cell_mats[cell].comp): #non-void cell
+                temp_subvoxel[0] = (non_void_sv_num, i, c)
+                subvoxel_array = np.append(subvoxel_array, temp_subvoxel)
+                non_void_sv_num += 1
 
     return subvoxel_array
 

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -181,7 +181,8 @@ def photon_source_to_hdf5(filename, chunkshape=(10000,)):
     f.close()
 
 
-def photon_source_hdf5_to_mesh(mesh, filename, tags):
+def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
+                               cell_mats=None):
     """This function reads in an hdf5 file produced by photon_source_to_hdf5
     and tags the requested data to the mesh of a PyNE Mesh object. Any
     combinations of nuclides and decay times are allowed. The photon source
@@ -205,16 +206,33 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags):
         dictionary could be:
 
         tags = {('U-235', 'shutdown') : 'tag1', ('TOTAL', '1 h') : 'tag2'}
+    sub_voxel: bool, optional
+        If the sub_voxel is True, then the sub-voxel r2s will be used.
+        Then the photon_source will be interpreted as sub-voxel photon source.
+    cell_mats : dict, optional
+        cell_mats is required when sub_voxel is True.
+        Maps geometry cell numbers to PyNE Material objects.
     """
+
     # find number of energy groups
     with tb.open_file(filename) as h5f:
         num_e_groups = len(h5f.root.data[0][3])
+    max_num_cells = -1
+    ves = list(mesh.iter_ve())
+    if sub_voxel:
+        num_vol_elements = len(mesh)
+        subvoxel_array = _get_subvoxel_array(mesh, cell_mats)
+        max_num_cells = \
+                len(mesh.mesh.getTagHandle('cell_number')[ves[0]])
+    else:
+        max_num_cells = 1
 
     # create a dict of tag handles for all keys of the tags dict
     tag_handles = {}
     for tag_name in tags.values():
         tag_handles[tag_name] = \
-            mesh.mesh.createTag(tag_name, num_e_groups, float)
+                mesh.mesh.createTag(tag_name, num_e_groups * max_num_cells,
+                                    float)
 
     # iterate through each requested nuclide/dectay time
     for cond in tags.keys():
@@ -230,13 +248,27 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags):
             matched_data = h5f.root.data.read_where(
                 "(nuc == '{0}') & (time == '{1}')".format(nuc, cond[1]))
 
-        idx = 0
-        for i, _, ve in mesh:
-            if matched_data[idx][0] == i:
-                tag_handles[tags[cond]][ve] = matched_data[idx][3]
-                idx += 1
-            else:
-                tag_handles[tags[cond]][ve] = [0] * num_e_groups
+        if not sub_voxel:
+            idx = 0
+            for i, _, ve in mesh:
+                if matched_data[idx][0] == i:
+                    tag_handles[tags[cond]][ve] = matched_data[idx][3]
+                    idx += 1
+                else:
+                    tag_handles[tags[cond]][ve] = [0] * num_e_groups
+        else:
+            temp_mesh_data = np.empty(
+                shape=(num_vol_elements, num_e_groups * max_num_cells))
+            for i in range(num_vol_elements):
+                temp_mesh_data[i] = [0.0] * num_e_groups * max_num_cells
+            for sve, row in enumerate(subvoxel_array):
+                    # start index of data
+                    d_s = row['scid'] * num_e_groups
+                    # end index of data
+                    d_e = (row['scid'] + 1) * num_e_groups
+                    temp_mesh_data[row['idx'],d_s:d_e] = matched_data[sve][3][:]
+            for i, _, ve in mesh:
+                tag_handles[tags[cond]][ve] = temp_mesh_data[i,:]
 
 def record_to_geom(mesh, cell_fracs, cell_mats, geom_file, matlib_file,
                    sig_figs=6, sub_voxel=False):
@@ -264,7 +296,7 @@ def record_to_geom(mesh, cell_fracs, cell_mats, geom_file, matlib_file,
             :rel_error: float
                 The relative error associated with the volume fraction.
 
-     cell_mats : dict
+    cell_mats : dict
         Maps geometry cell numbers to PyNE Material objects. Each PyNE material
         object must have 'name' specified in Material.metadata.
     geom_file : str
@@ -774,3 +806,43 @@ def _output_flux(ve, tag_flux,output,start,stop,direction):
 
     output += "\n\n"
     return output
+
+def _get_subvoxel_array(mesh, cell_mats):
+    """
+    This function returns an array of subvoxels.
+    Parameters
+    ----------
+    mesh : PyNE Mesh object
+        The Mesh object for which the geometry is discretized.
+
+    return : subvoxel_array: structured array
+        A sorted, one dimensional array, each entry containing the following
+        fields:
+
+            :svid: int
+                The index of non-void subvoxel id
+            :idx: int
+                The idx of the voxel
+            :scid: int
+                The cell index of the cell in that voxel
+
+    """
+    cell_number_tag = mesh.mesh.getTagHandle('cell_number')
+    subvoxel_array = np.zeros(0, dtype=[(b'svid', np.int64),
+                                                      (b'idx', np.int64),
+                                                      (b'scid', np.int64)])
+    temp_subvoxel = np.zeros(1, dtype=[(b'svid', np.int64),
+                                                      (b'idx', np.int64),
+                                                      (b'scid', np.int64)])
+    # calculate the total number of non-void sub-voxel
+    non_void_sv_num = 0
+    for i, _, ve in mesh:
+        for c, cell in enumerate(cell_number_tag[ve]):
+            if cell > 0:
+                if len(cell_mats[cell].comp):
+                    temp_subvoxel[0] = (non_void_sv_num, i, c)
+                    subvoxel_array = np.append(subvoxel_array, temp_subvoxel)
+                    non_void_sv_num += 1
+
+    return subvoxel_array
+

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -1231,9 +1231,9 @@ class Mesh(object):
         # creat tag frame with default value
         cell_largest_frac_number = [-1] * num_vol_elements
         cell_largest_frac = [0.0] * num_vol_elements
-        voxel_cell_number = np.empty(shape=(num_vol_elements,max_num_cells),
+        voxel_cell_number = np.empty(shape=(num_vol_elements, max_num_cells),
                                      dtype=int)
-        voxel_cell_fracs = np.empty(shape=(num_vol_elements,max_num_cells),
+        voxel_cell_fracs = np.empty(shape=(num_vol_elements, max_num_cells),
                                     dtype=float)
         voxel_cell_number.fill(-1)
         voxel_cell_fracs.fill(0.0)

--- a/tests/test_alara.py
+++ b/tests/test_alara.py
@@ -258,8 +258,8 @@ def test_photon_source_hdf5_to_mesh_subvoxel():
                                     ('vol_frac', np.float64),
                                     ('rel_error', np.float64)])
 
-    cell_fracs[:] = [(0, 11, 1, 0.0), (1, 11, 0.5, 0.0), (1, 12, 0.5, 0.0),
-                     (2, 11, 0.5, 0.0), (2, 13, 0.5, 0.0), (3, 13, 1, 0.0)]
+    cell_fracs[:] = [(0, 11, 1.0, 0.0), (1, 11, 0.5, 0.0), (1, 12, 0.5, 0.0),
+                     (2, 11, 0.5, 0.0), (2, 13, 0.5, 0.0), (3, 13, 1.0, 0.0)]
 
     cell_mats = {11: Material({'H': 1.0}, density=1.0),
                  12: Material({'He': 1.0}, density=1.0),
@@ -271,14 +271,14 @@ def test_photon_source_hdf5_to_mesh_subvoxel():
                                sub_voxel=sub_voxel, cell_mats=cell_mats)
 
     # create lists of lists of expected results
-    tag1_answers = [[1] + [0] * 41 + [0] * 42,
-                    [2] + [0] * 41 + [3] + [0] * 41,
-                    [4] + [0] * 41 + [0] * 42,
-                    [0] * 42 * 2]
-    tag2_answers = [[5] + [0] * 41 + [0] * 42,
-                    [6] + [0] * 41 + [7] + [0] * 41,
-                    [8] + [0] * 41 + [0] * 42,
-                    [0] * 42 * 2]
+    tag1_answers = [[1.0] + [0.0] * 41 + [0.0] * 42,
+                    [2.0] + [0.0] * 41 + [3.0] + [0.0] * 41,
+                    [4.0] + [0.0] * 41 + [0.0] * 42,
+                    [0.0] * 42 * 2]
+    tag2_answers = [[5.0] + [0.0] * 41 + [0.0] * 42,
+                    [6.0] + [0.0] * 41 + [7.0] + [0.0] * 41,
+                    [8.0] + [0.0] * 41 + [0.0] * 42,
+                    [0.0] * 42 * 2]
 
     for i, _, ve in mesh:
         assert_array_equal(mesh.mesh.getTagHandle("tag1")[ve], tag1_answers[i])

--- a/tests/test_alara.py
+++ b/tests/test_alara.py
@@ -40,7 +40,7 @@ def test_write_fluxin_single():
         raise SkipTest
 
     output_name = "fluxin.out"
-    forward_fluxin = os.path.join(thisdir, "files_test_alara", 
+    forward_fluxin = os.path.join(thisdir, "files_test_alara",
                                   "fluxin_single_forward.txt")
     output = os.path.join(os.getcwd(), output_name)
 
@@ -75,9 +75,9 @@ def test_write_fluxin_multiple():
         raise SkipTest
 
     output_name = "fluxin.out"
-    forward_fluxin = os.path.join(thisdir, "files_test_alara", 
+    forward_fluxin = os.path.join(thisdir, "files_test_alara",
                                   "fluxin_multiple_forward.txt")
-    reverse_fluxin = os.path.join(thisdir, "files_test_alara", 
+    reverse_fluxin = os.path.join(thisdir, "files_test_alara",
                                   "fluxin_multiple_reverse.txt")
     output = os.path.join(os.getcwd(), output_name)
 
@@ -240,14 +240,61 @@ def test_photon_source_hdf5_to_mesh():
     if os.path.isfile(filename + '.h5'):
         os.remove(filename + '.h5')
 
+def test_photon_source_hdf5_to_mesh_subvoxel():
+    """Tests the function photon source_h5_to_mesh
+    under sub-voxel r2s condition."""
+
+    if not HAVE_PYTAPS:
+        raise SkipTest
+
+    filename = os.path.join(thisdir, "files_test_alara", "phtn_src")
+    photon_source_to_hdf5(filename, chunkshape=(10,))
+    assert_true(os.path.exists(filename + '.h5'))
+    sub_voxel = True
+    mesh = Mesh(structured=True,
+                structured_coords=[[0, 1, 2], [0, 1, 2], [0, 1]])
+    cell_fracs = np.zeros(6, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+
+    cell_fracs[:] = [(0, 11, 1, 0.0), (1, 11, 0.5, 0.0), (1, 12, 0.5, 0.0),
+                     (2, 11, 0.5, 0.0), (2, 13, 0.5, 0.0), (3, 13, 1, 0.0)]
+
+    cell_mats = {11: Material({'H': 1.0}, density=1.0),
+                 12: Material({'He': 1.0}, density=1.0),
+                 13: Material({}, density=0.0, metadata={'name': 'void'})}
+    mesh.tag_cell_fracs(cell_fracs)
+    tags = {('1001', 'shutdown'): 'tag1', ('TOTAL', '1 h'): 'tag2'}
+
+    photon_source_hdf5_to_mesh(mesh, filename + '.h5', tags,
+                               sub_voxel=sub_voxel, cell_mats=cell_mats)
+
+    # create lists of lists of expected results
+    tag1_answers = [[1] + [0] * 41 + [0] * 42,
+                    [2] + [0] * 41 + [3] + [0] * 41,
+                    [4] + [0] * 41 + [0] * 42,
+                    [0] * 42 * 2]
+    tag2_answers = [[5] + [0] * 41 + [0] * 42,
+                    [6] + [0] * 41 + [7] + [0] * 41,
+                    [8] + [0] * 41 + [0] * 42,
+                    [0] * 42 * 2]
+
+    for i, _, ve in mesh:
+        assert_array_equal(mesh.mesh.getTagHandle("tag1")[ve], tag1_answers[i])
+        assert_array_equal(mesh.mesh.getTagHandle("tag2")[ve], tag2_answers[i])
+
+    if os.path.isfile(filename + '.h5'):
+        os.remove(filename + '.h5')
+
 def test_record_to_geom():
 
     if not HAVE_PYTAPS:
         raise SkipTest
 
-    expected_geom = os.path.join(thisdir, "files_test_alara", 
+    expected_geom = os.path.join(thisdir, "files_test_alara",
                                  "alara_record_geom.txt")
-    expected_matlib = os.path.join(thisdir, "files_test_alara", 
+    expected_matlib = os.path.join(thisdir, "files_test_alara",
                                    "alara_record_matlib.txt")
     geom = os.path.join(os.getcwd(), "alara_record_geom")
     matlib = os.path.join(os.getcwd(), "alara_record_matlib")
@@ -256,23 +303,23 @@ def test_record_to_geom():
                                         ('vol_frac', np.float64),
                                         ('rel_error', np.float64)])
 
-    cell_mats = {11: Material({'H1': 1.0, 'K39': 1.0}, density=1.1, 
+    cell_mats = {11: Material({'H1': 1.0, 'K39': 1.0}, density=1.1,
                               metadata={'name': 'fake_mat'}),
-                 12: Material({'H1': 0.1, 'O16': 1.0}, density=1.2, 
+                 12: Material({'H1': 0.1, 'O16': 1.0}, density=1.2,
                               metadata={'name': 'water'}),
-                 13: Material({'He4': 42.0}, density=1.3, 
+                 13: Material({'He4': 42.0}, density=1.3,
                               metadata={'name': 'helium'}),
                  14: Material({}, density=0.0, metadata={'name': 'void'}),
                  15: Material({}, density=0.0, metadata={'name': 'void'}),
-                 16: Material({'H1': 1.0, 'K39': 1.0}, density=1.1, 
+                 16: Material({'H1': 1.0, 'K39': 1.0}, density=1.1,
                               metadata={'name': 'fake_mat'})}
 
-    cell_fracs[:] = [(0, 11, 0.55, 0.0), (0, 12, 0.45, 0.0), (1, 11, 0.2, 0.0), 
-                     (1, 12, 0.3, 0.0), (1, 13, 0.5, 0.0), (2, 11, 0.15, 0.0), 
+    cell_fracs[:] = [(0, 11, 0.55, 0.0), (0, 12, 0.45, 0.0), (1, 11, 0.2, 0.0),
+                     (1, 12, 0.3, 0.0), (1, 13, 0.5, 0.0), (2, 11, 0.15, 0.0),
                      (2, 14, 0.01, 0.0), (2, 15, 0.04, 0.0), (2, 16, 0.8, 0.0),
                      (3, 11, 0.55, 0.0), (3, 12, 0.45, 0.0)]
 
-    m = Mesh(structured_coords=[[-1, 0, 1], [-1, 0, 1], [0, 1]], 
+    m = Mesh(structured_coords=[[-1, 0, 1], [-1, 0, 1], [0, 1]],
              structured=True, mats=None)
 
     record_to_geom(m, cell_fracs, cell_mats, geom, matlib)
@@ -336,7 +383,7 @@ def test_mesh_to_geom():
         raise SkipTest
 
     expected_geom = os.path.join(thisdir, "files_test_alara", "alara_geom.txt")
-    expected_matlib = os.path.join(thisdir, "files_test_alara", 
+    expected_matlib = os.path.join(thisdir, "files_test_alara",
                                    "alara_matlib.txt")
     geom = os.path.join(os.getcwd(), "alara_geom")
     matlib = os.path.join(os.getcwd(), "alara_matlib")
@@ -378,7 +425,7 @@ def test_num_den_to_mesh_shutdown():
     if not HAVE_PYTAPS:
         raise SkipTest
 
-    filename = os.path.join(thisdir, "files_test_alara", 
+    filename = os.path.join(thisdir, "files_test_alara",
                             "num_density_output.txt")
     m = Mesh(structured=True, structured_coords=[[0,1],[0,1],[0,1,2]])
     with open(filename) as f:
@@ -393,8 +440,8 @@ def test_num_den_to_mesh_shutdown():
                   20040000:7.1632e+02}
     exp_comp_1 = {10010000:4.1240e+13,
                   10020000:4.7443e+11,
-                  10030000:2.6627e+13, 
-                  20030000:8.3547e+10, 
+                  10030000:2.6627e+13,
+                  20030000:8.3547e+10,
                   20040000:2.6877e+19}
 
     # actual composition results
@@ -421,7 +468,7 @@ def test_num_den_to_mesh_stdout():
     if not HAVE_PYTAPS:
         raise SkipTest
 
-    filename = os.path.join(thisdir, "files_test_alara", 
+    filename = os.path.join(thisdir, "files_test_alara",
                             "num_density_output.txt")
     m = Mesh(structured=True, structured_coords=[[0,1],[0,1],[0,1,2]])
 
@@ -438,8 +485,8 @@ def test_num_den_to_mesh_stdout():
                   20040000:7.1632e+02}
     exp_comp_1 = {10010000:4.1240e+13,
                   10020000:4.7443e+11,
-                  10030000:2.6627e+13, 
-                  20030000:8.3547e+10, 
+                  10030000:2.6627e+13,
+                  20030000:8.3547e+10,
                   20040000:2.6877e+19}
 
     # actual composition results
@@ -466,7 +513,7 @@ def test_num_den_to_mesh_1_y():
     if not HAVE_PYTAPS:
         raise SkipTest
 
-    filename = os.path.join(thisdir, "files_test_alara", 
+    filename = os.path.join(thisdir, "files_test_alara",
                             "num_density_output.txt")
     m = Mesh(structured=True, structured_coords=[[0,1],[0,1],[0,1,2]])
     num_density_to_mesh(filename, '1 y', m)
@@ -479,8 +526,8 @@ def test_num_den_to_mesh_1_y():
                   20040000:7.1632e+02}
     exp_comp_1 = {10010000:4.1240e+13,
                   10020000:4.7443e+11,
-                  10030000:2.5176e+13, 
-                  20030000:1.5343e+12, 
+                  10030000:2.5176e+13,
+                  20030000:1.5343e+12,
                   20040000:2.6877e+19}
 
     # actual results
@@ -502,11 +549,11 @@ def test_num_den_to_mesh_1_y():
     assert_almost_equal(exp_density_1, m.mats[1].density)
 
 def test_irradiation_blocks():
- 
+
     # actual results
-    act = irradiation_blocks("matlib", "isolib", 
-                             "FEINDlib CINDER CINDER90 THERMAL", 
-                             ["1 h", "0.5 y"], "fluxin.out", "1 y", 
+    act = irradiation_blocks("matlib", "isolib",
+                             "FEINDlib CINDER CINDER90 THERMAL",
+                             ["1 h", "0.5 y"], "fluxin.out", "1 y",
                              output = "number_density")
 
     exp = ("material_lib matlib\n"
@@ -540,12 +587,12 @@ def test_irradiation_blocks():
 
 def test_phtn_src_energy_bounds():
 
-    input_file = os.path.join(thisdir, "files_test_alara", 
+    input_file = os.path.join(thisdir, "files_test_alara",
                               "alara_other_blocks.txt")
     e_bounds = phtn_src_energy_bounds(input_file)
-    expected_e_bounds = [0, 1.00E4, 2.00E4, 5.00E4, 1.00E5, 2.00E5, 3.00E5, 
-                         4.00E5, 6.00E5, 8.00E5, 1.00E6, 1.22E6, 1.44E6, 1.66E6, 
-                         2.00E6, 2.50E6, 3.00E6, 4.00E6, 5.00E6, 6.50E6, 8.00E6, 
+    expected_e_bounds = [0, 1.00E4, 2.00E4, 5.00E4, 1.00E5, 2.00E5, 3.00E5,
+                         4.00E5, 6.00E5, 8.00E5, 1.00E6, 1.22E6, 1.44E6, 1.66E6,
+                         2.00E6, 2.50E6, 3.00E6, 4.00E6, 5.00E6, 6.50E6, 8.00E6,
                          1.00E7, 1.20E7, 1.40E7, 2.00E7]
 
     assert_array_equal(e_bounds, expected_e_bounds)


### PR DESCRIPTION
Note: This pull request from branch `subvoxel_read_alara_fluxout` is dependent on a previous pull request #938 . 
Major changes:
For pyne/pyne/alara.py:
- Edit function `photon_source_hdf5_to_mesh()`: add a new method for sub-voxel r2s photon source treating
- Add private function `_get_non_void_sub_voxel_number()` to calculate the total number of non-void sub-voxel
- Add private function `_get_subvoxel_cell_idx()` to calculate the voxel idx and the cell index in the voxel

For pyne/tests/test_alara.py:
- Add test function `test_photon_source_hdf5_to_mesh_subvoxel()` to test the changes in the `alara.py`.