### PR TITLE
 Added details about decay heat function units

### DIFF
--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -608,7 +608,9 @@ cdef class _Material:
 
 
     def decay_heat(self):
-        """This provides the decay heat using the comp of the the Material.
+        """This provides the decay heat using the comp of the the Material. It
+        assumes that the composition of material is given in units of [grams]
+        and returns decay heat in units of [MW/material object total mass].  
 
         Returns
         -------

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -610,7 +610,7 @@ cdef class _Material:
     def decay_heat(self):
         """This provides the decay heat using the comp of the the Material. It
         assumes that the composition of material is given in units of [grams]
-        and returns decay heat in units of [MW/material object total mass].  
+        and returns decay heat in units of [MW].  
 
         Returns
         -------


### PR DESCRIPTION
The decay heat function units is in MW/material object total mass. These lines were added for the sake of clarity for future users. 