### PR TITLE
Tag cell fracs update numpyshape

### DIFF
--- a/news/tag_cell_fracs_update_numpyshape.rst
+++ b/news/tag_cell_fracs_update_numpyshape.rst
@@ -1,0 +1,14 @@
+**Added:** 
+* Test function for subvoxel with (N, 1) condition in test_mesh.py
+* Reshape the array when max_num_cells == 1
+
+**Changed:** 
+* Some clean up of white space
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -1226,17 +1226,18 @@ class Mesh(object):
         max_num_cells = -1
         for i in range(num_vol_elements):
             max_num_cells = max(max_num_cells,
-                                  len(cell_fracs[cell_fracs['idx'] == i]))
+                                len(cell_fracs[cell_fracs['idx'] == i]))
 
-        # creat tag frame with default value
+        # create tag frame with default value
         cell_largest_frac_number = [-1] * num_vol_elements
         cell_largest_frac = [0.0] * num_vol_elements
-        voxel_cell_number = np.empty(shape=(num_vol_elements,max_num_cells),
+        voxel_cell_number = np.empty(shape=(num_vol_elements, max_num_cells),
                                      dtype=int)
-        voxel_cell_fracs = np.empty(shape=(num_vol_elements,max_num_cells),
+        voxel_cell_fracs = np.empty(shape=(num_vol_elements, max_num_cells),
                                     dtype=float)
         voxel_cell_number.fill(-1)
         voxel_cell_fracs.fill(0.0)
+
         # set the data
         for i in range(num_vol_elements):
             for (cell, row) in enumerate(cell_fracs[cell_fracs['idx'] == i]):
@@ -1245,11 +1246,16 @@ class Mesh(object):
             # cell_largest_frac_tag
             cell_largest_frac[i] = max(voxel_cell_fracs[i, :])
             largest_index = \
-                list(voxel_cell_fracs[i, :]).index(cell_largest_frac[i])
+                    list(voxel_cell_fracs[i, :]).index(cell_largest_frac[i])
             cell_largest_frac_number[i] = \
-                int(voxel_cell_number[i, largest_index])
+                    int(voxel_cell_number[i, largest_index])
 
-        # creat the tags
+        # reshape the array
+        if max_num_cells == 1:
+            voxel_cell_number.shape = (num_vol_elements, )
+            voxel_cell_fracs.shape = (num_vol_elements, )
+
+        # create the tags
         self.tag(name='cell_number', value=voxel_cell_number,
                  doc='cell numbers of the voxel, -1 used to fill vacancy',
                  tagtype=IMeshTag, size=max_num_cells, dtype=int)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -814,6 +814,34 @@ def test_tag_cell_fracs():
         assert_equal(m.cell_largest_frac[i],
                            exp_cell_largest_frac[i])
 
+def test_tag_cell_fracs_subvoxel_equal_voxel():
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
+             mats = None)
+    cell_fracs = np.zeros(8, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+
+    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
+                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
+                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
+
+    m.tag_cell_fracs(cell_fracs)
+
+    #  Expected tags:
+    exp_cell_number = [[1], [2], [3], [4], [5], [6], [7], [8]]
+    exp_cell_fracs = [[1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0]]
+    exp_cell_largest_frac_number = [1, 2, 3, 4, 5, 6, 7, 8]
+    exp_cell_largest_frac = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+    for i in range(len(m)):
+        assert_array_equal(m.cell_number[i], exp_cell_number[i])
+        assert_array_equal(m.cell_fracs[i], exp_cell_fracs[i])
+        assert_equal(m.cell_largest_frac_number[i],
+                           exp_cell_largest_frac_number[i])
+        assert_equal(m.cell_largest_frac[i],
+                           exp_cell_largest_frac[i])
 
 def test_no_mats():
     mesh = gen_mesh(mats=None)


### PR DESCRIPTION
There was a bug in `pyne/mesh.py:tag_cell_fracs` . The error message is: `ValueError: could not broadcast input array from shape (N,1) into shape (N)`  where `N` is the number of volume elements. 

The bug appears when the `max_num_cells == 1`. If the `max_num_cells` is greater than 1, then there is no problem. 

So, I modified the code to differentiate two conditions of `max_num_cells` (it's 1 or greater than 1), and add some code to treat the condition when `max_num_cells == 1`. 

Major changes:
1. In `pyne/mesh.py`: add some code for the condition when `max_num_cells == 1`

2. In `tests/test_mesh.py`: add a test function `test_tag_cell_fracs_subvoxel_equal_voxel` to test this condition