### PR TITLE
R2s introduce map of tag names

### DIFF
--- a/news/r2s_intorduce_map_of_tag_names.rst
+++ b/news/r2s_intorduce_map_of_tag_names.rst
@@ -1,0 +1,13 @@
+**Added:** 
+* Constructor of Sampler using map<string, string> as an input parameter
+* A test function to test the added constructor
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/r2s_intorduce_map_of_tag_names.rst
+++ b/news/r2s_intorduce_map_of_tag_names.rst
@@ -1,6 +1,7 @@
 **Added:** 
 * Constructor of Sampler using map<string, string> as an input parameter
 * A test function to test the added constructor
+* A test function to test input check of tag_names
 
 **Changed:** None
 

--- a/news/r2s_intorduce_map_of_tag_names.rst
+++ b/news/r2s_intorduce_map_of_tag_names.rst
@@ -1,4 +1,5 @@
 **Added:** 
+
 * Constructor of Sampler using map<string, string> as an input parameter
 * A test function to test the added constructor
 * A test function to test input check of tag_names

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -41,7 +41,6 @@ cdef extern from "source_sampling.h" namespace "pyne":
         # attributes
 
         # methods
-        cpp_vector[double] get_xyzew() except +
         double get_x() except +
         double get_y() except +
         double get_z() except +

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -60,6 +60,7 @@ cdef extern from "source_sampling.h" namespace "pyne":
         Sampler(std_string, std_string, cpp_vector[double]) except +
         Sampler(std_string, std_string, cpp_vector[double], std_string) except +
         Sampler(std_string, std_string, cpp_vector[double], cpp_bool) except +
+        Sampler(cpp_map, cpp_vector, int) except +
 
         # attributes
 

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -60,7 +60,7 @@ cdef extern from "source_sampling.h" namespace "pyne":
         Sampler(std_string, std_string, cpp_vector[double]) except +
         Sampler(std_string, std_string, cpp_vector[double], std_string) except +
         Sampler(std_string, std_string, cpp_vector[double], cpp_bool) except +
-        Sampler(cpp_map[std_string, std_string], cpp_vector[double], int) except +
+        Sampler(std_string, cpp_map[std_string, std_string], cpp_vector[double], int) except +
 
         # attributes
 

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -11,6 +11,7 @@
 from libcpp cimport bool as cpp_bool
 from libcpp.string cimport string as std_string
 from libcpp.vector cimport vector as cpp_vector
+from libcpp.map cimport map as cpp_map
 
 cdef extern from "source_sampling.h" namespace "pyne":
 

--- a/pyne/cpp_source_sampling.pxd
+++ b/pyne/cpp_source_sampling.pxd
@@ -60,7 +60,7 @@ cdef extern from "source_sampling.h" namespace "pyne":
         Sampler(std_string, std_string, cpp_vector[double]) except +
         Sampler(std_string, std_string, cpp_vector[double], std_string) except +
         Sampler(std_string, std_string, cpp_vector[double], cpp_bool) except +
-        Sampler(cpp_map, cpp_vector, int) except +
+        Sampler(cpp_map[std_string, std_string], cpp_vector[double], int) except +
 
         # attributes
 

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -189,13 +189,13 @@ cdef class AliasTable:
     pass
 
 
-cdef cpp_vector[double] convert_e_bounds(e_bounds):
-    """convert_e_bounds(rands)
+cdef cpp_vector[double] convert_nparray_to_vector(array):
+    """convert_nparray_to_vector
     Convert python np.ndarray into cpp_vector[double]
     
     Parameters
     ----------
-    e_bounds : np.ndarray
+    array : np.ndarray
     
     Returns
     -------
@@ -203,16 +203,15 @@ cdef cpp_vector[double] convert_e_bounds(e_bounds):
     
     """
 
-    cdef cpp_vector[double] e_bounds_proxy
-    cdef int ie_bounds
-    cdef int e_bounds_size
-    cdef double * e_bounds_data
-    e_bounds = np.array(e_bounds, dtype=np.float64)
-    e_bounds_size = len(e_bounds)
-    e_bounds_data = <double *> np.PyArray_DATA(<np.ndarray> e_bounds)
-    e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
-    memcpy(<void*> &e_bounds_proxy[0], e_bounds_data, sizeof(double) *  e_bounds_size)
-    return e_bounds_proxy
+    cdef cpp_vector[double] array_proxy
+    cdef int array_size
+    cdef double * array_data
+    array = np.array(array, dtype=np.float64)
+    array_size = len(array)
+    array_data = <double *> np.PyArray_DATA(<np.ndarray> array)
+    array_proxy = cpp_vector[double](<size_t> array_size)
+    memcpy(<void*> &array_proxy[0], array_data, sizeof(double) *  array_size)
+    return array_proxy
 
 
 
@@ -302,7 +301,7 @@ cdef class Sampler:
         src_tag_name_bytes = src_tag_name.encode()
         bias_tag_name_bytes = bias_tag_name.encode()
         # convert e_bounds
-        cdef cpp_vector[double] e_bounds_proxy = convert_e_bounds(e_bounds)
+        cdef cpp_vector[double] e_bounds_proxy = convert_nparray_to_vector(e_bounds)
         # construct sampler
         self._inst = new cpp_source_sampling.Sampler(
                 std_string(<char *> filename_bytes),
@@ -339,7 +338,7 @@ cdef class Sampler:
         filename_bytes = filename.encode()
         src_tag_name_bytes = src_tag_name.encode()
         # convert e_bounds
-        cdef cpp_vector[double] e_bounds_proxy = convert_e_bounds(e_bounds)
+        cdef cpp_vector[double] e_bounds_proxy = convert_nparray_to_vector(e_bounds)
         # construct sampler
         self._inst = new cpp_source_sampling.Sampler(
                 std_string(<char *> filename_bytes),
@@ -373,7 +372,7 @@ cdef class Sampler:
         for key, value in tag_names.items():
             cpp_tag_names[key] = value
         # convert e_bounds
-        cdef cpp_vector[double] e_bounds_proxy = convert_e_bounds(e_bounds)
+        cdef cpp_vector[double] e_bounds_proxy = convert_nparray_to_vector(e_bounds)
         # construct sampler
         self._inst = new cpp_source_sampling.Sampler(
                 std_string(<char *> filename_bytes),

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -374,7 +374,7 @@ cdef class Sampler:
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
         self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, <bint> uniform)
 
-    def _sampler_sampler_5(self, names, e_bounds, mode):
+    def _sampler_sampler_2(self, names, e_bounds, mode):
         """Sampler(self, names, e_bounds, mode)
         
         Constuctor for overall Sampler
@@ -429,6 +429,7 @@ cdef class Sampler:
     
     _sampler_sampler_0_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, str), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("bias_tag_name", str)))
     _sampler_sampler_1_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, bool), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("uniform", bool)))
+    _sampler_sampler_2_argtypes = frozenset(((0, dict), (1, np.ndarray), (3, int), ("names", dict), ("e_bounds",  np.ndarray), ("mode", int)))
     
     def __init__(self, *args, **kwargs):
         """Sampler(self, filename, src_tag_name, e_bounds, uniform)
@@ -480,6 +481,9 @@ cdef class Sampler:
         if types <= self._sampler_sampler_1_argtypes:
             self._sampler_sampler_1(*args, **kwargs)
             return
+        if types <= self._sampler_sampler_2_argtypes:
+            self._sampler_sampler_2(*args, **kwargs)
+            return
         # duck-typed dispatch based on whatever works!
         try:
             self._sampler_sampler_0(*args, **kwargs)
@@ -492,6 +496,11 @@ cdef class Sampler:
         except (RuntimeError, TypeError, NameError):
             pass
         raise RuntimeError('method __init__() could not be dispatched')
+        try:
+            self._sampler_sampler_2(*args, **kwargs)
+            return
+        except (RuntimeError, TypeError, NameError):
+            pass
     
     def __dealloc__(self):
         if self._free_inst and self._inst is not NULL:

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -191,7 +191,7 @@ cdef class AliasTable:
 
 def convert_e_bounds(e_bounds):
     """convert_e_bounds(rands)
-    Convert python np.ndarray into vector< double> 
+    Convert python np.ndarray into cpp_vector[double]
     
     Parameters
     ----------
@@ -199,7 +199,7 @@ def convert_e_bounds(e_bounds):
     
     Returns
     -------
-    res1 : std::vector< double >
+    res1 : cpp_vector[double]
     
     """
 

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -403,7 +403,7 @@ cdef class Sampler:
                                              (2, np.ndarray),
                                              (3, int),
                                              ("filename", str),
-                                             ("names", dict),
+                                             ("tag_names", dict),
                                              ("e_bounds",  np.ndarray),
                                              ("mode", int)))
     

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -495,12 +495,12 @@ cdef class Sampler:
             return
         except (RuntimeError, TypeError, NameError):
             pass
-        raise RuntimeError('method __init__() could not be dispatched')
         try:
             self._sampler_sampler_2(*args, **kwargs)
             return
         except (RuntimeError, TypeError, NameError):
             pass
+        raise RuntimeError('method __init__() could not be dispatched')
     
     def __dealloc__(self):
         if self._free_inst and self._inst is not NULL:

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -189,7 +189,7 @@ cdef class AliasTable:
     pass
 
 
-def convert_e_bounds(e_bounds):
+cdef cpp_vector[double] convert_e_bounds(e_bounds):
     """convert_e_bounds(rands)
     Convert python np.ndarray into cpp_vector[double]
     

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -532,27 +532,6 @@ cdef class SourceParticle:
     def __cinit__(self, double x, double y, double z, double e, double w, int c):
         self.c_src = cpp_source_sampling.SourceParticle(x, y, z, e, w, c)
     
-    def get_xyzew(self):
-        """get_xyzew(self)
-        Get source particle x, y, z, e and w
-        
-        Parameters
-        ----------
-        None
-        
-        Returns
-        -------
-        res1 : std::vector< double >
-        
-        """
-        cdef cpp_vector[double] rtnval
-        cdef np.npy_intp rtnval_proxy_shape[1]
-        rtnval = self.c_src.get_xyzew()
-        rtnval_proxy_shape[0] = <np.npy_intp> rtnval.size()
-        rtnval_proxy = np.PyArray_SimpleNewFromData(1, rtnval_proxy_shape, np.NPY_FLOAT64, &rtnval[0])
-        rtnval_proxy = np.PyArray_Copy(rtnval_proxy)
-        return rtnval_proxy
-
     @property
     def c(self):
         return self.c_src.get_c()

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -268,25 +268,6 @@ cdef class Sampler:
         Returns
         -------
         None
-        
-        ################################################################
-        
-        Constuctor for analog and uniform sampling
-        
-        Parameters
-        ----------
-        e_bounds : std::vector< double >
-        
-        src_tag_name : std::string
-        
-        uniform : bool
-        
-        filename : std::string
-        
-        Returns
-        -------
-        None
-        
         """
         cdef char * filename_proxy
         cdef char * src_tag_name_proxy
@@ -333,25 +314,6 @@ cdef class Sampler:
         Returns
         -------
         None
-        
-        ################################################################
-        
-        Constuctor for analog and uniform sampling
-        
-        Parameters
-        ----------
-        e_bounds : std::vector< double >
-        
-        src_tag_name : std::string
-        
-        uniform : bool
-        
-        filename : std::string
-        
-        Returns
-        -------
-        None
-        
         """
         cdef char * filename_proxy
         cdef char * src_tag_name_proxy
@@ -388,21 +350,6 @@ cdef class Sampler:
         Returns
         -------
         None
-        
-        ################################################################
-        
-        Parameters
-        ----------
-        e_bounds : std::vector< double >
-        
-        names : std::map<std::string, std::string>
-        
-        mode : int
-        
-        Returns
-        -------
-        None
-        
         """
         cdef cpp_vector[double] e_bounds_proxy
         cdef int ie_bounds
@@ -424,12 +371,34 @@ cdef class Sampler:
             e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
             for ie_bounds in range(e_bounds_size):
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
-        self._inst = new cpp_source_sampling.Sampler(<cpp_map[std_string, std_string]> cpp_names, <cpp_vector[double]> e_bounds_proxy, <int> mode)
+        self._inst = new cpp_source_sampling.Sampler(
+                <cpp_map[std_string, std_string]> cpp_names,
+                <cpp_vector[double]> e_bounds_proxy,
+                <int> mode)
 
     
-    _sampler_sampler_0_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, str), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("bias_tag_name", str)))
-    _sampler_sampler_1_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, bool), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("uniform", bool)))
-    _sampler_sampler_2_argtypes = frozenset(((0, dict), (1, np.ndarray), (3, int), ("names", dict), ("e_bounds",  np.ndarray), ("mode", int)))
+    _sampler_sampler_0_argtypes = frozenset(((0, str),
+                                             (1, str),
+                                             (2, np.ndarray),
+                                             (3, str),
+                                             ("filename", str),
+                                             ("src_tag_name", str),
+                                             ("e_bounds", np.ndarray),
+                                             ("bias_tag_name", str)))
+    _sampler_sampler_1_argtypes = frozenset(((0, str),
+                                             (1, str),
+                                             (2, np.ndarray),
+                                             (3, bool),
+                                             ("filename", str),
+                                             ("src_tag_name", str),
+                                             ("e_bounds", np.ndarray),
+                                             ("uniform", bool)))
+    _sampler_sampler_2_argtypes = frozenset(((0, dict),
+                                             (1, np.ndarray),
+                                             (3, int),
+                                             ("names", dict),
+                                             ("e_bounds",  np.ndarray),
+                                             ("mode", int)))
     
     def __init__(self, *args, **kwargs):
         """Sampler(self, filename, src_tag_name, e_bounds, uniform)
@@ -452,25 +421,6 @@ cdef class Sampler:
         Returns
         -------
         None
-        
-        ################################################################
-        
-        Constuctor for analog and uniform sampling
-        
-        Parameters
-        ----------
-        e_bounds : std::vector< double >
-        
-        src_tag_name : std::string
-        
-        uniform : bool
-        
-        filename : std::string
-        
-        Returns
-        -------
-        None
-        
         """
         types = set([(i, type(a)) for i, a in enumerate(args)])
         types.update([(k, type(v)) for k, v in kwargs.items()])

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -336,14 +336,16 @@ cdef class Sampler:
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
         self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, <bint> uniform)
 
-    def _sampler_sampler_2(self, names, e_bounds, mode):
-        """Sampler(self, names, e_bounds, mode)
+    def _sampler_sampler_2(self, filename, tag_names, e_bounds, mode):
+        """Sampler(self, filename, tag_names, e_bounds, mode)
         
         Constuctor for overall Sampler
         
         Parameters
         ----------
-        names : std::map<std::string, std::string>
+        filename : std::string
+        
+        tag_names : std::map<std::string, std::string>
         
         e_bounds : std::vector< double >
         
@@ -351,15 +353,18 @@ cdef class Sampler:
         -------
         None
         """
+        cdef char * filename_proxy
         cdef cpp_vector[double] e_bounds_proxy
         cdef int ie_bounds
         cdef int e_bounds_size
         cdef double * e_bounds_data
-        # Convert names
-        cdef cpp_map[std_string, std_string] cpp_names = cpp_map[std_string, std_string]()
-        for key, value in names.items():
-            cpp_names[key] = value
-
+        # convert filename
+        filename_bytes = filename.encode()
+        # Convert tag_names
+        cdef cpp_map[std_string, std_string] cpp_tag_names = cpp_map[std_string, std_string]()
+        for key, value in tag_names.items():
+            cpp_tag_names[key] = value
+        # convert e_bounds
         # e_bounds is a ('vector', 'float64', 0)
         e_bounds_size = len(e_bounds)
         if isinstance(e_bounds, np.ndarray) and (<np.ndarray> e_bounds).descr.type_num == np.NPY_FLOAT64:
@@ -372,7 +377,8 @@ cdef class Sampler:
             for ie_bounds in range(e_bounds_size):
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
         self._inst = new cpp_source_sampling.Sampler(
-                <cpp_map[std_string, std_string]> cpp_names,
+                std_string(<char *> filename_bytes),
+                <cpp_map[std_string, std_string]> cpp_tag_names,
                 <cpp_vector[double]> e_bounds_proxy,
                 <int> mode)
 
@@ -393,9 +399,11 @@ cdef class Sampler:
                                              ("src_tag_name", str),
                                              ("e_bounds", np.ndarray),
                                              ("uniform", bool)))
-    _sampler_sampler_2_argtypes = frozenset(((0, dict),
-                                             (1, np.ndarray),
+    _sampler_sampler_2_argtypes = frozenset(((0, str),
+                                             (1, dict),
+                                             (2, np.ndarray),
                                              (3, int),
+                                             ("filename", str),
                                              ("names", dict),
                                              ("e_bounds",  np.ndarray),
                                              ("mode", int)))

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -372,7 +372,61 @@ cdef class Sampler:
             for ie_bounds in range(e_bounds_size):
                 e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
         self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, <bint> uniform)
+
+    def _sampler_sampler_5(self, names, e_bounds, mode):
+        """Sampler(self, names, e_bounds, mode)
+        
+        Constuctor for overall Sampler
+        
+        Parameters
+        ----------
+        names : std::map<std::string, std::string>
+        
+        e_bounds : std::vector< double >
+        
+        Returns
+        -------
+        None
+        
+        ################################################################
+        
+        Parameters
+        ----------
+        e_bounds : std::vector< double >
+        
+        names : std::map<std::string, std::string>
+        
+        mode : int
+        
+        Returns
+        -------
+        None
+        
+        """
+        cdef char * filename_proxy
+        cdef char * src_tag_name_proxy
+        cdef cpp_vector[double] e_bounds_proxy
+        cdef int ie_bounds
+        cdef int e_bounds_size
+        cdef double * e_bounds_data
+        cdef char * bias_tag_name_proxy
+        filename_bytes = filename.encode()
+        src_tag_name_bytes = src_tag_name.encode()
+        # e_bounds is a ('vector', 'float64', 0)
+        e_bounds_size = len(e_bounds)
+        if isinstance(e_bounds, np.ndarray) and (<np.ndarray> e_bounds).descr.type_num == np.NPY_FLOAT64:
+            e_bounds_data = <double *> np.PyArray_DATA(<np.ndarray> e_bounds)
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = e_bounds_data[ie_bounds]
+        else:
+            e_bounds_proxy = cpp_vector[double](<size_t> e_bounds_size)
+            for ie_bounds in range(e_bounds_size):
+                e_bounds_proxy[ie_bounds] = <double> e_bounds[ie_bounds]
+        bias_tag_name_bytes = bias_tag_name.encode()
+        self._inst = new cpp_source_sampling.Sampler(std_string(<char *> filename_bytes), std_string(<char *> src_tag_name_bytes), e_bounds_proxy, std_string(<char *> bias_tag_name_bytes))
     
+
     
     _sampler_sampler_0_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, str), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("bias_tag_name", str)))
     _sampler_sampler_1_argtypes = frozenset(((0, str), (1, str), (2, np.ndarray), (3, bool), ("filename", str), ("src_tag_name", str), ("e_bounds", np.ndarray), ("uniform", bool)))

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -190,8 +190,19 @@ cdef class AliasTable:
 
 
 def convert_e_bounds(e_bounds):
+    """convert_e_bounds(rands)
+    Convert python np.ndarray into vector< double> 
+    
+    Parameters
+    ----------
+    e_bounds : np.ndarray
+    
+    Returns
+    -------
+    res1 : std::vector< double >
+    
     """
-    """
+
     cdef cpp_vector[double] e_bounds_proxy
     cdef int ie_bounds
     cdef int e_bounds_size

--- a/pyne/source_sampling.pyx
+++ b/pyne/source_sampling.pyx
@@ -424,10 +424,10 @@ cdef class Sampler:
         if types <= self._sampler_sampler_0_argtypes:
             self._sampler_sampler_0(*args, **kwargs)
             return
-        if types <= self._sampler_sampler_1_argtypes:
+        elif types <= self._sampler_sampler_1_argtypes:
             self._sampler_sampler_1(*args, **kwargs)
             return
-        if types <= self._sampler_sampler_2_argtypes:
+        elif types <= self._sampler_sampler_2_argtypes:
             self._sampler_sampler_2(*args, **kwargs)
             return
         # duck-typed dispatch based on whatever works!

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -90,8 +90,23 @@ pyne::Sampler::Sampler(std::string filename,
   }
 
   // find out the src_tag_name and bias_tag_name
-  src_tag_name = tag_names["src_tag_name"];
-  bias_tag_name = tag_names["bias_tag_name"];
+  if (tag_names.find("src_tag_name") == tag_names.end()) {
+    // src_tag_name not found
+    throw std::invalid_argument("src_tag_name not found");
+  } else {
+    // found src_tag_name
+    src_tag_name = tag_names["src_tag_name"];
+  }
+  if (bias_mode == USER) {
+    // bias_tag_name required
+    if (tag_names.find("bias_tag_name") == tag_names.end()) {
+      // bias_tag_name not found
+      throw std::invalid_argument("bias_tag_name not dound");
+    } else {
+      // found bias_tag_name
+      bias_tag_name = tag_names["bias_tag_name"];
+    }
+  }
   setup();
 }
 

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -74,6 +74,26 @@ pyne::Sampler::Sampler(std::string filename,
   setup();
 }
 
+pyne::Sampler::Sampler(std::map<std::string, std::string> names, 
+                 std::vector<double> e_bounds, 
+                 int mode)
+  : e_bounds(e_bounds) {
+  // determine the bias_mode
+  if (mode == 0){
+    bias_mode = ANALOG; 
+  } else if (mode == 1) {
+    bias_mode = UNIFORM;
+  } else if (mode == 2) {
+    bias_mode = USER;
+  }
+
+  // find out the filename, src_tag_name and bias_tag_name
+  filename = names["filename"];
+  src_tag_name = names["src_tag_name"];
+  bias_tag_name = names["bias_tag_name"];
+  setup();
+}
+
 pyne::SourceParticle pyne::Sampler::particle_birth(std::vector<double> rands) {
   // select mesh volume and energy group
   //

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -435,15 +435,3 @@ pyne::SourceParticle::SourceParticle(double _x, double _y, double _z,
 
 pyne::SourceParticle::~SourceParticle() {};
 
-std::vector<double> pyne::SourceParticle::get_xyzew() {
-    std::vector<double> xyzew;
-    xyzew.push_back(x);
-    xyzew.push_back(y);
-    xyzew.push_back(z);
-    xyzew.push_back(e);
-    xyzew.push_back(w);
-    return xyzew;
-}
-
-
-

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -74,10 +74,12 @@ pyne::Sampler::Sampler(std::string filename,
   setup();
 }
 
-pyne::Sampler::Sampler(std::map<std::string, std::string> names, 
+pyne::Sampler::Sampler(std::string filename,
+                 std::map<std::string, std::string> tag_names,
                  std::vector<double> e_bounds, 
                  int mode)
-  : e_bounds(e_bounds) {
+  : filename(filename),
+    e_bounds(e_bounds) {
   // determine the bias_mode
   if (mode == 0){
     bias_mode = ANALOG; 
@@ -88,9 +90,8 @@ pyne::Sampler::Sampler(std::map<std::string, std::string> names,
   }
 
   // find out the filename, src_tag_name and bias_tag_name
-  filename = names["filename"];
-  src_tag_name = names["src_tag_name"];
-  bias_tag_name = names["bias_tag_name"];
+  src_tag_name = tag_names["src_tag_name"];
+  bias_tag_name = tag_names["bias_tag_name"];
   setup();
 }
 

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -89,7 +89,7 @@ pyne::Sampler::Sampler(std::string filename,
     bias_mode = USER;
   }
 
-  // find out the filename, src_tag_name and bias_tag_name
+  // find out the src_tag_name and bias_tag_name
   src_tag_name = tag_names["src_tag_name"];
   bias_tag_name = tag_names["bias_tag_name"];
   setup();

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -111,7 +111,6 @@ namespace pyne {
                    int c);
     ~SourceParticle();
 
-    std::vector<double> get_xyzew();
     double get_x() {return x;};
     double get_y() {return y;};
     double get_z() {return z;};

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -33,6 +33,7 @@
 #include <stdexcept> 
 #include <sstream>
 #include <string>
+#include <map>
 
 #include "moab/Range.hpp"
 #include "moab/Core.hpp"

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -161,10 +161,11 @@ namespace pyne {
             std::vector<double> e_bounds, 
             std::string bias_tag_name);
     /// Constuctor for overall sampler
-    /// \param names The map of filename, src_tag_name and bias_tag_name
+    /// \param filename The filename of the h5m file
+    /// \param tag_names The map of src_tag_name and bias_tag_name
     /// \param e_bounds The energy boundaries, note there are N + 1 energy
     ///                 bounds for N energy groups
-    /// \param mode If mode number, 1, 2 or 3
+    /// \param mode The mode number, 0, 1 or 2
     Sampler(std::string filename,
             std::map<std::string, std::string> tag_names,
             std::vector<double> e_bounds,

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -160,12 +160,6 @@ namespace pyne {
             std::string src_tag_name, 
             std::vector<double> e_bounds, 
             std::string bias_tag_name);
-    /// Samples particle birth parameters
-    /// \param rands Six pseudo-random numbers in range [0, 1].
-    /// \return A SourceParticle object containing the x position, y, position,
-    ///         z, position, e, energy and w, weight of a particle.
-    pyne::SourceParticle particle_birth(std::vector<double> rands);
-
     /// Constuctor for overall sampler
     /// \param names The map of filename, src_tag_name and bias_tag_name
     /// \param e_bounds The energy boundaries, note there are N + 1 energy
@@ -173,8 +167,14 @@ namespace pyne {
     /// \param mode If mode number, 1, 2 or 3
     Sampler(std::string filename,
             std::map<std::string, std::string> tag_names,
-            std::vector<double> e_bounds, 
+            std::vector<double> e_bounds,
             int mode);
+
+    /// Samples particle birth parameters
+    /// \param rands Six pseudo-random numbers in range [0, 1].
+    /// \return A SourceParticle object containing the x position, y, position,
+    ///         z, position, e, energy and w, weight of a particle.
+    pyne::SourceParticle particle_birth(std::vector<double> rands);
 
     ~Sampler() {
       delete mesh;

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -166,6 +166,16 @@ namespace pyne {
     ///         z, position, e, energy and w, weight of a particle.
     pyne::SourceParticle particle_birth(std::vector<double> rands);
 
+    /// Constuctor for overall sampler
+    /// \param names The map of filename, src_tag_name and bias_tag_name
+    /// \param e_bounds The energy boundaries, note there are N + 1 energy
+    ///                 bounds for N energy groups
+    /// \param mode If mode number, 1, 2 or 3
+    Sampler(std::string filename,
+            std::map<std::string, std::string> tag_names,
+            std::vector<double> e_bounds, 
+            int mode);
+
     ~Sampler() {
       delete mesh;
       delete at;

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -42,8 +42,6 @@ def test_single_tet_tag_names_map():
     filename = "sampling_mesh.h5m"
 
     # right condition
-    tag_names = {"src_tag_name": "src",
-                 "bias_tag_name": "bias"}
     tag_names = {"src_tag_name": "src"}
     e_bounds = np.array([0, 1])
     sampler = Sampler(filename, tag_names, e_bounds, 0)

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -37,7 +37,8 @@ def test_analog_single_hex():
     m.src = IMeshTag(1, float)
     m.src[0] = 1.0
     m.mesh.save("sampling_mesh.h5m")
-    sampler = Sampler("sampling_mesh.h5m", "src", np.array([0, 1]), False)
+    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src"}
+    sampler = Sampler(names, np.array([0, 1]), 0)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -69,7 +70,8 @@ def test_analog_multiple_hex():
     m.src = IMeshTag(2, float)
     m.src[:] = np.ones(shape=(8,2))
     m.mesh.save("sampling_mesh.h5m")
-    sampler = Sampler("sampling_mesh.h5m", "src", np.array([0, 0.5, 1]), False)
+    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src"}
+    sampler = Sampler(names, np.array([0, 0.5, 1]), 0)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -111,48 +113,8 @@ def test_analog_single_tet():
                [center, v1, v3, v4], 
                [center, v2, v3, v4]]
 
-    sampler = Sampler("tet.h5m", "src", np.array([0, 1]), False)
-    num_samples = 5000
-    score = 1.0/num_samples
-    tally = np.zeros(shape=(4))
-    for i in range(num_samples):
-        s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        assert_equal(s.w, 1.0)
-        for i, tet in enumerate(subtets):
-            if point_in_tet(tet, [s.x, s.y, s.z]):
-                tally[i] += score
-                break
-    
-    for t in tally:
-        assert(abs(t - 0.25)/0.25 < 0.2)
-
-@with_setup(None, try_rm_file('tet.h5m'))
-def test_analog_single_tet_map():
-    """This test tests uniform sampling within a single tetrahedron. This is
-    done by dividing the tetrahedron in 4 smaller tetrahedrons and ensuring
-    that each sub-tet is sampled equally.
-    """
-    seed(1953)
-    mesh = iMesh.Mesh()
-    v1 = [0, 0, 0]
-    v2 = [1, 0, 0]
-    v3 = [0, 1, 0]
-    v4 = [0, 0, 1]
-    verts = mesh.createVtx([v1, v2, v3, v4])
-    mesh.createEnt(iMesh.Topology.tetrahedron, verts)
-    m = Mesh(structured=False, mesh=mesh)
-    m.src = IMeshTag(1, float)
-    m.src[:] = np.array([1])
-    m.mesh.save("tet.h5m")
-    center = m.ve_center(list(m.iter_ve())[0])
-
-    subtets = [[center, v1, v2, v3], 
-               [center, v1, v2, v4], 
-               [center, v1, v3, v4], 
-               [center, v2, v3, v4]]
-
-    names = {"filename":"tet.h5m", "src_tag_name":"src"}
-    sampler = Sampler(names, np.array([0, 1]), False)
+    names = {"filename": "tet.h5m", "src_tag_name": "src"}
+    sampler = Sampler(names, np.array([0, 1]), 0)
     num_samples = 5000
     score = 1.0/num_samples
     tally = np.zeros(shape=(4))
@@ -183,7 +145,8 @@ def test_uniform():
     m.src[:] = [[2.0, 1.0], [9.0, 3.0]]
     e_bounds = np.array([0, 0.5, 1.0])
     m.mesh.save("sampling_mesh.h5m")
-    sampler = Sampler("sampling_mesh.h5m", "src", e_bounds, True)
+    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src"}
+    sampler = Sampler(names, e_bounds, 1)
 
     num_samples = 10000
     score = 1.0/num_samples
@@ -239,7 +202,9 @@ def test_bias():
     m.bias = IMeshTag(2, float)
     m.bias[:] = [[1.0, 2.0], [3.0, 3.0]]
     m.mesh.save("sampling_mesh.h5m")
-    sampler = Sampler("sampling_mesh.h5m", "src", e_bounds, "bias")
+    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src",
+             "bias_tag_name": "bias"}
+    sampler = Sampler(names, e_bounds, 2)
 
     num_samples = 10000
     score = 1.0/num_samples
@@ -285,7 +250,9 @@ def test_bias_spatial():
     m.bias[:] = [1, 1]
     e_bounds = np.array([0, 0.5, 1.0])
     m.mesh.save("sampling_mesh.h5m")
-    sampler = Sampler("sampling_mesh.h5m", "src", e_bounds, "bias")
+    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src", 
+             "bias_tag_name": "bias"}
+    sampler = Sampler(names, e_bounds, 2)
 
     num_samples = 10000
     score = 1.0/num_samples

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -122,9 +122,9 @@ def test_analog_single_tet():
     tally = np.zeros(shape=(4))
     for i in range(num_samples):
         s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
-        assert_equal(s[4], 1.0)
+        assert_equal(s.w, 1.0)
         for i, tet in enumerate(subtets):
-            if point_in_tet(tet, [s[0], s[1], s[2]]):
+            if point_in_tet(tet, [s.x, s.y, s.z]):
                 tally[i] += score
                 break
     

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -37,8 +37,9 @@ def test_analog_single_hex():
     m.src = IMeshTag(1, float)
     m.src[0] = 1.0
     m.mesh.save("sampling_mesh.h5m")
-    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src"}
-    sampler = Sampler(names, np.array([0, 1]), 0)
+    filename = "sampling_mesh.h5m"
+    tag_names = {"src_tag_name": "src"}
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), 0)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -70,8 +71,9 @@ def test_analog_multiple_hex():
     m.src = IMeshTag(2, float)
     m.src[:] = np.ones(shape=(8,2))
     m.mesh.save("sampling_mesh.h5m")
-    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src"}
-    sampler = Sampler(names, np.array([0, 0.5, 1]), 0)
+    filename = "sampling_mesh.h5m"
+    tag_names = {"src_tag_name": "src"}
+    sampler = Sampler(filename, tag_names, np.array([0, 0.5, 1]), 0)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -112,9 +114,9 @@ def test_analog_single_tet():
                [center, v1, v2, v4], 
                [center, v1, v3, v4], 
                [center, v2, v3, v4]]
-
-    names = {"filename": "tet.h5m", "src_tag_name": "src"}
-    sampler = Sampler(names, np.array([0, 1]), 0)
+    filename = "tet.h5m"
+    tag_names = {"src_tag_name": "src"}
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), 0)
     num_samples = 5000
     score = 1.0/num_samples
     tally = np.zeros(shape=(4))
@@ -145,8 +147,9 @@ def test_uniform():
     m.src[:] = [[2.0, 1.0], [9.0, 3.0]]
     e_bounds = np.array([0, 0.5, 1.0])
     m.mesh.save("sampling_mesh.h5m")
-    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src"}
-    sampler = Sampler(names, e_bounds, 1)
+    filename = "sampling_mesh.h5m"
+    tag_names = {"src_tag_name": "src"}
+    sampler = Sampler(filename, tag_names, e_bounds, 1)
 
     num_samples = 10000
     score = 1.0/num_samples
@@ -202,9 +205,10 @@ def test_bias():
     m.bias = IMeshTag(2, float)
     m.bias[:] = [[1.0, 2.0], [3.0, 3.0]]
     m.mesh.save("sampling_mesh.h5m")
-    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src",
-             "bias_tag_name": "bias"}
-    sampler = Sampler(names, e_bounds, 2)
+    filename = "sampling_mesh.h5m"
+    tag_names = {"src_tag_name": "src",
+                 "bias_tag_name": "bias"}
+    sampler = Sampler(filename, tag_names, e_bounds, 2)
 
     num_samples = 10000
     score = 1.0/num_samples
@@ -250,9 +254,10 @@ def test_bias_spatial():
     m.bias[:] = [1, 1]
     e_bounds = np.array([0, 0.5, 1.0])
     m.mesh.save("sampling_mesh.h5m")
-    names = {"filename": "sampling_mesh.h5m", "src_tag_name": "src", 
-             "bias_tag_name": "bias"}
-    sampler = Sampler(names, e_bounds, 2)
+    filename = "sampling_mesh.h5m"
+    tag_names = {"src_tag_name": "src",
+                 "bias_tag_name": "bias"}
+    sampler = Sampler(filename, tag_names, e_bounds, 2)
 
     num_samples = 10000
     score = 1.0/num_samples


### PR DESCRIPTION
This PR is used to introduce a new constructor for `pyne::Sampler`. 
This new constructor uses a map of <string, string> to store hard coded string in the source file, enables users to define the strings easier. 
This PR partly solves the problem addressed in issue: #994 .
However, the original constructors are currently remained in the code. I think it's better to remove these previous constructors when this PR merged into develop. 

Major changes:
1. Add a constructor  for `pyne::Sampler` in `source_sampling`. 
2. Modify tests functions to use the new added constructor. 