### PR TITLE
Subvoxel source subroutine sampling

### DIFF
--- a/news/subvoxel_source_subroutine_sampling.rst
+++ b/news/subvoxel_source_subroutine_sampling.rst
@@ -1,0 +1,17 @@
+**Added:** 
+* Functions and variables for sub-voxel r2s. Include analog, uniform and user define modes.
+* Tests functions for sub-voxel r2s source subroutine sampling
+* Add Sub_Mode as an indenfitier to simplify the code, rename Mode to Bias_Mode
+* Add class SourceParticle in source_sampling to store the sampling result
+* Add function to get source particle information
+
+**Changed:** 
+* Sampler difinition and particle_birth funciton to support sub-voxel mode
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -31,6 +31,18 @@ cdef extern from "source_sampling.h" namespace "pyne":
         pass
 
 
+cdef extern from "source_sampling.h" namespace "pyne":
+
+    cdef cppclass SourceParticle:
+        # constructors
+        SourceParticle() except +
+        SourceParticle(double, double, double, double, double, int) except +
+
+        # attributes
+
+        # methods
+        pass
+    
 
 cdef extern from "source_sampling.h" namespace "pyne":
 
@@ -42,15 +54,22 @@ cdef extern from "source_sampling.h" namespace "pyne":
         Sampler(std_string, std_string, cpp_vector[double]) except +
         Sampler(std_string, std_string, cpp_vector[double], std_string) except +
         Sampler(std_string, std_string, cpp_vector[double], cpp_bool) except +
+        Sampler(std_string, std_string, std_string, std_string, cpp_vector[double], cpp_bool) except +
+        Sampler(std_string, std_string, std_string, std_string, cpp_vector[double], std_string) except +
 
         # attributes
 
-
         # methods
-        cpp_vector[double] particle_birth() except +
-        cpp_vector[double] particle_birth(cpp_vector[double]) except +
+        void particle_birth() except +
+        void particle_birth(cpp_vector[double]) except +
+        int get_src_c() except +
+        double get_src_x() except +
+        double get_src_y() except +
+        double get_src_z() except +
+        double get_src_e() except +
+        double get_src_w() except +
+        cpp_vector [double] get_src_xyzew() except +
         pass
-
 
 
 

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -39,8 +39,11 @@ cdef extern from "source_sampling.h" namespace "pyne":
         SourceParticle(double, double, double, double, double, int) except +
 
         # attributes
-
+        double x, y, z, e, w
+        int c
         # methods
+        cpp_vector[double] get_src_xyzew() except +
+        int get_src_c() except +
         pass
     
 
@@ -60,15 +63,9 @@ cdef extern from "source_sampling.h" namespace "pyne":
         # attributes
 
         # methods
-        void particle_birth() except +
-        void particle_birth(cpp_vector[double]) except +
-        int get_src_c() except +
-        double get_src_x() except +
-        double get_src_y() except +
-        double get_src_z() except +
-        double get_src_e() except +
-        double get_src_w() except +
-        cpp_vector [double] get_src_xyzew() except +
+        SourceParticle particle_birth() except +
+        SourceParticle particle_birth(cpp_vector[double]) except +
+        
         pass
 
 

--- a/pyne/source_sampling.pxd
+++ b/pyne/source_sampling.pxd
@@ -32,9 +32,9 @@ cdef class AliasTable:
     pass
 
 
-cdef class SourceParticle:
-    cdef void * _inst
-    cdef public _free_inst
+cdef class PySourceParticle:
+    cdef cpp_source_sampling.SourceParticle c_src
+    cdef public int c
     pass
 
 {'cpppxd_footer': '', 'pyx_header': '', 'pxd_header': '', 'pxd_footer': '', 'cpppxd_header': '', 'pyx_footer': ''}

--- a/pyne/source_sampling.pxd
+++ b/pyne/source_sampling.pxd
@@ -32,6 +32,9 @@ cdef class AliasTable:
     pass
 
 
-
+cdef class SourceParticle:
+    cdef void * _inst
+    cdef public _free_inst
+    pass
 
 {'cpppxd_footer': '', 'pyx_header': '', 'pxd_header': '', 'pxd_footer': '', 'cpppxd_header': '', 'pyx_footer': ''}

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -213,6 +213,7 @@ cdef class Sampler:
     biased_weights (std::vector< double >) : Birth weights for
         biased sampling.
     at (None) : Alias table used for sampling.
+    source_particle (None) : Source Particle used to store sampling result
     
     
     Methods
@@ -229,6 +230,13 @@ cdef class Sampler:
     sample_w
     sample_xyz
     setup
+    get_src_x
+    get_src_y
+    get_src_z
+    get_src_e
+    get_src_w
+    get_src_c
+    get_src_xyzew
     
     Notes
     -----
@@ -373,9 +381,160 @@ cdef class Sampler:
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
         self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, <bint> uniform)
     
+    def _sampler_sampler_2(self, filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, uniform):
+        """Sampler(self, filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, uniform)
+         This method was overloaded in the C-based source. To overcome
+        this we will put the relevant docstring for each version below.
+        Each version will begin with a line of # characters.
+        
+        Constuctor for analog and uniform sampling
+        
+        Parameters
+        ----------
+        e_bounds : std::vector< double >
+        
+        src_tag_name : std::string
+
+        cell_num_tag_name : std::string
+
+        cell_fracs_tag_name : std::string
+        
+        bias_tag_name : std::string
+        
+        filename : std::string
+        
+        Returns
+        -------
+        None
+        
+        ################################################################
+        
+        Constuctor for analog and uniform sampling
+        
+        Parameters
+        ----------
+        e_bounds : std::vector< double >
+        
+        src_tag_name : std::string
+
+        cell_num_tag_name : std::string
+
+        cell_fracs_tag_name : std::string
+        
+        uniform : bool
+        
+        filename : std::string
+        
+        Returns
+        -------
+        None
+        
+        """
+        cdef char * filename_proxy
+        cdef char * src_tag_name_proxy
+        cdef char * cell_num_tag_name_proxy
+        cdef char * cell_fracs_tag_name_proxy
+        cdef cpp_vector[double] e_bounds_proxy
+        cdef int ie_bounds
+        cdef int e_bounds_size
+        cdef double * e_bounds_data
+        filename_bytes = filename.encode()
+        src_tag_name_bytes = src_tag_name.encode()
+        cell_num_tag_name_bytes = cell_num_tag_name.encode()
+        cell_fracs_tag_name_bytes = cell_fracs_tag_name.encode()
+        # e_bounds is a ('vector', 'float64', 0)
+        e_bounds_size = len(e_bounds)
+        if isinstance(e_bounds, np.ndarray) and (<np.ndarray> e_bounds).descr.type_num == np.NPY_FLOAT64:
+            e_bounds_data = <double *> np.PyArray_DATA(<np.ndarray> e_bounds)
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = e_bounds_data[ie_bounds]
+        else:
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
+        self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), std_string(<char *> cell_num_tag_name_bytes), std_string(<char *> cell_fracs_tag_name_bytes), e_bounds_proxy, <bint> uniform)
     
+    def _sampler_sampler_3(self, filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, bias_tag_name):
+        """Sampler(self, filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, bias_tag_name)
+         This method was overloaded in the C-based source. To overcome
+        this we ill put the relevant docstring for each version below.
+        Each version will begin with a line of # characters.
+        
+        Constructor for analog and uniform sampling
+        
+        Parameters
+        ----------
+        e_bounds : std::vector< double >
+        
+        src_tag_name : std::string
+
+        cell_num_tag_name : std::string
+
+        cell_fracs_tag_name : std::string
+        
+        bias_tag_name : std::string
+        
+        filename : std::string
+        
+        Returns
+        -------
+        None
+        
+        ################################################################
+        
+        Constructor for analog and uniform sampling
+        
+        Parameters
+        ----------
+        e_bounds : std::vector< double >
+        
+        src_tag_name : std::string
+
+        cell_num_tag_name : std::string
+
+        cell_fracs_tag_name : std::string
+        
+        bias_tag_name : std::string
+        
+        filename : std::string
+        
+        Returns
+        -------
+        None
+        
+        """
+        cdef char * filename_proxy
+        cdef char * src_tag_name_proxy
+        cdef char * cell_num_tag_name_proxy
+        cdef char * cell_fracs_tag_name_proxy
+        cdef cpp_vector[double] e_bounds_proxy
+        cdef int ie_bounds
+        cdef int e_bounds_size
+        cdef double * e_bounds_data
+        cdef char * bias_tag_name_proxy
+        filename_bytes = filename.encode()
+        src_tag_name_bytes = src_tag_name.encode()
+        cell_num_tag_name_bytes = cell_num_tag_name.encode()
+        cell_fracs_tag_name_bytes = cell_fracs_tag_name.encode()
+        # e_bounds is a ('vector', 'float64', 0)
+        e_bounds_size = len(e_bounds)
+        if isinstance(e_bounds, np.ndarray) and (<np.ndarray> e_bounds).descr.type_num == np.NPY_FLOAT64:
+            e_bounds_data = <double *> np.PyArray_DATA(<np.ndarray> e_bounds)
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = e_bounds_data[ie_bounds]
+        else:
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
+        bias_tag_name_bytes = bias_tag_name.encode()
+        self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), std_string(<char *> cell_num_tag_name_bytes), std_string(<char *> cell_fracs_tag_name_bytes), e_bounds_proxy, std_string(<char *> bias_tag_name_bytes))
+ 
     _sampler_sampler_0_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, str), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("bias_tag_name", str)))
     _sampler_sampler_1_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, bool), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("uniform", bool)))
+    _sampler_sampler_2_argtypes = frozenset(((0, str), (1, str), (2, str), (3, str), (4, np.ndarray), (5, bool), ("filename", str), ("src_tag_name", str), ("cell_num_tag_name", str), ("cell_fracs_tag_name", str), ("e_bounds", np.ndarray), ("uniform", bool)))
+    _sampler_sampler_3_argtypes = frozenset(((0, str), (1, str), (2, str), (3, str), (4, np.ndarray), (5, str), ("filename", str), ("src_tag_name", str), ("cell_num_tag_name", str), ("cell_fracs_tag_name", str), ("e_bounds", np.ndarray), ("bias_tag_name", str)))
     
     def __init__(self, *args, **kwargs):
         """Sampler(self, filename, src_tag_name, e_bounds, uniform)
@@ -383,7 +542,7 @@ cdef class Sampler:
         this we ill put the relevant docstring for each version below.
         Each version will begin with a line of # characters.
         
-        Constuctor for analog and uniform sampling
+        Constructor for analog and uniform sampling
         
         Parameters
         ----------
@@ -401,7 +560,7 @@ cdef class Sampler:
         
         ################################################################
         
-        Constuctor for analog and uniform sampling
+        Constructor for analog and uniform sampling
         
         Parameters
         ----------
@@ -427,6 +586,12 @@ cdef class Sampler:
         if types <= self._sampler_sampler_1_argtypes:
             self._sampler_sampler_1(*args, **kwargs)
             return
+        if types <= self._sampler_sampler_2_argtypes:
+            self._sampler_sampler_2(*args, **kwargs)
+            return
+        if types <= self._sampler_sampler_3_argtypes:
+            self._sampler_sampler_3(*args, **kwargs)
+            return
         # duck-typed dispatch based on whatever works!
         try:
             self._sampler_sampler_0(*args, **kwargs)
@@ -435,6 +600,16 @@ cdef class Sampler:
             pass
         try:
             self._sampler_sampler_1(*args, **kwargs)
+            return
+        except (RuntimeError, TypeError, NameError):
+            pass
+        try:
+            self._sampler_sampler_2(*args, **kwargs)
+            return
+        except (RuntimeError, TypeError, NameError):
+            pass
+        try:
+            self._sampler_sampler_3(*args, **kwargs)
             return
         except (RuntimeError, TypeError, NameError):
             pass
@@ -464,7 +639,6 @@ cdef class Sampler:
         cdef int irands
         cdef int rands_size
         cdef double * rands_data
-        cdef cpp_vector[double] rtnval
         
         cdef np.npy_intp rtnval_proxy_shape[1]
         # rands is a ('vector', 'float64', 0)
@@ -478,14 +652,187 @@ cdef class Sampler:
             rands_proxy = cpp_vector[double](<size_t> rands_size)
             for irands in range(rands_size):
                 rands_proxy[irands] = <double> rands[irands]
-        rtnval = (<cpp_source_sampling.Sampler *> self._inst).particle_birth(rands_proxy)
+        (<cpp_source_sampling.Sampler *> self._inst).particle_birth(rands_proxy)
+    
+    def get_src_c(self):
+        """get_src_c(self)
+        Get the source particle cell number
+        
+        Parameters
+        ----------
+        None 
+
+        Returns
+        -------
+        cell_number : int
+        
+        """
+        cdef int cell_number
+        cell_number = (<cpp_source_sampling.Sampler *> self._inst).get_src_c()
+        return cell_number
+
+    def get_src_x(self):
+        """get_src_x(self)
+        Get the source particle x coordinate
+        
+        Parameters
+        ----------
+        None 
+
+        Returns
+        -------
+        x : double
+        
+        """
+        cdef double x
+        x = (<cpp_source_sampling.Sampler *> self._inst).get_src_x()
+        return x
+
+    def get_src_y(self):
+        """get_src_y(self)
+        Get the source particle y coordinate
+        
+        Parameters
+        ----------
+        None 
+
+        Returns
+        -------
+        y : double
+        
+        """
+        cdef double y
+        y = (<cpp_source_sampling.Sampler *> self._inst).get_src_y()
+        return y
+
+    def get_src_z(self):
+        """get_src_z(self)
+        Get the source particle z coordinate
+        
+        Parameters
+        ----------
+        None 
+
+        Returns
+        -------
+        z : double
+        
+        """
+        cdef double z
+        z = (<cpp_source_sampling.Sampler *> self._inst).get_src_z()
+        return z
+   
+    def get_src_e(self):
+        """get_src_e(self)
+        Get the source particle energy
+        
+        Parameters
+        ----------
+        None 
+
+        Returns
+        -------
+        e : double
+        
+        """
+        cdef double e
+        e = (<cpp_source_sampling.Sampler *> self._inst).get_src_e()
+        return e
+   
+    def get_src_w(self):
+        """get_src_w(self)
+        Get the source particle weight
+        
+        Parameters
+        ----------
+        None 
+
+        Returns
+        -------
+        w : double
+        
+        """
+        cdef double w
+        w = (<cpp_source_sampling.Sampler *> self._inst).get_src_w()
+        return w
+   
+    def get_src_xyzew(self):
+        """get_src_xyzew(self)
+        Get source particle x, y, z, e and w
+        
+        Parameters
+        ----------
+        None
+        
+        Returns
+        -------
+        res1 : std::vector< double >
+        
+        """
+        cdef cpp_vector[double] rtnval
+        cdef np.npy_intp rtnval_proxy_shape[1]
+        rtnval = (<cpp_source_sampling.Sampler *> self._inst).get_src_xyzew()
         rtnval_proxy_shape[0] = <np.npy_intp> rtnval.size()
         rtnval_proxy = np.PyArray_SimpleNewFromData(1, rtnval_proxy_shape, np.NPY_FLOAT64, &rtnval[0])
         rtnval_proxy = np.PyArray_Copy(rtnval_proxy)
         return rtnval_proxy
     
+
+cdef class SourceParticle:
+    """Constructor for class SourceParticle
     
+    Attributes
+    ----------
+    x (double) : The x coordinate of the source particle
+    y (double) : The y coordinate of the source particle
+    z (double) : The z coordinate of the source particle
+    e (double) : The energy of the source particle
+    w (double) : The weight of the source particle
+    c (int) : The cell number of the source particle
     
+    Methods
+    -------
+    SourceParticle
+    ~SourceParticle
+    
+    Notes
+    -----
+    This class was defined in source_sampling.h
+    
+    The class is found in the "pyne" namespace"""
+
+
+
+    # constuctors
+    def __cinit__(self, *args, **kwargs):
+        self._inst = NULL
+        self._free_inst = True
+
+    def __init__(self, x, y, z, e, w, c):
+        """SourceParticle(self, x, y, z, e, w, c)
+        Constructor
+        
+        Parameters
+        ----------
+        x : double
+        y : double
+        z : double
+        e : double
+        w : double
+        c : int
+        
+        Returns
+        -------
+        None
+        
+        """
+        self._inst = new cpp_source_sampling.SourceParticle(x, y, z, e, w, c)
+    
+    def __dealloc__(self):
+        if self._free_inst and self._inst is not NULL:
+            free(self._inst)
+
+
 
     pass
 

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -230,14 +230,7 @@ cdef class Sampler:
     sample_w
     sample_xyz
     setup
-    get_src_x
-    get_src_y
-    get_src_z
-    get_src_e
-    get_src_w
-    get_src_c
-    get_src_xyzew
-    
+        
     Notes
     -----
     This class was defined in source_sampling.h
@@ -652,110 +645,41 @@ cdef class Sampler:
             rands_proxy = cpp_vector[double](<size_t> rands_size)
             for irands in range(rands_size):
                 rands_proxy[irands] = <double> rands[irands]
-        (<cpp_source_sampling.Sampler *> self._inst).particle_birth(rands_proxy)
+        cdef cpp_source_sampling.SourceParticle c_src = (<cpp_source_sampling.Sampler *> self._inst).particle_birth(rands_proxy)
+        return PySourceParticle(c_src.x, c_src.y, c_src.z, c_src.e, c_src.w, c_src.c)
     
-    def get_src_c(self):
-        """get_src_c(self)
-        Get the source particle cell number
-        
-        Parameters
-        ----------
-        None 
 
-        Returns
-        -------
-        cell_number : int
-        
-        """
-        cdef int cell_number
-        cell_number = (<cpp_source_sampling.Sampler *> self._inst).get_src_c()
-        return cell_number
+cdef class PySourceParticle:
+    """Constructor for class PySourceParticle
+    
+    Attributes
+    ----------
+    x (double) : The x coordinate of the source particle
+    y (double) : The y coordinate of the source particle
+    z (double) : The z coordinate of the source particle
+    e (double) : The energy of the source particle
+    w (double) : The weight of the source particle
+    c (int) : The cell number of the source particle
+    
+    Methods
+    -------
+    SourceParticle
+    ~SourceParticle
+    get_src_xyzew
+    get_src_c
+    
+    Notes
+    -----
+    This class was defined in source_sampling.h
+    
+    The class is found in the "pyne" namespace"""
 
-    def get_src_x(self):
-        """get_src_x(self)
-        Get the source particle x coordinate
-        
-        Parameters
-        ----------
-        None 
 
-        Returns
-        -------
-        x : double
-        
-        """
-        cdef double x
-        x = (<cpp_source_sampling.Sampler *> self._inst).get_src_x()
-        return x
 
-    def get_src_y(self):
-        """get_src_y(self)
-        Get the source particle y coordinate
-        
-        Parameters
-        ----------
-        None 
-
-        Returns
-        -------
-        y : double
-        
-        """
-        cdef double y
-        y = (<cpp_source_sampling.Sampler *> self._inst).get_src_y()
-        return y
-
-    def get_src_z(self):
-        """get_src_z(self)
-        Get the source particle z coordinate
-        
-        Parameters
-        ----------
-        None 
-
-        Returns
-        -------
-        z : double
-        
-        """
-        cdef double z
-        z = (<cpp_source_sampling.Sampler *> self._inst).get_src_z()
-        return z
-   
-    def get_src_e(self):
-        """get_src_e(self)
-        Get the source particle energy
-        
-        Parameters
-        ----------
-        None 
-
-        Returns
-        -------
-        e : double
-        
-        """
-        cdef double e
-        e = (<cpp_source_sampling.Sampler *> self._inst).get_src_e()
-        return e
-   
-    def get_src_w(self):
-        """get_src_w(self)
-        Get the source particle weight
-        
-        Parameters
-        ----------
-        None 
-
-        Returns
-        -------
-        w : double
-        
-        """
-        cdef double w
-        w = (<cpp_source_sampling.Sampler *> self._inst).get_src_w()
-        return w
-   
+    # constuctors
+    def __cinit__(self, double x, double y, double z, double e, double w, int c):
+        self.c_src = cpp_source_sampling.SourceParticle(x, y, z, e, w, c)
+    
     def get_src_xyzew(self):
         """get_src_xyzew(self)
         Get source particle x, y, z, e and w
@@ -771,68 +695,27 @@ cdef class Sampler:
         """
         cdef cpp_vector[double] rtnval
         cdef np.npy_intp rtnval_proxy_shape[1]
-        rtnval = (<cpp_source_sampling.Sampler *> self._inst).get_src_xyzew()
+        rtnval = self.c_src.get_src_xyzew()
         rtnval_proxy_shape[0] = <np.npy_intp> rtnval.size()
         rtnval_proxy = np.PyArray_SimpleNewFromData(1, rtnval_proxy_shape, np.NPY_FLOAT64, &rtnval[0])
         rtnval_proxy = np.PyArray_Copy(rtnval_proxy)
         return rtnval_proxy
-    
 
-cdef class SourceParticle:
-    """Constructor for class SourceParticle
-    
-    Attributes
-    ----------
-    x (double) : The x coordinate of the source particle
-    y (double) : The y coordinate of the source particle
-    z (double) : The z coordinate of the source particle
-    e (double) : The energy of the source particle
-    w (double) : The weight of the source particle
-    c (int) : The cell number of the source particle
-    
-    Methods
-    -------
-    SourceParticle
-    ~SourceParticle
-    
-    Notes
-    -----
-    This class was defined in source_sampling.h
-    
-    The class is found in the "pyne" namespace"""
-
-
-
-    # constuctors
-    def __cinit__(self, *args, **kwargs):
-        self._inst = NULL
-        self._free_inst = True
-
-    def __init__(self, x, y, z, e, w, c):
-        """SourceParticle(self, x, y, z, e, w, c)
-        Constructor
+    def get_src_c(self):
+        """get_src_c(self)
+        Get source particle c
         
         Parameters
         ----------
-        x : double
-        y : double
-        z : double
-        e : double
-        w : double
-        c : int
+        None
         
         Returns
         -------
-        None
+        res1 : int
         
         """
-        self._inst = new cpp_source_sampling.SourceParticle(x, y, z, e, w, c)
-    
-    def __dealloc__(self):
-        if self._free_inst and self._inst is not NULL:
-            free(self._inst)
-
-
+        cdef int c = self.c_src.get_src_c()
+        return c
 
     pass
 

--- a/share/source.F90
+++ b/share/source.F90
@@ -55,6 +55,7 @@ subroutine source
     integer :: icl_tmp ! temporary cell variable
     integer :: find_cell
     integer :: tries
+    integer :: cell_num
   
     if (first_run .eqv. .true.) then
         call sampling_setup(idum(1))
@@ -71,7 +72,7 @@ subroutine source
    rands(4) = rang() ! sample y
    rands(5) = rang() ! sample z
  
-   call particle_birth(rands, xxx, yyy, zzz, erg, wgt)
+   call particle_birth(rands, xxx, yyy, zzz, erg, wgt, cell_num)
    icl_tmp = find_cell()
    if (mat(icl_tmp).eq.0 .and. tries < idum(2)) then
        tries = tries + 1

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -10,6 +10,8 @@ void pyne::sampling_setup_(int* mode) {
   if (sampler == NULL) {
     std::string filename ("source.h5m");
     std::string src_tag_name ("source_density");
+    std::string cell_num_tag_name ("cell_num");
+    std::string cell_fracs_tag_name ("cell_fracs");
     std::string e_bounds_file ("e_bounds");
     std::vector<double> e_bounds = read_e_bounds(e_bounds_file);
     if (*mode == 0) {
@@ -19,6 +21,13 @@ void pyne::sampling_setup_(int* mode) {
     } else if (*mode == 2) {
       std::string bias_tag_name ("biased_source_density");
       sampler = new pyne::Sampler(filename, src_tag_name, e_bounds, bias_tag_name);
+    } else if (*mode == 3) {
+      sampler = new pyne::Sampler(filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, false);
+    } else if (*mode == 4) {
+      sampler = new pyne::Sampler(filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, true);
+    } else if (*mode == 5) {
+      std::string bias_tag_name ("biased_source_density");
+      sampler = new pyne::Sampler(filename, src_tag_name, cell_num_tag_name, cell_fracs_tag_name, e_bounds, bias_tag_name);
     }
   }
 }
@@ -28,14 +37,16 @@ void pyne::particle_birth_(double* rands,
                            double* y,
                            double* z,
                            double* e,
-                           double* w) {
+                           double* w,
+                           int* c) {
     std::vector<double> rands2(rands, rands + 6);
-    std::vector<double> samp = sampler->particle_birth(rands2);
-    *x = samp[0];
-    *y = samp[1];
-    *z = samp[2];
-    *e = samp[3];
-    *w = samp[4];
+    sampler->particle_birth(rands2);
+    *x = sampler->get_src_x();
+    *y = sampler->get_src_y();
+    *z = sampler->get_src_z();
+    *e = sampler->get_src_e();
+    *w = sampler->get_src_w();
+    *c = sampler->get_src_c();
 }
 
 std::vector<double> pyne::read_e_bounds(std::string e_bounds_file){
@@ -51,32 +62,66 @@ std::vector<double> pyne::read_e_bounds(std::string e_bounds_file){
 
 
 // C++ API
-pyne::Sampler::Sampler(std::string filename, 
-                 std::string src_tag_name, 
-                 std::vector<double> e_bounds, 
+pyne::Sampler::Sampler(std::string filename,
+                 std::string src_tag_name,
+                 std::vector<double> e_bounds,
                  bool uniform)
   : filename(filename), src_tag_name(src_tag_name), e_bounds(e_bounds) {
-  mode = (uniform) ? UNIFORM : ANALOG;
+  sub_mode = DEFAULT;
+  bias_mode = (uniform) ? UNIFORM : ANALOG;
   setup();
 }
 
-pyne::Sampler::Sampler(std::string filename,  
-                 std::string src_tag_name, 
-                 std::vector<double> e_bounds, 
+pyne::Sampler::Sampler(std::string filename,
+                 std::string src_tag_name,
+                 std::string cell_num_tag_name,
+                 std::string cell_fracs_tag_name,
+                 std::vector<double> e_bounds,
+                 bool uniform)
+  : filename(filename), src_tag_name(src_tag_name), cell_num_tag_name(cell_num_tag_name), cell_fracs_tag_name(cell_fracs_tag_name), e_bounds(e_bounds) {
+  sub_mode = SUBVOXEL;
+  bias_mode = (uniform) ? UNIFORM : ANALOG;
+  setup();
+}
+
+pyne::Sampler::Sampler(std::string filename,
+                 std::string src_tag_name,
+                 std::vector<double> e_bounds,
                  std::string bias_tag_name)
-  : filename(filename), 
-    src_tag_name(src_tag_name), 
-    e_bounds(e_bounds), 
+  : filename(filename),
+    src_tag_name(src_tag_name),
+    e_bounds(e_bounds),
     bias_tag_name(bias_tag_name) {
-  mode = USER;
+  sub_mode = DEFAULT;
+  bias_mode = USER;
   setup();
 }
 
-std::vector<double> pyne::Sampler::particle_birth(std::vector<double> rands) {
+pyne::Sampler::Sampler(std::string filename,
+                 std::string src_tag_name,
+                 std::string cell_num_tag_name,
+                 std::string cell_fracs_tag_name,
+                 std::vector<double> e_bounds,
+                 std::string bias_tag_name)
+  : filename(filename),
+    src_tag_name(src_tag_name),
+    cell_num_tag_name(cell_num_tag_name),
+    cell_fracs_tag_name(cell_fracs_tag_name),
+    e_bounds(e_bounds),
+    bias_tag_name(bias_tag_name) {
+  sub_mode = SUBVOXEL;
+  bias_mode = USER;
+  setup();
+}
+
+void pyne::Sampler::particle_birth(std::vector<double> rands) {
   // select mesh volume and energy group
-  //
-  int pdf_idx =at->sample_pdf(rands[0], rands[1]);
-  int ve_idx = pdf_idx/num_e_groups;
+  // In DEFAULT mode, pdf_idx contains num_ves*num_e_groups elements,
+  // the max_num_cells=1; While, in SUBVOXEL mode, pdf_idx contains
+  // num_ves*max_num_cells*num_e_groups elements
+  int pdf_idx = at->sample_pdf(rands[0], rands[1]);
+  int ve_idx = pdf_idx/max_num_cells/num_e_groups;
+  int c_idx = (pdf_idx/num_e_groups)%max_num_cells;
   int e_idx = pdf_idx % num_e_groups;
 
   // Sample uniformly within the selected mesh volume element and energy
@@ -87,12 +132,18 @@ std::vector<double> pyne::Sampler::particle_birth(std::vector<double> rands) {
   xyz_rands.push_back(rands[3]);
   xyz_rands.push_back(rands[4]);
   moab::CartVect pos = sample_xyz(ve_idx, xyz_rands);
-  samp.push_back(pos[0]); 
-  samp.push_back(pos[1]); 
-  samp.push_back(pos[2]); 
+  samp.push_back(pos[0]);
+  samp.push_back(pos[1]);
+  samp.push_back(pos[2]);
   samp.push_back(sample_e(e_idx, rands[5]));
   samp.push_back(sample_w(pdf_idx));
-  return samp;
+  if (sub_mode == SUBVOXEL) {
+    samp.push_back(double(cell_number[ve_idx*max_num_cells + c_idx]));
+  } else {
+    samp.push_back(-1.0);
+  }
+  //return samp;
+  source_particle = new SourceParticle(samp[0], samp[1], samp[2], samp[3], samp[4], int(samp[5]));
 }
 
 void pyne::Sampler::setup() {
@@ -105,7 +156,7 @@ void pyne::Sampler::setup() {
   if (rval != moab::MB_SUCCESS)
     throw std::invalid_argument("Could not load mesh file.");
 
-  // Get mesh volume elemebts 
+  // Get mesh volume elemebts
   moab::Range ves;
   rval = mesh->get_entities_by_dimension(loaded_file_set, 3, ves);
   if (rval != moab::MB_SUCCESS)
@@ -138,7 +189,7 @@ void pyne::Sampler::mesh_geom_data(moab::Range ves, std::vector<double> &volumes
     throw std::runtime_error("Problem getting mesh connectivity.");
 
   // Grab the coordinates that define 4 connected points within a mesh volume
-  // element and setup a data structure to allow uniform sampling with each 
+  // element and setup a data structure to allow uniform sampling with each
   // mesh volume element.
   double coords[verts_per_ve*3];
   int i;
@@ -165,53 +216,86 @@ void pyne::Sampler::mesh_geom_data(moab::Range ves, std::vector<double> &volumes
   }
 }
 
-void pyne::Sampler::mesh_tag_data(moab::Range ves, 
+void pyne::Sampler::mesh_tag_data(moab::Range ves,
                                   const std::vector<double> volumes) {
   moab::ErrorCode rval;
   moab::Tag src_tag;
+  moab::Tag cell_number_tag;
+  moab::Tag cell_fracs_tag;
   rval = mesh->tag_get_handle(src_tag_name.c_str(),
-                              moab::MB_TAG_VARLEN, 
-                              moab::MB_TYPE_DOUBLE, 
+                              moab::MB_TAG_VARLEN,
+                              moab::MB_TYPE_DOUBLE,
                               src_tag);
   // THIS rval FAILS because we do not know number of energy groups a priori.
   // That's okay. That's what the next line is all about:
   num_e_groups = num_groups(src_tag);
-  std::vector<double> pdf(num_ves*num_e_groups); 
+  // Set the default value of max_num_cells to 1, so that the normal r2s and sub-voxel
+  // r2s can use the same form of pdf size description
+  max_num_cells = 1;
+  if (sub_mode == SUBVOXEL) {
+      // Read the cell_number tag and cell_fracs tag
+      rval = mesh->tag_get_handle(cell_num_tag_name.c_str(),
+                                  cell_number_tag);
+      rval = mesh->tag_get_handle(cell_fracs_tag_name.c_str(),
+                                  cell_fracs_tag);
+      max_num_cells = num_groups(cell_fracs_tag);
+      num_e_groups /= max_num_cells;
+      cell_fracs.resize(num_ves*max_num_cells);
+      rval = mesh->tag_get_data(cell_fracs_tag, ves, &cell_fracs[0]);
+      cell_number.resize(num_ves*max_num_cells);
+      rval = mesh->tag_get_data(cell_number_tag, ves, &cell_number[0]);
+  }
+
+  std::vector<double> pdf(num_ves*num_e_groups*max_num_cells);
   rval = mesh->tag_get_data(src_tag, ves, &pdf[0]);
   if (rval != moab::MB_SUCCESS)
     throw std::runtime_error("Problem getting source tag data.");
 
-  // Multiply the source densities by the VE volumes
-  int i, j;
-  for (i=0; i<num_ves; ++i) {
-    for (j=0; j<num_e_groups; ++j) {
-       pdf[i*num_e_groups + j] *= volumes[i];
+  if (sub_mode == SUBVOXEL) {
+    // Multiply the source densities by the sub-voxel volumes
+    int v, c, e;
+    for (v=0; v<num_ves; ++v) {
+        for (c=0; c<max_num_cells; ++c) {
+            for (e=0; e<num_e_groups; ++e) {
+                pdf[v*max_num_cells*num_e_groups + c*num_e_groups + e] *=
+                    volumes[v]*cell_fracs[v*max_num_cells + c];
+            }
+        }
+    }
+  } else {
+    // Multiply the source densities by the VE volumes
+    int i, j;
+    for (i=0; i<num_ves; ++i) {
+      for (j=0; j<num_e_groups; ++j) {
+         pdf[i*num_e_groups + j] *= volumes[i];
+      }
     }
   }
+
   normalize_pdf(pdf);
 
   // Setup alias table based off PDF or biased PDF
-  if (mode == ANALOG) {
+  if (bias_mode == ANALOG) {
     at = new AliasTable(pdf);
   } else {
     std::vector<double> bias_pdf = read_bias_pdf(ves, volumes, pdf);
     normalize_pdf(bias_pdf);
-    //  Create alias table based off biased pdf and calculate birth weights.
-    biased_weights.resize(num_ves*num_e_groups);
-    for (i=0; i<num_ves*num_e_groups; ++i) {
+    biased_weights.resize(num_ves*num_e_groups*max_num_cells);
+    int i;
+    for (i=0; i<num_ves*num_e_groups*max_num_cells; ++i) {
       biased_weights[i] = pdf[i]/bias_pdf[i];
     }
     at = new AliasTable(bias_pdf);
   }
 }
 
-std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves, 
+std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
                                                  std::vector<double> volumes,
                                                  std::vector<double> pdf) {
-    std::vector<double> bias_pdf(num_ves*num_e_groups);
-    int i, j;
+    std::vector<double> bias_pdf(num_ves*max_num_cells*num_e_groups);
+    int i, j, k;
     moab::ErrorCode rval;
-    if (mode == UNIFORM) {
+    if (sub_mode == DEFAULT && bias_mode == UNIFORM) {
       // Uniform sampling: uniform in space, analog in energy. Biased PDF is
       // found by normalizing the total photon emission density to 1 in each
       // mesh volume element and multiplying by the volume of the element.
@@ -232,12 +316,12 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
           }
         }
       }
-    } else if (mode == USER) {
+    } else if (sub_mode == DEFAULT && bias_mode == USER) {
       // Get the biased PDF from the mesh
       moab::Tag bias_tag;
-      rval = mesh->tag_get_handle(bias_tag_name.c_str(), 
-                                  moab::MB_TAG_VARLEN, 
-                                  moab::MB_TYPE_DOUBLE, 
+      rval = mesh->tag_get_handle(bias_tag_name.c_str(),
+                                  moab::MB_TAG_VARLEN,
+                                  moab::MB_TYPE_DOUBLE,
                                   bias_tag);
       num_bias_groups = num_groups(bias_tag);
 
@@ -253,7 +337,7 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
         // Spatial biasing only: the supplied bias PDF values are applied
         // to all energy groups within a mesh volume element, which are
         // sampled in analog.
-        std::vector<double> spatial_pdf(num_ves); 
+        std::vector<double> spatial_pdf(num_ves);
         rval = mesh->tag_get_data(bias_tag, ves, &spatial_pdf[0]);
         if (rval != moab::MB_SUCCESS)
           throw std::runtime_error("Problem getting bias tag data.");
@@ -265,7 +349,7 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
           }
           if (q_in_group > 0){
             for (j=0; j<num_e_groups; ++j){
-              bias_pdf[i*num_e_groups + j] = 
+              bias_pdf[i*num_e_groups + j] =
                 spatial_pdf[i]*volumes[i]*pdf[i*num_e_groups + j]/q_in_group;
             }
           } else {
@@ -277,6 +361,111 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
         throw std::length_error("Length of bias tag must equal length of the"
                                 "  source tag, or 1.");
       }
+    } else if (sub_mode == SUBVOXEL && bias_mode == UNIFORM) {
+      // Sub-voxel Uniform sampling: uniform in space, analog in energy. Biased PDF is
+      // found by normalizing the total photon emission density to 1 in each
+      // mesh volume element and multiplying by the volume of the element.
+      double q_in_group;
+      for (i=0; i<num_ves; ++i) {
+        for (j=0; j<max_num_cells; ++j) {
+            q_in_group = 0.0;
+            for (k=0; k<num_e_groups; ++k) {
+                q_in_group += pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k];
+            }
+
+            if (q_in_group > 0) {
+                for (k=0; k<num_e_groups; ++k) {
+                    bias_pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k] =
+                        volumes[i]*cell_fracs[i*max_num_cells + j]*pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k]/q_in_group;
+                }
+            } else {
+                for (k=0; k<num_e_groups; ++k) {
+                  bias_pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k] = 0.0;
+                }
+            }
+        }
+      }
+    } else if (sub_mode == SUBVOXEL && bias_mode == USER) {
+      // Get the biased PDF from the mesh
+      moab::Tag bias_tag;
+      rval = mesh->tag_get_handle(bias_tag_name.c_str(),
+                                  moab::MB_TAG_VARLEN,
+                                  moab::MB_TYPE_DOUBLE,
+                                  bias_tag);
+      num_bias_groups = num_groups(bias_tag);
+      if (num_bias_groups == num_e_groups * max_num_cells) {
+        // Spatial, cell and energy biasing. The supplied bias PDF values are
+        // applied to each specific energy group and sub-voxels in a mesh
+        // volume element.
+        rval = mesh->tag_get_data(bias_tag, ves, &bias_pdf[0]);
+        if (rval != moab::MB_SUCCESS)
+          throw std::runtime_error("Problem getting bias tag data.");
+        for (i=0; i<num_ves; ++i) {
+            for (j=0; j<max_num_cells; j++) {
+                for (k=0; k<num_e_groups; ++k)
+                    bias_pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k] *=  volumes[i]*cell_fracs[i*max_num_cells + j];
+            }
+        }
+      } else if (num_bias_groups == 1) {
+        // Spatial biasing only: the supplied bias PDF values are applied
+        // to all energy groups within a mesh volume element, which are
+        // sampled in analog.
+        std::vector<double> spatial_pdf(num_ves);
+        rval = mesh->tag_get_data(bias_tag, ves, &spatial_pdf[0]);
+        if (rval != moab::MB_SUCCESS)
+          throw std::runtime_error("Problem getting bias tag data.");
+        double q_in_group;
+        for (i=0; i<num_ves; ++i) {
+          q_in_group = 0;
+          for (j=0; j<max_num_cells; ++j){
+              for (k=0; k<num_e_groups; ++k){
+                q_in_group += pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k];
+              }
+          }
+          if (q_in_group > 0){
+            for (j=0; j<max_num_cells; ++j){
+                for (k=0; k<num_e_groups; ++k){
+                    bias_pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k] =
+                        spatial_pdf[i]*volumes[i]*cell_fracs[i*max_num_cells + j]*pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k]/q_in_group;
+                }
+            }
+          } else {
+            for (j=0; j<max_num_cells; ++j)
+                for (k=0; k<num_e_groups; ++k){
+                    bias_pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k] =  0;
+                }
+          }
+        }
+      } else if (num_bias_groups == num_e_groups) {
+        // Voxel and energy biasing. Apply the energy bias to all the sub-voxel in the voxel
+        std::vector<double> spa_erg_pdf(num_ves*num_e_groups);
+        rval = mesh->tag_get_data(bias_tag, ves, &spa_erg_pdf[0]);
+        if (rval != moab::MB_SUCCESS)
+          throw std::runtime_error("Problem getting bias tag data.");
+        double q_in_group;
+        for (i=0; i<num_ves; ++i) {
+            for (k=0; k<num_e_groups; ++k) {
+                q_in_group = 0.0;
+                for (j=0; j<max_num_cells; ++j) {
+                    q_in_group += pdf[i*max_num_cells*num_e_groups + j*num_e_groups +k];
+                }
+                if (q_in_group >0) {
+                    for (j=0; j<max_num_cells; ++j) {
+                        bias_pdf[i*max_num_cells*num_e_groups + j*num_e_groups +k] =
+                            spa_erg_pdf[i*num_e_groups+k]*volumes[i]*cell_fracs[i*max_num_cells + j]*
+                            pdf[i*max_num_cells*num_e_groups + j*num_e_groups +k]/q_in_group;
+                    }
+                } else {
+                    for (j=0; j<max_num_cells; ++j) {
+                        bias_pdf[i*max_num_cells*num_e_groups + j*num_e_groups + k] = 0.0;
+                    }
+                }
+            }
+        }
+      } else {
+        throw std::length_error("Length of bias tag must equal length of the"
+                                "  max_num_cells*num_e_group, num_e_groups, or 1.");
+      }
     }
 return bias_pdf;
 }
@@ -287,7 +476,7 @@ moab::CartVect pyne::Sampler::sample_xyz(int ve_idx, std::vector<double> rands) 
   double u = rands[2];
 
   // Transform s, t, u to uniformly sample a tetrahedron. See:
-  // C. Rocchini and P. Cignoni, “Generating Random Points in a Tetrahedron,” 
+  // C. Rocchini and P. Cignoni, “Generating Random Points in a Tetrahedron,”
   //  Journal of Graphics Tools, 5, 200–202 (2001).
   if (ve_type == moab::MBTET) {
     if (s + t > 1) {
@@ -320,15 +509,15 @@ double pyne::Sampler::sample_e(int e_idx, double rand) {
 }
 
 double pyne::Sampler::sample_w(int pdf_idx) {
-  return (mode == ANALOG) ? 1.0 : biased_weights[pdf_idx];
+  return (bias_mode == ANALOG) ? 1.0 : biased_weights[pdf_idx];
 }
 
 void pyne::Sampler::normalize_pdf(std::vector<double> & pdf) {
   double sum = 0;
   int i;
-  for (i=0; i<num_ves*num_e_groups; ++i)
+  for (i=0; i<pdf.size(); ++i)
     sum += pdf[i];
-  for (i=0; i<num_ves*num_e_groups; ++i)
+  for (i=0; i<pdf.size(); ++i)
     pdf[i] /= sum;
 }
 
@@ -355,7 +544,7 @@ pyne::AliasTable::AliasTable(std::vector<double> p) {
   std::vector<double> large(n);
   int i, a, g;
 
-  for (i=0; i<n; ++i) 
+  for (i=0; i<n; ++i)
     p[i] *= n;
 
   // Set separate index lists for small and large probabilities:
@@ -393,4 +582,48 @@ pyne::AliasTable::AliasTable(std::vector<double> p) {
 int pyne::AliasTable::sample_pdf(double rand1, double rand2) {
   int i = (int) n * rand1;
   return rand2 < prob[i] ? i : alias[i];
+}
+
+pyne::SourceParticle::SourceParticle(double x, double y, double z,
+                                     double e, double w, int c) {
+    this->x = x;
+    this->y = y;
+    this->z = z;
+    this->e = e;
+    this->w = w;
+    this->c = c;
+}
+
+int pyne::Sampler::get_src_c(){
+    return source_particle->c;
+}
+
+double pyne::Sampler::get_src_x() {
+    return source_particle->x;
+}
+
+double pyne::Sampler::get_src_y() {
+    return source_particle->y;
+}
+
+double pyne::Sampler::get_src_z() {
+    return source_particle->z;
+}
+
+double pyne::Sampler::get_src_e() {
+    return source_particle->e;
+}
+
+double pyne::Sampler::get_src_w() {
+    return source_particle->w;
+}
+
+std::vector<double> pyne::Sampler::get_src_xyzew() {
+    std::vector<double> xyzew;
+    xyzew.push_back(source_particle->x);
+    xyzew.push_back(source_particle->y);
+    xyzew.push_back(source_particle->z);
+    xyzew.push_back(source_particle->e);
+    xyzew.push_back(source_particle->w);
+    return xyzew;
 }

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -40,13 +40,13 @@ void pyne::particle_birth_(double* rands,
                            double* w,
                            int* c) {
     std::vector<double> rands2(rands, rands + 6);
-    sampler->particle_birth(rands2);
-    *x = sampler->get_src_x();
-    *y = sampler->get_src_y();
-    *z = sampler->get_src_z();
-    *e = sampler->get_src_e();
-    *w = sampler->get_src_w();
-    *c = sampler->get_src_c();
+    pyne::SourceParticle src = sampler->particle_birth(rands2);
+    *x = src.x;
+    *y = src.y;
+    *z = src.z;
+    *e = src.e;
+    *w = src.w;
+    *c = src.c;
 }
 
 std::vector<double> pyne::read_e_bounds(std::string e_bounds_file){
@@ -114,7 +114,7 @@ pyne::Sampler::Sampler(std::string filename,
   setup();
 }
 
-void pyne::Sampler::particle_birth(std::vector<double> rands) {
+pyne::SourceParticle pyne::Sampler::particle_birth(std::vector<double> rands) {
   // select mesh volume and energy group
   // In DEFAULT mode, pdf_idx contains num_ves*num_e_groups elements,
   // the max_num_cells=1; While, in SUBVOXEL mode, pdf_idx contains
@@ -142,8 +142,9 @@ void pyne::Sampler::particle_birth(std::vector<double> rands) {
   } else {
     samp.push_back(-1.0);
   }
-  //return samp;
-  source_particle = new SourceParticle(samp[0], samp[1], samp[2], samp[3], samp[4], int(samp[5]));
+  //return a source particle
+  pyne::SourceParticle src = SourceParticle(samp[0], samp[1], samp[2], samp[3], samp[4], int(samp[5]));
+  return src;
 }
 
 void pyne::Sampler::setup() {
@@ -584,6 +585,15 @@ int pyne::AliasTable::sample_pdf(double rand1, double rand2) {
   return rand2 < prob[i] ? i : alias[i];
 }
 
+pyne::SourceParticle::SourceParticle() {
+    this->x = -1.0;
+    this->y = -1.0;
+    this->z = -1.0;
+    this->e = -1.0;
+    this->w = -1.0;
+    this->c = -1;
+}
+
 pyne::SourceParticle::SourceParticle(double x, double y, double z,
                                      double e, double w, int c) {
     this->x = x;
@@ -594,36 +604,18 @@ pyne::SourceParticle::SourceParticle(double x, double y, double z,
     this->c = c;
 }
 
-int pyne::Sampler::get_src_c(){
-    return source_particle->c;
-}
+pyne::SourceParticle::~SourceParticle() {};
 
-double pyne::Sampler::get_src_x() {
-    return source_particle->x;
-}
-
-double pyne::Sampler::get_src_y() {
-    return source_particle->y;
-}
-
-double pyne::Sampler::get_src_z() {
-    return source_particle->z;
-}
-
-double pyne::Sampler::get_src_e() {
-    return source_particle->e;
-}
-
-double pyne::Sampler::get_src_w() {
-    return source_particle->w;
-}
-
-std::vector<double> pyne::Sampler::get_src_xyzew() {
+std::vector<double> pyne::SourceParticle::get_src_xyzew() {
     std::vector<double> xyzew;
-    xyzew.push_back(source_particle->x);
-    xyzew.push_back(source_particle->y);
-    xyzew.push_back(source_particle->z);
-    xyzew.push_back(source_particle->e);
-    xyzew.push_back(source_particle->w);
+    xyzew.push_back(this->x);
+    xyzew.push_back(this->y);
+    xyzew.push_back(this->z);
+    xyzew.push_back(this->e);
+    xyzew.push_back(this->w);
     return xyzew;
+}
+
+int pyne::SourceParticle::get_src_c() {
+    return this->c;
 }

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -2,25 +2,26 @@
 /// \author Elliott Biondo (biondo\@wisc.edu)
 ///
 /// \brief Mesh-based Monte Carlo source sampling.
-/// 
+///
 /// The Sampler class is used for Monte Carlo source sampling from mesh-based
 /// sources.  The source density distribution and optional biased source density
-/// distribution are defined on a MOAB mesh. Upon instantiation, a Sampler  
+/// distribution are defined on a MOAB mesh. Upon instantiation, a Sampler
 /// object reads this mesh and creates an alias table for randomly sampling
-/// particle birth parameters. The particle_birth member function is supplied 
-/// with 6 pseudo-random numbers and returns the position, energy, and weight 
-/// of a particle upon birth. 
-/// There are three sampling modes: analog, uniform, and user-speficied
+/// particle birth parameters. The particle_birth member function is supplied
+/// with 6 pseudo-random numbers and returns the position, energy, and weight
+/// of a particle upon birth.
+/// There are three sampling bias modes: analog, uniform, and user-speficied
+/// User can choose to use sub-voxel mode or not.
 /// In analog sampling, no source biasing is used and birth weights
-/// are all 1. In uniform sampling, the position of the particle (but not the 
-/// energy) is sampled uniformly and weights are adjusted accordingly. In 
-/// user-speficied mode, a supplied biased source density distribution is used 
-/// for sampling and particle weights are adjusted accordingly. The biased 
-/// source density distribution must have the same number of energy groups as 
+/// are all 1. In uniform sampling, the position of the particle (but not the
+/// energy) is sampled uniformly and weights are adjusted accordingly. In
+/// user-speficied mode, a supplied biased source density distribution is used
+/// for sampling and particle weights are adjusted accordingly. The biased
+/// source density distribution must have the same number of energy groups as
 /// the unbiased distribution. Alternatively, it may have exactly 1 energy
 /// group, in which case only spatial biasing is done, and energies are sampled
 /// in analog.
- 
+
 #ifndef PYNE_6OR6BJURKJHHTOFWXO2VMQM5EY
 #define PYNE_6OR6BJURKJHHTOFWXO2VMQM5EY
 
@@ -30,7 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
-#include <stdexcept> 
+#include <stdexcept>
 #include <sstream>
 #include <string>
 
@@ -46,7 +47,8 @@ extern "C" {
 namespace pyne {
 
   /// MCNP interface for source sampling setup
-  /// \param mode The sampling mode: 1 = analog, 2 = uniform, 3 = user-specified
+  /// \param mode The sampling mode: 1 = default-analog, 2 = default-uniform, 3 = default-user-specified
+  ///                                4 = subvoxel-analog, 5 = subvoxel-uniform, 6 = subvoxel-user-specified
   void sampling_setup_(int* mode);
   /// MCNP interface to sample particle birth parameters after sampling setup
   /// \param rands Six pseudo-random numbers supplied from the Fortran side.
@@ -55,12 +57,14 @@ namespace pyne {
   /// \param z The sampled z position returned by this function
   /// \param e The sampled energy returned by this function
   /// \param w The sampled y statistical weight returned by this function
+  /// \param c The cell_number of the particle
   void particle_birth_(double* rands,
                             double* x,
                             double* y,
                             double* z,
                             double* e,
-                            double* w);
+                            double* w,
+                            int* c);
   /// Helper function for MCNP interface that reads energy boudaries from a file
   /// \param e_bounds_file A file containing the energy group boundaries.
   std::vector<double> read_e_bounds(std::string e_bounds_file);
@@ -72,7 +76,7 @@ namespace pyne {
     moab::CartVect y_vec;
     moab::CartVect z_vec;
   };
-  
+
   /// A data structure for O(1) source sampling
   class AliasTable {
   public:
@@ -88,24 +92,53 @@ namespace pyne {
     std::vector<double> prob; /// Probabilities.
     std::vector<int> alias; /// Alias probabilities.
   };
-  
+
+  // class Source particle
+  class SourceParticle {
+    public:
+    /// Constructor for source particle
+    /// \param x The x coordinate of the source particle
+    /// \param y The y coordinate of the source particle
+    /// \param z The z coordinate of the source particle
+    /// \param e The energy of the source particle
+    /// \param w The weight of the source particle
+    /// \param c The cell number of the source particle
+    SourceParticle(double x,
+                   double y,
+                   double z,
+                   double e,
+                   double w,
+                   int c);
+
+    ~SourceParticle() {};
+
+    double x; // x coordinate
+    double y; // y coordinate
+    double z; // z coordinate
+    double e; // energy
+    double w; // weight
+    int c; // cell number
+
+  };
+
   /// Problem modes
-  enum Mode {USER, ANALOG, UNIFORM};
-  
+  enum BiasMode {USER, ANALOG, UNIFORM};
+  enum SubMode {DEFAULT, SUBVOXEL};
+
   /// Mesh based Monte Carlo source sampling.
   class Sampler {
   public:
     /// Constuctor for analog and uniform sampling
     /// \param filename The path to the MOAB mesh (.h5m) file
-    /// \param src_tag_name The name of the tag that describes the unbiased 
+    /// \param src_tag_name The name of the tag that describes the unbiased
     ///                     source density distribution.
     /// \param e_bounds The energy boundaries, note there are N + 1 energy
     ///                 bounds for N energy groups
     /// \param uniform If false, analog sampling is used. If true, uniform
     ///                sampling is used.
-    Sampler(std::string filename, 
-            std::string src_tag_name, 
-            std::vector<double> e_bounds, 
+    Sampler(std::string filename,
+            std::string src_tag_name,
+            std::vector<double> e_bounds,
             bool uniform);
     /// Constuctor for analog and uniform sampling
     /// \param filename The path to the MOAB mesh (.h5m) file
@@ -118,30 +151,82 @@ namespace pyne {
     ///                       number of energy groups as <src_tag_name> or 1.
     ///                       If 1 (i.e. spatial biasing only), all energy groups
     ///                       within a mesh volume element are sampled equally.
-    Sampler(std::string filename, 
-            std::string src_tag_name, 
-            std::vector<double> e_bounds, 
+    Sampler(std::string filename,
+            std::string src_tag_name,
+            std::vector<double> e_bounds,
             std::string bias_tag_name);
+    //// Constuctor for sub-voxel analog and uniform sampling
+    /// \param filename The path to the MOAB mesh (.h5m) file
+    /// \param src_tag_name The name of the tag that describes the unbiased
+    ///                     source density distribution.
+    /// \param cell_num_tag_name The name of the tag that describes the cell number
+    /// \param cell_fracs_tag_name The name of the tag that describes the cell volume fractions
+    /// \param e_bounds The energy boundaries, note there are N + 1 energy
+    ///                 bounds for N energy groups
+    /// \param uniform If false, analog sampling is used. If true, uniform
+    ///                sampling is used.
+    Sampler(std::string filename,
+            std::string src_tag_name,
+            std::string cell_num_tag_name,
+            std::string cell_fracs_tag_name,
+            std::vector<double> e_bounds,
+            bool uniform);
+    /// Constructor for sub-voxel r2s user define sampling
+    /// \param filename The path to the MOAB mesh (.h5m) file
+    /// \param src_tag_name The name of the tag with the unbiased source density
+    ///                     distribution.
+    /// \param cell_num_tag_name The name of the tag that describes the cell number
+    /// \param cell_fracs_tag_name The name of the tag that describes the cell volume fractions
+    /// \param e_bounds The energy boundaries, note there are N + 1 energy
+    ///                 bounds for N energy groups
+    /// \param bias_tag_name The name of the tag describing the biased source
+    ///                       density distribution. The tag must have the same
+    ///                       number of energy groups as max_num_cells*num_e_groups,
+    ///                       max_num_cells, or 1.
+    ///                       If 1 (i.e. spatial biasing only), all sub-voxels and energy groups
+    ///                       within a mesh volume element are sampled equally.
+    ///                       If max_num_cells (i.e. bias applied to the sub-voxel),
+    ///                       all energy groups within a sub-voxel are sampled equally.
+    ///                       If max_num_cells*num_e_groups (i.e. bias applied to each energy group)
+    Sampler(std::string filename,
+            std::string src_tag_name,
+            std::string cell_num_tag_name,
+            std::string cell_fracs_tag_name,
+            std::vector<double> e_bounds,
+            std::string bias_tag_name);
+
     /// Samples particle birth parameters
     /// \param rands Six pseudo-random numbers in range [0, 1].
     /// \return A vector containing the x position, y, position, z, point, energy
     ///         and weight of a particle (in that order).
-    std::vector<double> particle_birth(std::vector<double> rands);
+    void particle_birth(std::vector<double> rands);
+    int get_src_c();
+    double get_src_x();
+    double get_src_y();
+    double get_src_z();
+    double get_src_e();
+    double get_src_w();
+    std::vector<double> get_src_xyzew();
     ~Sampler() {
       delete mesh;
       delete at;
+      delete source_particle;
     };
-  
+
   // member variables
   private:
     // problem parameters
     std::string filename; ///< MOAB mesh file path
     std::string src_tag_name; ///< Unbiased source density distribution
+    std::string cell_num_tag_name; ///< Cell numbers tag
+    std::string cell_fracs_tag_name; ///< Cell fractions tag
     std::string bias_tag_name; ///< Biased source density distribution
     std::vector<double> e_bounds;  ///< Energy boundaries
     int num_e_groups; ///< Number of groups in tag \a _src_tag_name
     int num_bias_groups; ///< Number of groups tag \a _bias_tag_name
-    Mode mode; ///< Problem mode: analog, uniform, user
+    int max_num_cells; ///< Max numbers of cells in voxels
+    BiasMode bias_mode; ///< Problem bais mode: analog, uniform, user
+    SubMode sub_mode; ///< Problem Sub-voxel mode: use sub-voxel r2s when SUBVOXEL
     // mesh
     moab::Interface* mesh; ///< MOAB mesh
     int num_ves; ///< Number of mesh volume elements on \a mesh.
@@ -150,8 +235,11 @@ namespace pyne {
     // sampling
     std::vector<edge_points> all_edge_points; ///< Four connected points on a VE.
     std::vector<double> biased_weights; ///< Birth weights for biased sampling.
+    std::vector<int> cell_number; ///< Tag cell_number
+    std::vector<double> cell_fracs; ///< Tag cell_fracs
     AliasTable* at; ///< Alias table used for sampling.
-  
+    SourceParticle* source_particle; ///< source particle generated
+
   // member functions
   private:
     // instantiation
@@ -165,9 +253,10 @@ namespace pyne {
     // helper functions
     void normalize_pdf(std::vector<double> & pdf);
     int num_groups(moab::Tag tag);
-    std::vector<double> read_bias_pdf(moab::Range ves, std::vector<double> volumes, 
+    std::vector<double> read_bias_pdf(moab::Range ves, std::vector<double> volumes,
                                       std::vector<double> pdf);
   };
+
 } //end namespace pyne
 
 #ifdef __cplusplus

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -96,6 +96,7 @@ namespace pyne {
   // class Source particle
   class SourceParticle {
     public:
+    SourceParticle();
     /// Constructor for source particle
     /// \param x The x coordinate of the source particle
     /// \param y The y coordinate of the source particle
@@ -109,8 +110,7 @@ namespace pyne {
                    double e,
                    double w,
                    int c);
-
-    ~SourceParticle() {};
+    ~SourceParticle();
 
     double x; // x coordinate
     double y; // y coordinate
@@ -118,7 +118,8 @@ namespace pyne {
     double e; // energy
     double w; // weight
     int c; // cell number
-
+    std::vector<double> get_src_xyzew();
+    int get_src_c();
   };
 
   /// Problem modes
@@ -199,18 +200,11 @@ namespace pyne {
     /// \param rands Six pseudo-random numbers in range [0, 1].
     /// \return A vector containing the x position, y, position, z, point, energy
     ///         and weight of a particle (in that order).
-    void particle_birth(std::vector<double> rands);
-    int get_src_c();
-    double get_src_x();
-    double get_src_y();
-    double get_src_z();
-    double get_src_e();
-    double get_src_w();
-    std::vector<double> get_src_xyzew();
+    pyne::SourceParticle particle_birth(std::vector<double> rands);
+    
     ~Sampler() {
       delete mesh;
       delete at;
-      delete source_particle;
     };
 
   // member variables
@@ -238,7 +232,6 @@ namespace pyne {
     std::vector<int> cell_number; ///< Tag cell_number
     std::vector<double> cell_fracs; ///< Tag cell_fracs
     AliasTable* at; ///< Alias table used for sampling.
-    SourceParticle* source_particle; ///< source particle generated
 
   // member functions
   private:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -843,6 +843,37 @@ def test_tag_cell_fracs_subvoxel_equal_voxel():
         assert_equal(m.cell_largest_frac[i],
                            exp_cell_largest_frac[i])
 
+def test_tag_cell_fracs_subvoxel_equal_voxel():
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
+             mats = None)
+    m.src = IMeshTag(2, float)
+    m.src[:] = np.ones(shape=(8,2))
+    cell_fracs = np.zeros(8, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+
+    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
+                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
+                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
+
+    m.tag_cell_fracs(cell_fracs)
+
+    #  Expected tags:
+    exp_cell_number = [[1], [2], [3], [4], [5], [6], [7], [8]]
+    exp_cell_fracs = [[1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0], [1.0]]
+    exp_cell_largest_frac_number = [1, 2, 3, 4, 5, 6, 7, 8]
+    exp_cell_largest_frac = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+
+    for i in range(len(m)):
+        assert_array_equal(m.cell_number[i], exp_cell_number[i])
+        assert_array_equal(m.cell_fracs[i], exp_cell_fracs[i])
+        assert_equal(m.cell_largest_frac_number[i],
+                           exp_cell_largest_frac_number[i])
+        assert_equal(m.cell_largest_frac[i],
+                           exp_cell_largest_frac[i])
+
 def test_no_mats():
     mesh = gen_mesh(mats=None)
     assert_true(mesh.mats is None)

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -18,21 +18,21 @@ from pyne.utils import QAWarning
 warnings.simplefilter("ignore", QAWarning)
 
 from pyne.mesh import Mesh, IMeshTag
-from pyne.source_sampling import Sampler, AliasTable
+from pyne.source_sampling import Sampler, AliasTable, SourceParticle
 
 def try_rm_file(filename):
     return lambda: os.remove(filename) if os.path.exists(filename) else None
 
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_analog_single_hex():
-    """This test tests that particles of sampled evenly within the phase-space 
+    """This test tests that particles of sampled evenly within the phase-space
     of a single mesh volume element with one energy group in an analog sampling
-    scheme. This done by dividing each dimension (x, y, z, E) in half, then 
-    sampling particles and tallying on the basis of which of the 2^4 = 8 regions
-    of phase space the particle is born into. 
+    scheme. This done by dividing each dimension (x, y, z, E) in half, then
+    sampling particles and tallying on the basis of which of the 2^4 = 16 regions
+    of phase space the particle is born into.
     """
     seed(1953)
-    m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]], 
+    m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]],
              mats = None)
     m.src = IMeshTag(1, float)
     m.src[0] = 1.0
@@ -45,9 +45,11 @@ def test_analog_single_hex():
     tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
 
     for i in range(num_samples):
-        s = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
+        c = sampler.get_src_c()
         assert_equal(s[4], 1.0) # analog: all weights must be one
-        tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs), 
+        tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
               int(s[3]*num_divs)] += score
 
     # Test that each half-space of phase space (e.g. x > 0.5) is sampled about
@@ -57,14 +59,197 @@ def test_analog_single_hex():
             assert(abs(np.sum(np.rollaxis(tally, i)[j,:,:,:]) - 0.5) < 0.05)
 
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_analog_single_hex_subvoxel_analog():
+    """This test tests that particles of sampled evenly within the phase-space
+    of a single mesh volume element (also a sub-voxel) with one energy group
+    in an analog sampling scheme. This done by dividing each dimension
+    (x, y, z, E) in half, then sampling particles and tallying on the basis of
+    which of the 2^4 = 16 regions of phase space the particle is born into.
+    """
+    seed(1953)
+    m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]],
+             mats = None)
+    m.src = IMeshTag(1, float)
+    m.src[0] = 1.0
+    cell_fracs = np.zeros(1, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+    cell_fracs[:] = [(0, 11, 1.0, 0.0)]
+    m.tag_cell_fracs(cell_fracs)
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      np.array([0, 1]), False)
+
+    num_samples = 5000
+    score = 1.0/num_samples
+    num_divs = 2
+    tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
+
+    for i in range(num_samples):
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        assert_equal(s[4], 1.0) # analog: all weights must be one
+        assert_equal(cell_number, 11) # analog: the cell number
+        tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
+              int(s[3]*num_divs)] += score
+
+    # Test that each half-space of phase space (e.g. x > 0.5) is sampled about
+    # half the time.
+    for i in range(0, 4):
+        for j in range(0, 2):
+            assert(abs(np.sum(np.rollaxis(tally, i)[j,:,:,:]) - 0.5) < 0.05)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_single_hex_subvoxel_uniform():
+    """This test tests that particles of sampled evenly within the phase-space
+    of a single mesh volume element with one energy group in an uniform sampling
+    scheme. This done by dividing each dimension (x, y, z, E) in half, then
+    sampling particles and tallying on the basis of which of the 2^4 = 8 regions
+    of phase space the particle is born into.
+    """
+    seed(1953)
+    m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]],
+             mats = None)
+    m.src = IMeshTag(1, float)
+    m.src[0] = 1.0
+    cell_fracs = np.zeros(1, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+    cell_fracs[:] = [(0, 11, 1.0, 0.0)]
+    m.tag_cell_fracs(cell_fracs)
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      np.array([0, 1]), True)
+
+    num_samples = 5000
+    score = 1.0/num_samples
+    num_divs = 2
+    tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
+
+    for i in range(num_samples):
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        assert_equal(s[4], 1.0) # analog: all weights must be one
+        assert_equal(cell_number, 11) # analog: the cell number
+        tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
+              int(s[3]*num_divs)] += score
+
+    # Test that each half-space of phase space (e.g. x > 0.5) is sampled about
+    # half the time.
+    for i in range(0, 4):
+        for j in range(0, 2):
+            assert(abs(np.sum(np.rollaxis(tally, i)[j,:,:,:]) - 0.5) < 0.05)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_analog_single_hex_multiple_subvoxel():
+    """This test tests that particles of sampled analog within the phase-space
+    of a single mesh volume element but multiple sub-voxels with one energy
+    group in an analog sampling scheme. Then sampling particles and tallying
+    the particles and check the probability of particles born in each
+    sub-voxel and the cell_number.
+    """
+    seed(1953)
+    m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]],
+             mats = None)
+    m.src = IMeshTag(3, float)
+    m.src[:] = np.empty(shape=(1, 3))
+    m.src[0] = [0, 0.2, 0.8]
+
+    cell_fracs = np.zeros(3, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+    cell_fracs[:] = [(0, 11, 0.3, 0.0), (0, 12, 0.3, 0.0), (0, 13, 0.4, 0.0)]
+    m.tag_cell_fracs(cell_fracs)
+
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      np.array([0, 1]), False)
+
+    num_samples = 50000
+    score = 1.0/num_samples
+    num_divs = 2
+    tally = [0.0] * 3
+
+    for i in range(num_samples):
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        assert_equal(s[4], 1.0) # analog: all weights must be one
+        if int(cell_number) == 11:
+            tally[0] += score
+        if int(cell_number) == 12:
+            tally[1] += score
+        if int(cell_number) == 13:
+            tally[2] += score
+
+    # Test that each source particle in each cell has right frequency
+    assert_equal(tally[0], 0.0)
+    assert(abs(tally[1] - 0.158)/0.158 < 0.05)
+    assert(abs(tally[2] - 0.842)/0.842 < 0.05)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_analog_single_hex_multiple_subvoxel_uniform():
+    """This test tests that particles of sampled evenly within the phase-space
+    of a single mesh volume element with one energy group in an uniform sampling
+    scheme. This done by dividing each dimension (x, y, z, E) in half, then
+    sampling particles and tallying on the basis of which of the 2^4 = 8 regions
+    of phase space the particle is born into.
+    """
+    seed(1953)
+    m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1]],
+             mats = None)
+    m.src = IMeshTag(3, float)
+    m.src[:] = np.empty(shape=(1, 3))
+    m.src[0] = [0, 0.2, 0.8]
+
+    cell_fracs = np.zeros(3, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+    cell_fracs[:] = [(0, 11, 0.3, 0.0), (0, 12, 0.3, 0.0), (0, 13, 0.4, 0.0)]
+    m.tag_cell_fracs(cell_fracs)
+
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      np.array([0, 1]), True)
+
+    num_samples = 5000
+    score = 1.0/num_samples
+    num_divs = 2
+    tally = [0.0] * 3
+
+    for i in range(num_samples):
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        if int(cell_number) == 11:
+            tally[0] += score
+        if int(cell_number) == 12:
+            tally[1] += score
+            assert(abs(s[4] - 0.369)/0.369 < 0.05) # analog: all weights must be one
+        if int(cell_number) == 13:
+            tally[2] += score
+            assert(abs(s[4] - 1.475)/1.475 < 0.05)
+
+    # Test that each source particle in each cell has right frequency
+    assert_equal(tally[0], 0.0)
+    assert(abs(tally[1] - 0.428) < 0.05)
+    assert(abs(tally[2] - 0.572) < 0.05)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_analog_multiple_hex():
     """This test tests that particle are sampled uniformly from a uniform source
     defined on eight mesh volume elements in two energy groups. This is done
     using the exact same method ass test_analog_multiple_hex.
     """
     seed(1953)
-    m = Mesh(structured=True, 
-             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]], 
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
              mats = None)
     m.src = IMeshTag(2, float)
     m.src[:] = np.ones(shape=(8,2))
@@ -76,15 +261,333 @@ def test_analog_multiple_hex():
     num_divs = 2
     tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
     for i in range(num_samples):
-        s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
         assert_equal(s[4], 1.0)
-        tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs), 
+        tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
               int(s[3]*num_divs)] += score
-    
+
     for i in range(0, 4):
         for j in range(0, 2):
             halfspace_sum = np.sum(np.rollaxis(tally, i)[j,:,:,:])
             assert(abs(halfspace_sum - 0.5)/0.5 < 0.1)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_analog_multiple_hex_subvoxel():
+    """This test tests that particle are sampled analog from a uniform source
+    defined on eight mesh volume elements in two energy groups. This is done
+    using the exact same method as test_analog_multiple_hex_subvoxel.
+    """
+    seed(1953)
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
+             mats = None)
+    m.src = IMeshTag(2, float)
+    m.src[:] = np.ones(shape=(8,2))
+    cell_fracs = np.zeros(8, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+
+    cell_fracs[:] = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0), (2, 3, 1.0, 0.0),
+                     (3, 4, 1.0, 0.0), (4, 5, 1.0, 0.0), (5, 6, 1.0, 0.0),
+                     (6, 7, 1.0, 0.0), (7, 8, 1.0, 0.0)]
+
+    m.tag_cell_fracs(cell_fracs)
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      np.array([0, 0.5, 1]), False)
+
+    num_samples = 5000
+    score = 1.0/num_samples
+    num_divs = 2
+    tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
+    for i in range(num_samples):
+        sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        assert_equal(s[4], 1.0)
+        assert_equal(cell_number, 4*int(s[0]*num_divs) + 2*int(s[1]*num_divs)
+                     + int(s[2]*num_divs) + 1)
+        tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
+              int(s[3]*num_divs)] += score
+
+    for i in range(0, 4):
+        for j in range(0, 2):
+            halfspace_sum = np.sum(np.rollaxis(tally, i)[j,:,:,:])
+            assert(abs(halfspace_sum - 0.5)/0.5 < 0.1)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_analog_multiple_hex_subvoxel_uniform():
+    """This test tests that particle are sampled uniformly from a uniform source
+    defined on eight mesh volume elements in two energy groups. This is done
+    using the exact same method ass test_analog_multiple_hex_subvoxel.
+    """
+    seed(1953)
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 0.5, 1], [0, 0.5, 1]],
+             mats = None)
+    m.src = IMeshTag(2, float)
+    m.src[:] = np.empty(shape=(8,2), dtype=float)
+    m.src[:] = [[0,0], [1,0], [0,0], [2,0],
+                [0,0], [3,0], [0,0], [4,0]]
+    cell_fracs = np.zeros(8, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+
+    cell_fracs[:] = [(0, 0, 1.0, 0.0), (1, 1, 1.0, 0.0), (2, 2, 1.0, 0.0),
+                     (3, 3, 1.0, 0.0), (4, 4, 1.0, 0.0), (5, 5, 1.0, 0.0),
+                     (6, 6, 1.0, 0.0), (7, 7, 1.0, 0.0)]
+
+    empty_cells = [0, 2, 4, 6]
+    m.tag_cell_fracs(cell_fracs)
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      np.array([0, 0.5, 1]), True)
+
+    num_samples = 50000
+    score = 1.0/num_samples
+    num_divs = 2
+    tally = [0.0] * 8
+    for i in range(num_samples):
+        sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        # check the cell_number
+        assert_equal(cell_number, 4*int(s[0]*num_divs) + 2*int(s[1]*num_divs)
+                     + int(s[2]*num_divs))
+        # check the weight of each subvoxel
+        if cell_number not in empty_cells:
+            # weight for cell 1, 3, 5, 7 should be: 0.4, 0.8, 1.2, 1.6
+            exp_w = (cell_number + 1) / 2 * 0.4
+            out_w = s[4]
+            assert(abs(out_w - exp_w)/exp_w < 0.05) # hand calculate
+        # count the tally
+        tally[cell_number] += score
+
+    # check the real sample rate
+    for i, item in enumerate(tally):
+        if i not in empty_cells:
+            assert(abs(item - 0.25)/0.25 < 0.05)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_subvoxel_multiple_hex_bias_1():
+    """This test tests that particle are sampled from a biased source
+    defined on two voxels (2*2 = 4 sub-voxels) with the biased tag length of 1.
+    """
+    seed(1953)
+    # mesh contains two voxels. 2 * 1 * 1 = 2
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 1], [0, 1]],
+             mats = None)
+
+    # max_num_cells = 2. 4 sub-voxels
+    cell_fracs = np.zeros(4, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+    cell_fracs[:] = [(0, 11, 0.5, 0.0), (0, 12, 0.5, 0.0),
+                     (1, 21, 0.5, 0.0), (1, 22, 0.5, 0.0)]
+    m.tag_cell_fracs(cell_fracs)
+
+    # the photon emitting rate of 4 sub-voxels is 0.1, 0.2, 0.3, 0.4
+    m.src = IMeshTag(4, float)
+    m.src[:] = np.empty(shape=(2,4), dtype=float)
+    m.src[:] = [[0.05, 0.05, 0.10, 0.10],
+                [0.15, 0.15, 0.20, 0.20]]
+    e_bounds = np.array([0, 0.5, 1.0])
+    # bias, tag size = 1
+    m.bias = IMeshTag(1, float)
+    m.bias[:] = [[0.4], [0.6]]
+
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      e_bounds, "bias")
+
+    num_samples = 50000
+    score = 1.0/num_samples
+    num_divs = 2
+    # tally shape (v, c, e)
+    tally = np.zeros(shape=(num_divs, num_divs, num_divs))
+    for i in range(num_samples):
+        sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        vid = cell_number/10 - 1
+        cid = cell_number%10 - 1
+        eid = 0 if s[3] < 0.5 else 1;
+        wgt = s[4]
+        # check the cell_number
+        if s[0] < 0.5:
+            assert(cell_number in [11, 12])
+        if s[0] > 0.5:
+            assert(cell_number in [21, 22])
+        # check the weight of each subvoxel
+        if vid == 0:
+            assert(abs(wgt - 0.746) / 0.746 < 0.05)
+        if vid == 1:
+            assert(abs(wgt - 1.163) / 1.163 < 0.05)
+        # count the tally
+        tally[vid, cid, eid] += score
+
+    # check the real sample rate
+    # exp_tally calculated by hand
+    exp_tally = np.zeros(shape=(2, 2, 2))
+    exp_tally[:] = [[[0.067, 0.067],
+                     [0.133, 0.133]],
+                    [[0.129, 0.129],
+                     [0.171, 0.171]]]
+    for v in range(2):
+        for c in range(2):
+            for e in range(2):
+                assert(abs(tally[v, c, e] - exp_tally[v, c, e]) / exp_tally[v, c, e] < 0.05)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_subvoxel_multiple_hex_bias_max_num_cells_num_e_groups():
+    """This test tests that particle are sampled from a biased source
+    defined on two voxels (2*2 = 4 sub-voxels) with the biased tag length
+    of max_num_cells*num_e_group.
+    """
+    seed(1953)
+    # mesh contains two voxels. 2 * 1 * 1 = 2
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 1], [0, 1]],
+             mats = None)
+
+    # max_num_cells = 2. 4 sub-voxels
+    cell_fracs = np.zeros(4, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+    cell_fracs[:] = [(0, 11, 0.5, 0.0), (0, 12, 0.5, 0.0),
+                     (1, 21, 0.5, 0.0), (1, 22, 0.5, 0.0)]
+    m.tag_cell_fracs(cell_fracs)
+
+    # the photon emitting rate of 4 sub-voxels is 0.1, 0.2, 0.3, 0.4
+    m.src = IMeshTag(4, float)
+    m.src[:] = np.empty(shape=(2,4), dtype=float)
+    m.src[:] = [[0.125, 0.125, 0.125, 0.125],
+                [0.125, 0.125, 0.125, 0.125]]
+    e_bounds = np.array([0, 0.5, 1.0])
+    # bias, tag size = 1
+    m.bias = IMeshTag(4, float)
+    m.bias[:] = [[0.125, 0.125, 0.1, 0.15], [0.1, 0.1, 0.15, 0.15]]
+
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      e_bounds, "bias")
+
+    num_samples = 50000
+    score = 1.0/num_samples
+    num_divs = 2
+    # tally shape (v, c, e)
+    tally = np.zeros(shape=(num_divs, num_divs, num_divs))
+    exp_wgt = np.zeros(shape=(num_divs, num_divs, num_divs))
+    exp_wgt[:] = [[[1.0, 1.0], [1.25, 0.83]], [[1.25, 1.25], [0.83, 0.83]]]
+    for i in range(num_samples):
+        sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        vid = cell_number/10 - 1
+        cid = cell_number%10 - 1
+        eid = 0 if s[3] < 0.5 else 1;
+        wgt = s[4]
+        # check the cell_number
+        if s[0] < 0.5:
+            assert(cell_number in [11, 12])
+        if s[0] > 0.5:
+            assert(cell_number in [21, 22])
+        # check the weight of each subvoxel
+        assert(abs(wgt - exp_wgt[vid, cid, eid]) / exp_wgt[vid, cid, eid] < 0.05)
+        # count the tally
+        tally[vid, cid, eid] += score
+
+    # check the real sample rate
+    exp_tally = np.zeros(shape=(2, 2, 2))
+    exp_tally[:] = [[[0.125, 0.125], [0.100, 0.150]],
+                    [[0.100, 0.100], [0.150, 0.150]]]
+    for v in range(2):
+        for c in range(2):
+            for e in range(2):
+                assert(abs(tally[v, c, e] - exp_tally[v, c, e]) / exp_tally[v, c, e] < 0.05)
+
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
+def test_subvoxel_multiple_hex_bias_e_groups():
+    """This test tests that particle are sampled from a biased source
+    defined on two voxels (2*2 = 4 sub-voxels) with the biased tag length
+    of energy groups.
+    """
+    seed(1953)
+    # mesh contains two voxels. 2 * 1 * 1 = 2
+    m = Mesh(structured=True,
+             structured_coords=[[0, 0.5, 1], [0, 1], [0, 1]],
+             mats = None)
+
+    # max_num_cells = 2. 4 sub-voxels
+    cell_fracs = np.zeros(4, dtype=[('idx', np.int64),
+                                    ('cell', np.int64),
+                                    ('vol_frac', np.float64),
+                                    ('rel_error', np.float64)])
+    cell_fracs[:] = [(0, 11, 0.5, 0.0), (0, 12, 0.5, 0.0),
+                     (1, 21, 0.5, 0.0), (1, 22, 0.5, 0.0)]
+    m.tag_cell_fracs(cell_fracs)
+
+    # the photon emitting rate of 4 sub-voxels is 0.1, 0.2, 0.3, 0.4
+    m.src = IMeshTag(4, float)
+    m.src[:] = np.empty(shape=(2,4), dtype=float)
+    m.src[:] = [[0.05, 0.05, 0.10, 0.10],
+                [0.15, 0.15, 0.20, 0.20]]
+    e_bounds = np.array([0, 0.5, 1.0])
+    # bias, tag size = 1
+    m.bias = IMeshTag(2, float)
+    m.bias[:] = [[0.1, 0.3], [0.2, 0.4]]
+
+    m.mesh.save("sampling_mesh.h5m")
+    sampler = Sampler("sampling_mesh.h5m", "src", "cell_number", "cell_fracs",
+                      e_bounds, "bias")
+
+    num_samples = 50000
+    score = 1.0/num_samples
+    num_divs = 2
+    # tally shape (v, c, e)
+    tally = np.zeros(shape=(num_divs, num_divs, num_divs))
+    for i in range(num_samples):
+        sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = sampler.get_src_xyzew()
+        cell_number = sampler.get_src_c()
+        vid = cell_number/10 - 1
+        cid = cell_number%10 - 1
+        eid = 0 if s[3] < 0.5 else 1;
+        wgt = s[4]
+        # check the cell_number
+        if s[0] < 0.5:
+            assert(cell_number in [11, 12])
+        if s[0] > 0.5:
+            assert(cell_number in [21, 22])
+        # check the weight of each subvoxel
+        if vid == 0 and eid == 0:
+            assert(abs(wgt - 1.5)/1.5 < 0.05)
+        if vid == 0 and eid == 1:
+            assert(abs(wgt - 0.5)/0.5 < 0.05)
+        if vid == 1 and eid == 0:
+            assert(abs(wgt - 1.75)/1.75 < 0.05)
+        if vid == 1 and eid == 1:
+            assert(abs(wgt - 0.875)/0.875 < 0.05)
+        # count the tally
+        tally[vid, cid, eid] += score
+
+    # check the real sample rate
+    exp_tally = np.zeros(shape=(2, 2, 2))
+    exp_tally[:] = [[[0.0333, 0.1000],
+                     [0.0667, 0.2000]],
+                    [[0.0857, 0.1714],
+                     [0.1143, 0.2286]]]
+    for v in range(2):
+        for c in range(2):
+            for e in range(2):
+                assert(abs(tally[v, c, e] - exp_tally[v, c, e]) / exp_tally[v, c, e] < 0.05)
 
 @with_setup(None, try_rm_file('tet.h5m'))
 def test_analog_single_tet():
@@ -106,9 +609,9 @@ def test_analog_single_tet():
     m.mesh.save("tet.h5m")
     center = m.ve_center(list(m.iter_ve())[0])
 
-    subtets = [[center, v1, v2, v3], 
-               [center, v1, v2, v4], 
-               [center, v1, v3, v4], 
+    subtets = [[center, v1, v2, v3],
+               [center, v1, v2, v4],
+               [center, v1, v3, v4],
                [center, v2, v3, v4]]
 
     sampler = Sampler("tet.h5m", "src", np.array([0, 1]), False)
@@ -116,13 +619,14 @@ def test_analog_single_tet():
     score = 1.0/num_samples
     tally = np.zeros(shape=(4))
     for i in range(num_samples):
-        s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = sampler.get_src_xyzew()
         assert_equal(s[4], 1.0)
         for i, tet in enumerate(subtets):
             if point_in_tet(tet, [s[0], s[1], s[2]]):
                 tally[i] += score
                 break
-    
+
     for t in tally:
         assert(abs(t - 0.25)/0.25 < 0.2)
 
@@ -135,7 +639,7 @@ def test_uniform():
        in the Theory Manual.
     """
     seed(1953)
-    m = Mesh(structured=True, 
+    m = Mesh(structured=True,
              structured_coords=[[0, 3, 3.5], [0, 1], [0, 1]],
              mats = None)
     m.src = IMeshTag(2, float)
@@ -151,14 +655,15 @@ def test_uniform():
     spatial_tally = np.zeros(shape=(num_divs, num_divs, num_divs))
     e_tally = np.zeros(shape=(4)) # number of phase space groups
     for i in range(num_samples):
-        s = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
         if s[0] < 3.0:
             assert_almost_equal(s[4], 0.7) # hand calcs
         else:
             assert_almost_equal(s[4], 2.8) # hand calcs
 
-        spatial_tally[int(s[0]*num_divs/3.5), 
-                      int(s[1]*num_divs/1.0), 
+        spatial_tally[int(s[0]*num_divs/3.5),
+                      int(s[1]*num_divs/1.0),
                       int(s[2]*num_divs/1.0)]  += score
 
         if s[0] < 3 and s[3] < 0.5:
@@ -189,8 +694,8 @@ def test_bias():
        in the Theory Manual.
     """
     seed(1953)
-    m = Mesh(structured=True, 
-             structured_coords=[[0, 3, 3.5], [0, 1], [0, 1]], 
+    m = Mesh(structured=True,
+             structured_coords=[[0, 3, 3.5], [0, 1], [0, 1]],
              mats = None)
     m.src = IMeshTag(2, float)
     m.src[:] = [[2.0, 1.0], [9.0, 3.0]]
@@ -205,7 +710,8 @@ def test_bias():
     num_divs = 2
     tally = np.zeros(shape=(4))
     for i in range(num_samples):
-        s = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
         if s[0] < 3:
             if s[3] < 0.5:
               assert_almost_equal(s[4], 1.6) # hand calcs
@@ -228,14 +734,14 @@ def test_bias():
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_bias_spatial():
     """This test tests a user-specified biasing scheme for which the only 1
-    bias group is supplied for a source distribution containing two energy 
+    bias group is supplied for a source distribution containing two energy
     groups. This bias group is applied to both energy groups. In this test,
-    the user-supplied bias distribution that was choosen, correspondes to 
+    the user-supplied bias distribution that was choosen, correspondes to
     uniform sampling, so that results can be checked against Case 1 in the
     theory manual.
     """
     seed(1953)
-    m = Mesh(structured=True, 
+    m = Mesh(structured=True,
              structured_coords=[[0, 3, 3.5], [0, 1], [0, 1]],
              mats = None)
     m.src = IMeshTag(2, float)
@@ -253,14 +759,15 @@ def test_bias_spatial():
     spatial_tally = np.zeros(shape=(num_divs, num_divs, num_divs))
     e_tally = np.zeros(shape=(4)) # number of phase space groups
     for i in range(num_samples):
-        s = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = sampler.get_src_xyzew()
         if s[0] < 3.0:
             assert_almost_equal(s[4], 0.7) # hand calcs
         else:
             assert_almost_equal(s[4], 2.8) # hand calcs
 
-        spatial_tally[int(s[0]*num_divs/3.5), 
-                      int(s[1]*num_divs/1.0), 
+        spatial_tally[int(s[0]*num_divs/3.5),
+                      int(s[1]*num_divs/1.0),
                       int(s[2]*num_divs/1.0)]  += score
 
         if s[0] < 3 and s[3] < 0.5:
@@ -284,7 +791,7 @@ def test_bias_spatial():
 
 def test_alias_table():
     """This tests that the AliasTable class produces samples in the ratios
-    consistant with the supplied PDF.
+    consistent with the supplied PDF.
     """
     seed(1953)
     pdf = np.array([0.1, 0.2, 0.7])

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -18,7 +18,7 @@ from pyne.utils import QAWarning
 warnings.simplefilter("ignore", QAWarning)
 
 from pyne.mesh import Mesh, IMeshTag
-from pyne.source_sampling import Sampler, AliasTable, SourceParticle
+from pyne.source_sampling import Sampler, AliasTable, PySourceParticle
 
 def try_rm_file(filename):
     return lambda: os.remove(filename) if os.path.exists(filename) else None
@@ -45,9 +45,9 @@ def test_analog_single_hex():
     tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
 
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
-        c = sampler.get_src_c()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
+        c = src.get_src_c()
         assert_equal(s[4], 1.0) # analog: all weights must be one
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
               int(s[3]*num_divs)] += score
@@ -87,9 +87,9 @@ def test_analog_single_hex_subvoxel_analog():
     tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
 
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         assert_equal(s[4], 1.0) # analog: all weights must be one
         assert_equal(cell_number, 11) # analog: the cell number
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
@@ -130,9 +130,9 @@ def test_single_hex_subvoxel_uniform():
     tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
 
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         assert_equal(s[4], 1.0) # analog: all weights must be one
         assert_equal(cell_number, 11) # analog: the cell number
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
@@ -176,9 +176,9 @@ def test_analog_single_hex_multiple_subvoxel():
     tally = [0.0] * 3
 
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         assert_equal(s[4], 1.0) # analog: all weights must be one
         if int(cell_number) == 11:
             tally[0] += score
@@ -224,9 +224,9 @@ def test_analog_single_hex_multiple_subvoxel_uniform():
     tally = [0.0] * 3
 
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         if int(cell_number) == 11:
             tally[0] += score
         if int(cell_number) == 12:
@@ -261,9 +261,9 @@ def test_analog_multiple_hex():
     num_divs = 2
     tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
     for i in range(num_samples):
-        sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         assert_equal(s[4], 1.0)
         tally[int(s[0]*num_divs), int(s[1]*num_divs), int(s[2]*num_divs),
               int(s[3]*num_divs)] += score
@@ -304,9 +304,9 @@ def test_analog_multiple_hex_subvoxel():
     num_divs = 2
     tally = np.zeros(shape=(num_divs, num_divs, num_divs, num_divs))
     for i in range(num_samples):
-        sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         assert_equal(s[4], 1.0)
         assert_equal(cell_number, 4*int(s[0]*num_divs) + 2*int(s[1]*num_divs)
                      + int(s[2]*num_divs) + 1)
@@ -352,9 +352,9 @@ def test_analog_multiple_hex_subvoxel_uniform():
     num_divs = 2
     tally = [0.0] * 8
     for i in range(num_samples):
-        sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         # check the cell_number
         assert_equal(cell_number, 4*int(s[0]*num_divs) + 2*int(s[1]*num_divs)
                      + int(s[2]*num_divs))
@@ -412,9 +412,9 @@ def test_subvoxel_multiple_hex_bias_1():
     # tally shape (v, c, e)
     tally = np.zeros(shape=(num_divs, num_divs, num_divs))
     for i in range(num_samples):
-        sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         vid = cell_number/10 - 1
         cid = cell_number%10 - 1
         eid = 0 if s[3] < 0.5 else 1;
@@ -487,9 +487,9 @@ def test_subvoxel_multiple_hex_bias_max_num_cells_num_e_groups():
     exp_wgt = np.zeros(shape=(num_divs, num_divs, num_divs))
     exp_wgt[:] = [[[1.0, 1.0], [1.25, 0.83]], [[1.25, 1.25], [0.83, 0.83]]]
     for i in range(num_samples):
-        sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         vid = cell_number/10 - 1
         cid = cell_number%10 - 1
         eid = 0 if s[3] < 0.5 else 1;
@@ -554,9 +554,9 @@ def test_subvoxel_multiple_hex_bias_e_groups():
     # tally shape (v, c, e)
     tally = np.zeros(shape=(num_divs, num_divs, num_divs))
     for i in range(num_samples):
-        sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        s = sampler.get_src_xyzew()
-        cell_number = sampler.get_src_c()
+        src = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = src.get_src_xyzew()
+        cell_number = src.get_src_c()
         vid = cell_number/10 - 1
         cid = cell_number%10 - 1
         eid = 0 if s[3] < 0.5 else 1;
@@ -619,8 +619,8 @@ def test_analog_single_tet():
     score = 1.0/num_samples
     tally = np.zeros(shape=(4))
     for i in range(num_samples):
-        sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        s = sampler.get_src_xyzew()
+        src = sampler.particle_birth([uniform(0, 1) for x in range(6)])
+        s = src.get_src_xyzew()
         assert_equal(s[4], 1.0)
         for i, tet in enumerate(subtets):
             if point_in_tet(tet, [s[0], s[1], s[2]]):
@@ -655,8 +655,8 @@ def test_uniform():
     spatial_tally = np.zeros(shape=(num_divs, num_divs, num_divs))
     e_tally = np.zeros(shape=(4)) # number of phase space groups
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
         if s[0] < 3.0:
             assert_almost_equal(s[4], 0.7) # hand calcs
         else:
@@ -710,8 +710,8 @@ def test_bias():
     num_divs = 2
     tally = np.zeros(shape=(4))
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
         if s[0] < 3:
             if s[3] < 0.5:
               assert_almost_equal(s[4], 1.6) # hand calcs
@@ -759,8 +759,8 @@ def test_bias_spatial():
     spatial_tally = np.zeros(shape=(num_divs, num_divs, num_divs))
     e_tally = np.zeros(shape=(4)) # number of phase space groups
     for i in range(num_samples):
-        sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
-        s = sampler.get_src_xyzew()
+        src = sampler.particle_birth(np.array([uniform(0, 1) for x in range(6)]))
+        s = src.get_src_xyzew()
         if s[0] < 3.0:
             assert_almost_equal(s[4], 0.7) # hand calcs
         else:


### PR DESCRIPTION
PR #974 contains only the subvoxel-analog mode. However, the analog, uniform and user define modes are highly related with each other with `if - else` clauses. 

It's better to put them in one PR. So I closed #974  and put these three (analog, uniform and user define) subvoxel sampling method together in this PR. 

Major changes:
1. Add functions and variable for subvoxel source sampling. 
2. Add test functions to these three sampling mode. 