### PR TITLE
Remove alarapy sec conv

### DIFF
--- a/news/remove_alarapy_sec_conv.rst
+++ b/news/remove_alarapy_sec_conv.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** 
+
+* Add input units check to the function utils.py/to_sec
+* Use function utils.py/to_sec to replace alara.py/_TO_SEC
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import os
 import collections
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QAWarning, to_sec
 
 import numpy as np
 import tables as tb
@@ -852,23 +852,6 @@ def _get_subvoxel_array(mesh, cell_mats):
 
     return subvoxel_array
 
-_TO_SEC = {
-    's': 1,
-    'second': 1,
-    'm': 60,
-    'minute': 60,
-    'h': 60 * 60,
-    'hour': 60 * 60,
-    'd': 60 * 60 * 24,
-    'day': 60 * 60 * 24,
-    'w': 60 * 60 * 24 * 7,
-    'week': 60 * 60 * 24 * 7,
-    'y': 60 * 60 * 24 * 365.25,
-    'year': 60 * 60 * 24 * 365.25,
-    'c': 60 * 60 * 24 * 365.25 * 100,
-    'century': 60 * 60 * 24 * 365.25 * 100,
-}
-
 def _convert_unit_to_s(dc):
     """
     This function return a float number represent a time in unit of s.
@@ -882,11 +865,8 @@ def _convert_unit_to_s(dc):
     """
     # get num and unit
     num, unit = dc.split()
-    conv = _TO_SEC.get(unit, None)
-    if conv:
-        return float(num) * conv
-    else:
-        raise ValueError('Invalid unit: {0}'.format(unit))
+    return to_sec(float(num), unit)
+        
 
 def _find_phsrc_dc(idc, phtn_src_dc):
     """

--- a/pyne/utils.py
+++ b/pyne/utils.py
@@ -49,9 +49,15 @@ time_conv_dict = {'as': 1e-18,
                   'd': 86400.0,
                   'day': 86400.0,
                   'days': 86400.0,
+                  'w': 86400.0*7.0,
+                  'week': 86400.0*7.0,
+                  'weeks': 86400.0*7.0,
                   'y': 86400.0*365.25,
                   'year': 86400.0*365.25,
                   'years': 86400.0*365.25,
+                  'c': 86400.0*365.25*100,
+                  'century': 86400.0*365.25*100,
+                  'centuries': 86400.0*365.25*100,
                   }
 
 
@@ -71,9 +77,12 @@ def to_sec(input_time, units):
         Time value in [sec].
 
     """
-    sec_time = input_time * time_conv_dict[units.lower()]
-    return sec_time
-
+    conv = time_conv_dict.get(units.lower(), None)
+    if conv:
+        sec_time = input_time * conv
+        return sec_time
+    else:
+        raise ValueError('Invalid units: {0}'.format(units))
 
 barn_conv_dict = {
     'mb': 1E-3,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,8 +13,68 @@ import numpy as np
 
 
 def test_to_sec():
+    # as
+    assert_equal(2e-18, utils.to_sec(2, 'AS'))
+    assert_equal(2e-18, utils.to_sec(2, 'attosec'))
+    assert_equal(2e-18, utils.to_sec(2, 'attosecond'))
+    assert_equal(2e-18, utils.to_sec(2, 'attoseconds'))
+    # fs
+    assert_equal(2e-15, utils.to_sec(2, 'FS'))
+    assert_equal(2e-15, utils.to_sec(2, 'femtosec'))
+    assert_equal(2e-15, utils.to_sec(2, 'femtosecond'))
+    assert_equal(2e-15, utils.to_sec(2, 'femtoseconds'))
+    # ps
+    assert_equal(2e-12, utils.to_sec(2, 'PS'))
+    assert_equal(2e-12, utils.to_sec(2, 'picosec'))
+    assert_equal(2e-12, utils.to_sec(2, 'picosecond'))
+    assert_equal(2e-12, utils.to_sec(2, 'picoseconds'))
+    # ns
+    assert_equal(2e-9, utils.to_sec(2, 'NS'))
+    assert_equal(2e-9, utils.to_sec(2, 'nanosec'))
+    assert_equal(2e-9, utils.to_sec(2, 'nanosecond'))
+    assert_equal(2e-9, utils.to_sec(2, 'nanoseconds'))
+    # us
+    assert_equal(2e-6, utils.to_sec(2, 'US'))
+    assert_equal(2e-6, utils.to_sec(2, 'microsec'))
+    assert_equal(2e-6, utils.to_sec(2, 'microsecond'))
+    assert_equal(2e-6, utils.to_sec(2, 'microseconds'))
+    # ms
+    assert_equal(2e-3, utils.to_sec(2, 'MS'))
+    assert_equal(2e-3, utils.to_sec(2, 'millisec'))
+    assert_equal(2e-3, utils.to_sec(2, 'millisecond'))
+    assert_equal(2e-3, utils.to_sec(2, 'milliseconds'))
+    # s
+    assert_equal(2.0, utils.to_sec(2, 'S'))
+    assert_equal(2.0, utils.to_sec(2, 'sec'))
+    assert_equal(2.0, utils.to_sec(2, 'second'))
+    assert_equal(2.0, utils.to_sec(2, 'seconds'))
+    # m
     assert_equal(120.0, utils.to_sec(2, 'M'))
-
+    assert_equal(120.0, utils.to_sec(2, 'min'))
+    assert_equal(120.0, utils.to_sec(2, 'minute'))
+    assert_equal(120.0, utils.to_sec(2, 'minutes'))
+    # h
+    assert_equal(7200.0, utils.to_sec(2, 'H'))
+    assert_equal(7200.0, utils.to_sec(2, 'hour'))
+    assert_equal(7200.0, utils.to_sec(2, 'hours'))
+    # d
+    assert_equal(172800.0, utils.to_sec(2, 'D'))
+    assert_equal(172800.0, utils.to_sec(2, 'day'))
+    assert_equal(172800.0, utils.to_sec(2, 'days'))
+    # w
+    assert_equal(1209600.0, utils.to_sec(2, 'W'))
+    assert_equal(1209600.0, utils.to_sec(2, 'week'))
+    assert_equal(1209600.0, utils.to_sec(2, 'weeks'))
+    # y
+    assert_equal(63115200.0, utils.to_sec(2, 'Y'))
+    assert_equal(63115200.0, utils.to_sec(2, 'year'))
+    assert_equal(63115200.0, utils.to_sec(2, 'years'))
+    # c
+    assert_equal(6311520000.0, utils.to_sec(2, 'C'))
+    assert_equal(6311520000.0, utils.to_sec(2, 'century'))
+    assert_equal(6311520000.0, utils.to_sec(2, 'centuries'))
+    # undifined unit trigs ValueError
+    assert_raises(ValueError, utils.to_sec, 2, 'month')
 
 def test_to_barns():
     assert_equal(3E3, utils.to_barns(3, 'KB'))


### PR DESCRIPTION
I added a map `_TO_SEC` in `alara.py` for the purpose of time unit conversion in PR #1000.  But I found that there is a function `to_sec` do the same thing in `untils.py`. So, I modified `to_sec` and use it replace the `_TO_SEC` in `alara.py`. 

Major changes:
1. Add units `week` and `century` in `to_sec`.
2. Use `to_sec` to replace `_TO_SEC` in `alara.py`. 