### PR TITLE
Subvoxel source subroutine analog only

### DIFF
--- a/news/subvoxel_source_subroutine_analog_only.rst
+++ b/news/subvoxel_source_subroutine_analog_only.rst
@@ -1,6 +1,7 @@
 **Added:** 
 * Functions and variables for sub-voxel r2s-analog mode
 * Tests functions for sub-voxel r2s-analog mode
+* Add SubMode as an indenfitier to simplify the code
 
 **Changed:** 
 * Sampler difinition and particle_birth funciton to support sub-voxel mode

--- a/news/subvoxel_source_subroutine_analog_only.rst
+++ b/news/subvoxel_source_subroutine_analog_only.rst
@@ -1,0 +1,14 @@
+**Added:** 
+* Functions and variables for sub-voxel r2s-analog mode
+* Tests functions for sub-voxel r2s-analog mode
+
+**Changed:** 
+* Sampler difinition and particle_birth funciton to support sub-voxel mode
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -45,8 +45,6 @@ cdef extern from "source_sampling.h" namespace "pyne":
         Sampler(std_string, std_string, std_string, std_string, cpp_vector[double], cpp_bool) except +
 
         # attributes
-        cpp_vector[int] cell_number
-        int max_num_cells
 
         # methods
         cpp_vector[double] particle_birth() except +

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -42,6 +42,7 @@ cdef extern from "source_sampling.h" namespace "pyne":
         Sampler(std_string, std_string, cpp_vector[double]) except +
         Sampler(std_string, std_string, cpp_vector[double], std_string) except +
         Sampler(std_string, std_string, cpp_vector[double], cpp_bool) except +
+        Sampler(std_string, std_string, std_string, std_string, cpp_vector[double], cpp_bool) except +
 
         # attributes
 

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -45,7 +45,8 @@ cdef extern from "source_sampling.h" namespace "pyne":
         Sampler(std_string, std_string, std_string, std_string, cpp_vector[double], cpp_bool) except +
 
         # attributes
-
+        cpp_vector[int] cell_number
+        int max_num_cells
 
         # methods
         cpp_vector[double] particle_birth() except +

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -373,9 +373,84 @@ cdef class Sampler:
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
         self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, <bint> uniform)
     
+    def _sampler_sampler_2(self, filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, uniform):
+        """Sampler(self, filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, uniform)
+         This method was overloaded in the C-based source. To overcome
+        this we will put the relevant docstring for each version below.
+        Each version will begin with a line of # characters.
+        
+        Constuctor for analog and uniform sampling
+        
+        Parameters
+        ----------
+        e_bounds : std::vector< double >
+        
+        src_tag_name : std::string
+
+        cell_num_tag_name : std::string
+
+        cell_fracs_tag_name : std::string
+        
+        bias_tag_name : std::string
+        
+        filename : std::string
+        
+        Returns
+        -------
+        None
+        
+        ################################################################
+        
+        Constuctor for analog and uniform sampling
+        
+        Parameters
+        ----------
+        e_bounds : std::vector< double >
+        
+        src_tag_name : std::string
+
+        cell_num_tag_name : std::string
+
+        cell_fracs_tag_name : std::string
+        
+        uniform : bool
+        
+        filename : std::string
+        
+        Returns
+        -------
+        None
+        
+        """
+        cdef char * filename_proxy
+        cdef char * src_tag_name_proxy
+        cdef char * cell_num_tag_name_proxy
+        cdef char * cell_fracs_tag_name_proxy
+        cdef cpp_vector[double] e_bounds_proxy
+        cdef int ie_bounds
+        cdef int e_bounds_size
+        cdef double * e_bounds_data
+        filename_bytes = filename.encode()
+        src_tag_name_bytes = src_tag_name.encode()
+        cell_num_tag_name_bytes = cell_num_tag_name.encode()
+        cell_fracs_tag_name_bytes = cell_fracs_tag_name.encode()
+        # e_bounds is a ('vector', 'float64', 0)
+        e_bounds_size = len(e_bounds)
+        if isinstance(e_bounds, np.ndarray) and (<np.ndarray> e_bounds).descr.type_num == np.NPY_FLOAT64:
+            e_bounds_data = <double *> np.PyArray_DATA(<np.ndarray> e_bounds)
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = e_bounds_data[ie_bounds]
+        else:
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
+        self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), std_string(<char *> cell_num_tag_name_bytes), std_string(<char *> cell_fracs_tag_name_bytes), e_bounds_proxy, <bint> uniform)
     
+
     _sampler_sampler_0_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, str), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("bias_tag_name", str)))
     _sampler_sampler_1_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, bool), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("uniform", bool)))
+    _sampler_sampler_2_argtypes = frozenset(((0, str), (1, str), (2, str), (3, str), (4, np.ndarray), (5, bool), ("filename", str), ("src_tag_name", str), ("cell_num_tag_name", str), ("cell_fracs_tag_name", str), ("e_bounds", np.ndarray), ("uniform", bool)))
     
     def __init__(self, *args, **kwargs):
         """Sampler(self, filename, src_tag_name, e_bounds, uniform)
@@ -427,6 +502,9 @@ cdef class Sampler:
         if types <= self._sampler_sampler_1_argtypes:
             self._sampler_sampler_1(*args, **kwargs)
             return
+        if types <= self._sampler_sampler_2_argtypes:
+            self._sampler_sampler_2(*args, **kwargs)
+            return
         # duck-typed dispatch based on whatever works!
         try:
             self._sampler_sampler_0(*args, **kwargs)
@@ -435,6 +513,11 @@ cdef class Sampler:
             pass
         try:
             self._sampler_sampler_1(*args, **kwargs)
+            return
+        except (RuntimeError, TypeError, NameError):
+            pass
+        try:
+            self._sampler_sampler_2(*args, **kwargs)
             return
         except (RuntimeError, TypeError, NameError):
             pass

--- a/share/source.F90
+++ b/share/source.F90
@@ -72,7 +72,7 @@ subroutine source
    rands(4) = rang() ! sample y
    rands(5) = rang() ! sample z
  
-   call particle_birth(rands, xxx, yyy, zzz, erg, wgt)
+   call particle_birth(rands, xxx, yyy, zzz, erg, wgt, cell_num)
    icl_tmp = find_cell()
    if (mat(icl_tmp).eq.0 .and. tries < idum(2)) then
        tries = tries + 1

--- a/share/source.F90
+++ b/share/source.F90
@@ -55,6 +55,7 @@ subroutine source
     integer :: icl_tmp ! temporary cell variable
     integer :: find_cell
     integer :: tries
+    integer :: cell_num
   
     if (first_run .eqv. .true.) then
         call sampling_setup(idum(1))

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -219,7 +219,6 @@ void pyne::Sampler::mesh_tag_data(moab::Range ves,
       rval = mesh->tag_get_data(cell_fracs_tag, ves, &cell_fracs[0]);
       cell_number.resize(num_ves*max_num_cells);
       rval = mesh->tag_get_data(cell_number_tag, ves, &cell_number[0]);
-      }
   }
 
   std::vector<double> pdf(num_ves*num_e_groups*max_num_cells);

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -98,7 +98,7 @@ std::vector<double> pyne::Sampler::particle_birth(std::vector<double> rands) {
   // the max_num_cells=1; While, in SUBVOXEL mode, pdf_idx contains
   // num_ves*max_num_cells*num_e_groups elements
   int pdf_idx = at->sample_pdf(rands[0], rands[1]);
-  int ve_idx = pdf_idx/num_e_groups/max_num_cells;
+  int ve_idx = pdf_idx/max_num_cells/num_e_groups;
   int c_idx = (pdf_idx/num_e_groups)%max_num_cells;
   int e_idx = pdf_idx % num_e_groups;
 

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -92,6 +92,7 @@ namespace pyne {
 
   /// Problem modes
   enum Mode {USER, ANALOG, UNIFORM, SUBVOXEL_ANALOG, SUBVOXEL_UNIFORM, SUBVOXEL_USER};
+  enum SubMode {DEFAULT, SUBVOXEL};
 
   /// Mesh based Monte Carlo source sampling.
   class Sampler {
@@ -162,6 +163,7 @@ namespace pyne {
     int num_bias_groups; ///< Number of groups tag \a _bias_tag_name
     int max_num_cells; ///< Max numbers of cells in voxels
     Mode mode; ///< Problem mode: analog, uniform, user
+    SubMode submode; ///< Sub-voxel mode: use sub-voxel r2s when SUBVOXEL
     // mesh
     moab::Interface* mesh; ///< MOAB mesh
     int num_ves; ///< Number of mesh volume elements on \a mesh.

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -160,6 +160,7 @@ namespace pyne {
     std::vector<double> e_bounds;  ///< Energy boundaries
     int num_e_groups; ///< Number of groups in tag \a _src_tag_name
     int num_bias_groups; ///< Number of groups tag \a _bias_tag_name
+    int max_num_cells; ///< Max numbers of cells in voxels
     Mode mode; ///< Problem mode: analog, uniform, user
     // mesh
     moab::Interface* mesh; ///< MOAB mesh
@@ -169,6 +170,7 @@ namespace pyne {
     // sampling
     std::vector<edge_points> all_edge_points; ///< Four connected points on a VE.
     std::vector<double> biased_weights; ///< Birth weights for biased sampling.
+    std::vector<int> cell_number; ///< Tag cell_number
     AliasTable* at; ///< Alias table used for sampling.
 
   // member functions

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -2,25 +2,25 @@
 /// \author Elliott Biondo (biondo\@wisc.edu)
 ///
 /// \brief Mesh-based Monte Carlo source sampling.
-/// 
+///
 /// The Sampler class is used for Monte Carlo source sampling from mesh-based
 /// sources.  The source density distribution and optional biased source density
-/// distribution are defined on a MOAB mesh. Upon instantiation, a Sampler  
+/// distribution are defined on a MOAB mesh. Upon instantiation, a Sampler
 /// object reads this mesh and creates an alias table for randomly sampling
-/// particle birth parameters. The particle_birth member function is supplied 
-/// with 6 pseudo-random numbers and returns the position, energy, and weight 
-/// of a particle upon birth. 
+/// particle birth parameters. The particle_birth member function is supplied
+/// with 6 pseudo-random numbers and returns the position, energy, and weight
+/// of a particle upon birth.
 /// There are three sampling modes: analog, uniform, and user-speficied
 /// In analog sampling, no source biasing is used and birth weights
-/// are all 1. In uniform sampling, the position of the particle (but not the 
-/// energy) is sampled uniformly and weights are adjusted accordingly. In 
-/// user-speficied mode, a supplied biased source density distribution is used 
-/// for sampling and particle weights are adjusted accordingly. The biased 
-/// source density distribution must have the same number of energy groups as 
+/// are all 1. In uniform sampling, the position of the particle (but not the
+/// energy) is sampled uniformly and weights are adjusted accordingly. In
+/// user-speficied mode, a supplied biased source density distribution is used
+/// for sampling and particle weights are adjusted accordingly. The biased
+/// source density distribution must have the same number of energy groups as
 /// the unbiased distribution. Alternatively, it may have exactly 1 energy
 /// group, in which case only spatial biasing is done, and energies are sampled
 /// in analog.
- 
+
 #ifndef PYNE_6OR6BJURKJHHTOFWXO2VMQM5EY
 #define PYNE_6OR6BJURKJHHTOFWXO2VMQM5EY
 
@@ -30,7 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
-#include <stdexcept> 
+#include <stdexcept>
 #include <sstream>
 #include <string>
 
@@ -72,7 +72,7 @@ namespace pyne {
     moab::CartVect y_vec;
     moab::CartVect z_vec;
   };
-  
+
   /// A data structure for O(1) source sampling
   class AliasTable {
   public:
@@ -88,24 +88,24 @@ namespace pyne {
     std::vector<double> prob; /// Probabilities.
     std::vector<int> alias; /// Alias probabilities.
   };
-  
+
   /// Problem modes
-  enum Mode {USER, ANALOG, UNIFORM};
-  
+  enum Mode {USER, ANALOG, UNIFORM, SUBVOXEL_ANALOG, SUBVOXEL_UNIFORM, SUBVOXEL_USER};
+
   /// Mesh based Monte Carlo source sampling.
   class Sampler {
   public:
     /// Constuctor for analog and uniform sampling
     /// \param filename The path to the MOAB mesh (.h5m) file
-    /// \param src_tag_name The name of the tag that describes the unbiased 
+    /// \param src_tag_name The name of the tag that describes the unbiased
     ///                     source density distribution.
     /// \param e_bounds The energy boundaries, note there are N + 1 energy
     ///                 bounds for N energy groups
     /// \param uniform If false, analog sampling is used. If true, uniform
     ///                sampling is used.
-    Sampler(std::string filename, 
-            std::string src_tag_name, 
-            std::vector<double> e_bounds, 
+    Sampler(std::string filename,
+            std::string src_tag_name,
+            std::vector<double> e_bounds,
             bool uniform);
     /// Constuctor for analog and uniform sampling
     /// \param filename The path to the MOAB mesh (.h5m) file
@@ -118,11 +118,27 @@ namespace pyne {
     ///                       number of energy groups as <src_tag_name> or 1.
     ///                       If 1 (i.e. spatial biasing only), all energy groups
     ///                       within a mesh volume element are sampled equally.
-    Sampler(std::string filename, 
-            std::string src_tag_name, 
-            std::vector<double> e_bounds, 
+    Sampler(std::string filename,
+            std::string src_tag_name,
+            std::vector<double> e_bounds,
             std::string bias_tag_name);
-    /// Samples particle birth parameters
+    //// Constuctor for sub-voxel analog and uniform sampling
+    /// \param filename The path to the MOAB mesh (.h5m) file
+    /// \param src_tag_name The name of the tag that describes the unbiased
+    ///                     source density distribution.
+    /// \param cell_num_tag_name The name of the tag that describes the cell number
+    /// \param cell_fracs_tag_name The name of the tag that describes the cell volume fractions
+    /// \param e_bounds The energy boundaries, note there are N + 1 energy
+    ///                 bounds for N energy groups
+    /// \param uniform If false, analog sampling is used. If true, uniform
+    ///                sampling is used.
+    Sampler(std::string filename,
+            std::string src_tag_name,
+            std::string cell_num_tag_name,
+            std::string cell_fracs_tag_name,
+            std::vector<double> e_bounds,
+            bool uniform);
+// Samples particle birth parameters
     /// \param rands Six pseudo-random numbers in range [0, 1].
     /// \return A vector containing the x position, y, position, z, point, energy
     ///         and weight of a particle (in that order).
@@ -131,12 +147,14 @@ namespace pyne {
       delete mesh;
       delete at;
     };
-  
+
   // member variables
   private:
     // problem parameters
     std::string filename; ///< MOAB mesh file path
     std::string src_tag_name; ///< Unbiased source density distribution
+    std::string cell_num_tag_name; ///< Cell numbers tag
+    std::string cell_fracs_tag_name; ///< Cell fractions tag
     std::string bias_tag_name; ///< Biased source density distribution
     std::vector<double> e_bounds;  ///< Energy boundaries
     int num_e_groups; ///< Number of groups in tag \a _src_tag_name
@@ -151,7 +169,7 @@ namespace pyne {
     std::vector<edge_points> all_edge_points; ///< Four connected points on a VE.
     std::vector<double> biased_weights; ///< Birth weights for biased sampling.
     AliasTable* at; ///< Alias table used for sampling.
-  
+
   // member functions
   private:
     // instantiation
@@ -165,7 +183,7 @@ namespace pyne {
     // helper functions
     void normalize_pdf(std::vector<double> & pdf);
     int num_groups(moab::Tag tag);
-    std::vector<double> read_bias_pdf(moab::Range ves, std::vector<double> volumes, 
+    std::vector<double> read_bias_pdf(moab::Range ves, std::vector<double> volumes,
                                       std::vector<double> pdf);
   };
 } //end namespace pyne

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -60,7 +60,8 @@ namespace pyne {
                             double* y,
                             double* z,
                             double* e,
-                            double* w);
+                            double* w,
+                            double* c);
   /// Helper function for MCNP interface that reads energy boudaries from a file
   /// \param e_bounds_file A file containing the energy group boundaries.
   std::vector<double> read_e_bounds(std::string e_bounds_file);

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -875,6 +875,8 @@ def test_tag_cell_fracs_subvoxel_equal_voxel():
                            exp_cell_largest_frac[i])
 
 >>>>>>> clean up source_sampling.cpp
+=======
+>>>>>>> move the test function from this branch to branch tag_cell_fracs_update_numpyshape
 def test_no_mats():
     mesh = gen_mesh(mats=None)
     assert_true(mesh.mats is None)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -874,9 +874,6 @@ def test_tag_cell_fracs_subvoxel_equal_voxel():
         assert_equal(m.cell_largest_frac[i],
                            exp_cell_largest_frac[i])
 
->>>>>>> clean up source_sampling.cpp
-=======
->>>>>>> move the test function from this branch to branch tag_cell_fracs_update_numpyshape
 def test_no_mats():
     mesh = gen_mesh(mats=None)
     assert_true(mesh.mats is None)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -843,37 +843,6 @@ def test_tag_cell_fracs_subvoxel_equal_voxel():
         assert_equal(m.cell_largest_frac[i],
                            exp_cell_largest_frac[i])
 
-def test_tag_cell_fracs_subvoxel_equal_voxel():
-    m = Mesh(structured=True,
-             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
-             mats = None)
-    m.src = IMeshTag(2, float)
-    m.src[:] = np.ones(shape=(8,2))
-    cell_fracs = np.zeros(8, dtype=[('idx', np.int64),
-                                    ('cell', np.int64),
-                                    ('vol_frac', np.float64),
-                                    ('rel_error', np.float64)])
-
-    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
-                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
-                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
-
-    m.tag_cell_fracs(cell_fracs)
-
-    #  Expected tags:
-    exp_cell_number = [[1], [2], [3], [4], [5], [6], [7], [8]]
-    exp_cell_fracs = [[1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0]]
-    exp_cell_largest_frac_number = [1, 2, 3, 4, 5, 6, 7, 8]
-    exp_cell_largest_frac = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-
-    for i in range(len(m)):
-        assert_array_equal(m.cell_number[i], exp_cell_number[i])
-        assert_array_equal(m.cell_fracs[i], exp_cell_fracs[i])
-        assert_equal(m.cell_largest_frac_number[i],
-                           exp_cell_largest_frac_number[i])
-        assert_equal(m.cell_largest_frac[i],
-                           exp_cell_largest_frac[i])
-
 def test_no_mats():
     mesh = gen_mesh(mats=None)
     assert_true(mesh.mats is None)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -843,6 +843,37 @@ def test_tag_cell_fracs_subvoxel_equal_voxel():
         assert_equal(m.cell_largest_frac[i],
                            exp_cell_largest_frac[i])
 
+def test_tag_cell_fracs_subvoxel_equal_voxel():
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
+             mats = None)
+    m.src = IMeshTag(2, float)
+    m.src[:] = np.ones(shape=(8,2))
+    cell_fracs = np.zeros(8, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+
+    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
+                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
+                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
+
+    m.tag_cell_fracs(cell_fracs)
+
+    #  Expected tags:
+    exp_cell_number = [[1], [2], [3], [4], [5], [6], [7], [8]]
+    exp_cell_fracs = [[1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0]]
+    exp_cell_largest_frac_number = [1, 2, 3, 4, 5, 6, 7, 8]
+    exp_cell_largest_frac = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+    for i in range(len(m)):
+        assert_array_equal(m.cell_number[i], exp_cell_number[i])
+        assert_array_equal(m.cell_fracs[i], exp_cell_fracs[i])
+        assert_equal(m.cell_largest_frac_number[i],
+                           exp_cell_largest_frac_number[i])
+        assert_equal(m.cell_largest_frac[i],
+                           exp_cell_largest_frac[i])
+
 def test_no_mats():
     mesh = gen_mesh(mats=None)
     assert_true(mesh.mats is None)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -843,6 +843,38 @@ def test_tag_cell_fracs_subvoxel_equal_voxel():
         assert_equal(m.cell_largest_frac[i],
                            exp_cell_largest_frac[i])
 
+def test_tag_cell_fracs_subvoxel_equal_voxel():
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
+             mats = None)
+    m.src = IMeshTag(2, float)
+    m.src[:] = np.ones(shape=(8,2))
+    cell_fracs = np.zeros(8, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+
+    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
+                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
+                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
+
+    m.tag_cell_fracs(cell_fracs)
+
+    #  Expected tags:
+    exp_cell_number = [[1], [2], [3], [4], [5], [6], [7], [8]]
+    exp_cell_fracs = [[1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0]]
+    exp_cell_largest_frac_number = [1, 2, 3, 4, 5, 6, 7, 8]
+    exp_cell_largest_frac = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+    for i in range(len(m)):
+        assert_array_equal(m.cell_number[i], exp_cell_number[i])
+        assert_array_equal(m.cell_fracs[i], exp_cell_fracs[i])
+        assert_equal(m.cell_largest_frac_number[i],
+                           exp_cell_largest_frac_number[i])
+        assert_equal(m.cell_largest_frac[i],
+                           exp_cell_largest_frac[i])
+
+>>>>>>> clean up source_sampling.cpp
 def test_no_mats():
     mesh = gen_mesh(mats=None)
     assert_true(mesh.mats is None)

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -162,6 +162,8 @@ def test_analog_multiple_hex_subvoxel():
         assert_equal(s[4], 1.0)
         assert_equal(int(s[5], 4*int[s[0]]+2*int[s[1]]+int[s[3]]))
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
+=======
+>>>>>>> add test_analog_single_hex_subvoxel in tests/test_source_sampling.py
               int(s[3]*num_divs)] += score
 
     for i in range(0, 4):

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -162,8 +162,6 @@ def test_analog_multiple_hex_subvoxel():
         assert_equal(s[4], 1.0)
         assert_equal(int(s[5], 4*int[s[0]]+2*int[s[1]]+int[s[3]]))
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
-=======
->>>>>>> add test_analog_single_hex_subvoxel in tests/test_source_sampling.py
               int(s[3]*num_divs)] += score
 
     for i in range(0, 4):

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -191,9 +191,9 @@ def test_analog_multiple_hex_subvoxel():
                                     ('vol_frac', np.float64),
                                     ('rel_error', np.float64)])
 
-    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
-                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
-                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
+    cell_fracs[:] = [(0, 0, 1.0, 0.0), (1, 1, 1.0, 0.0), (2, 2, 1.0, 0.0),
+                     (3, 3, 1.0, 0.0), (4, 4, 1.0, 0.0), (5, 5, 1.0, 0.0),
+                     (6, 6, 1.0, 0.0), (7, 7, 1.0, 0.0)]
 
     m.tag_cell_fracs(cell_fracs)
     m.mesh.save("sampling_mesh.h5m")
@@ -207,7 +207,8 @@ def test_analog_multiple_hex_subvoxel():
     for i in range(num_samples):
         s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
         assert_equal(s[4], 1.0)
-        assert_equal(int(s[5], 4*int[s[0]]+2*int[s[1]]+int[s[3]]))
+        assert_equal(int(s[5]), 4*int(s[0]*num_divs) + 2*int(s[1]*num_divs)
+                     + int(s[2]*num_divs))
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
               int(s[3]*num_divs)] += score
 
@@ -215,7 +216,6 @@ def test_analog_multiple_hex_subvoxel():
         for j in range(0, 2):
             halfspace_sum = np.sum(np.rollaxis(tally, i)[j,:,:,:])
             assert(abs(halfspace_sum - 0.5)/0.5 < 0.1)
-
 
 @with_setup(None, try_rm_file('tet.h5m'))
 def test_analog_single_tet():

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -76,7 +76,7 @@ def test_analog_single_hex_subvoxel():
     cell_fracs[:] = [(0, 11, 1.0, 0.0)]
     m.tag_cell_fracs(cell_fracs)
     m.mesh.save("sampling_mesh.h5m")
-    sampler = Sampler("sampling_mesh.h5m", "src", np.array([0, 1]), False)
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs", np.array([0, 1]), False)
 
     num_samples = 5000
     score = 1.0/num_samples

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -28,7 +28,7 @@ def test_analog_single_hex():
     """This test tests that particles of sampled evenly within the phase-space
     of a single mesh volume element with one energy group in an analog sampling
     scheme. This done by dividing each dimension (x, y, z, E) in half, then
-    sampling particles and tallying on the basis of which of the 2^4 = 8 regions
+    sampling particles and tallying on the basis of which of the 2^4 = 16 regions
     of phase space the particle is born into.
     """
     seed(1953)
@@ -59,10 +59,10 @@ def test_analog_single_hex():
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_analog_single_hex_subvoxel():
     """This test tests that particles of sampled evenly within the phase-space
-    of a single mesh volume element with one energy group in an analog sampling
-    scheme. This done by dividing each dimension (x, y, z, E) in half, then
-    sampling particles and tallying on the basis of which of the 2^4 = 8 regions
-    of phase space the particle is born into.
+    of a single mesh volume element (also a sub-voxel) with one energy group
+    in an analog sampling scheme. This done by dividing each dimension
+    (x, y, z, E) in half, then sampling particles and tallying on the basis of
+    which of the 2^4 = 16 regions of phase space the particle is born into.
     """
     seed(1953)
     m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]],
@@ -99,11 +99,11 @@ def test_analog_single_hex_subvoxel():
 
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_analog_single_hex_multiple_subvoxel():
-    """This test tests that particles of sampled evenly within the phase-space
-    of a single mesh volume element with one energy group in an analog sampling
-    scheme. This done by dividing each dimension (x, y, z, E) in half, then
-    sampling particles and tallying on the basis of which of the 2^4 = 8 regions
-    of phase space the particle is born into.
+    """This test tests that particles of sampled analog within the phase-space
+    of a single mesh volume element but multiple sub-voxels with one energy
+    group in an analog sampling scheme. Then sampling particles and tallying
+    the particles and check the probability of particles born in each
+    sub-voxel and the cell_number.
     """
     seed(1953)
     m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]],
@@ -139,7 +139,6 @@ def test_analog_single_hex_multiple_subvoxel():
             tally[2] += score
 
     # Test that each source particle in each cell has right frequency
-    print tally
     assert_equal(tally[0], 0.0)
     assert(abs(tally[1] - 0.2) < 0.05)
     assert(abs(tally[2] - 0.8) < 0.05)
@@ -176,9 +175,9 @@ def test_analog_multiple_hex():
 
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_analog_multiple_hex_subvoxel():
-    """This test tests that particle are sampled uniformly from a uniform source
+    """This test tests that particle are sampled analog from a uniform source
     defined on eight mesh volume elements in two energy groups. This is done
-    using the exact same method ass test_analog_multiple_hex_subvoxel.
+    using the exact same method as test_analog_multiple_hex_subvoxel.
     """
     seed(1953)
     m = Mesh(structured=True,
@@ -191,9 +190,9 @@ def test_analog_multiple_hex_subvoxel():
                                     ('vol_frac', np.float64),
                                     ('rel_error', np.float64)])
 
-    cell_fracs[:] = [(0, 0, 1.0, 0.0), (1, 1, 1.0, 0.0), (2, 2, 1.0, 0.0),
-                     (3, 3, 1.0, 0.0), (4, 4, 1.0, 0.0), (5, 5, 1.0, 0.0),
-                     (6, 6, 1.0, 0.0), (7, 7, 1.0, 0.0)]
+    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
+                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
+                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
 
     m.tag_cell_fracs(cell_fracs)
     m.mesh.save("sampling_mesh.h5m")
@@ -208,7 +207,7 @@ def test_analog_multiple_hex_subvoxel():
         s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
         assert_equal(s[4], 1.0)
         assert_equal(int(s[5]), 4*int(s[0]*num_divs) + 2*int(s[1]*num_divs)
-                     + int(s[2]*num_divs))
+                     + int(s[2]*num_divs) + 1)
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
               int(s[3]*num_divs)] += score
 


### PR DESCRIPTION
This PR added some code to implement the sub-voxel r2s - analog mode. 
Major  changes:
1. Functions and variables definition in `source_sampling.h`, `source_sampling.cpp`, `source_sampling.pyx` and `cpp_source_sampling.pxd`. 
2. Add a return value:`cell_number` for `particle_birth` function. 
3. Add three test function for sub-voxel r2s - analog mode