### PR TITLE
change ebounds unit to MeV

### DIFF
--- a/news/change_ebounds_unit_to_MeV.rst
+++ b/news/change_ebounds_unit_to_MeV.rst
@@ -1,0 +1,11 @@
+**Added:** None
+
+**Changed:** Unit of e_bounds changed from eV to MeV
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -620,7 +620,7 @@ def phtn_src_energy_bounds(input_file):
     Returns
     -------
     e_bounds : list of floats
-        The lower and upper energy bounds for the photon_source discretization.
+    The lower and upper energy bounds for the photon_source discretization. Unit: eV.
     """
     phtn_src_lines = ""
     with open(input_file, 'r') as f:

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -180,6 +180,7 @@ def step2():
     e_bounds = phtn_src_energy_bounds("alara_geom")
     e_bounds_str = ""
     for e in e_bounds:
+        e = e/1e6 # convert unit to MeV
         e_bounds_str += "{0}\n".format(e)
     with open("e_bounds", 'w') as f:
         f.write(e_bounds_str)


### PR DESCRIPTION
Major change:
1. Change the unit of `e_bounds` from `eV` to `MeV`.  The default energy unit of DAG-MCNP is `MeV`.