### PR TITLE
R2s fix wrong mode doc

### DIFF
--- a/news/r2s_fix_wrong_mode_doc
+++ b/news/r2s_fix_wrong_mode_doc
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** 
+* Correct the wrong mode description comment in pyne/src/source_sampling.h
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -46,7 +46,7 @@ extern "C" {
 namespace pyne {
 
   /// MCNP interface for source sampling setup
-  /// \param mode The sampling mode: 1 = analog, 2 = uniform, 3 = user-specified
+  /// \param mode The sampling mode: 0 = analog, 1 = uniform, 2 = user-specified
   void sampling_setup_(int* mode);
   /// MCNP interface to sample particle birth parameters after sampling setup
   /// \param rands Six pseudo-random numbers supplied from the Fortran side.


### PR DESCRIPTION
Major change:
1. Correct the wrong mode description comment in `pyne/src/source_sampling.h`.