### PR TITLE
Treat mesh cell tag size 1

### DIFF
--- a/news/treat_mesh_cell_tag_size_1.rst
+++ b/news/treat_mesh_cell_tag_size_1.rst
@@ -1,0 +1,15 @@
+**Added:**
+
+* Add a test function to test for read cell_number_tag with size of 1
+
+**Changed:** 
+
+* Fix the problem of reading cell_number_tag with size of 1
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -224,7 +224,7 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
         subvoxel_array = _get_subvoxel_array(mesh, cell_mats)
         # get max_num_cells
         ve0_cell_number_tag = mesh.mesh.getTagHandle('cell_number')[ve0]
-        if type(ve0_cell_number_tag) in (int, np.int32, np.int64):
+        if isinstance(ve0_cell_number_tag, (int, np.int32, np.int64)):
             max_num_cells = 1
         else:
             max_num_cells = \
@@ -850,7 +850,7 @@ def _get_subvoxel_array(mesh, cell_mats):
     non_void_sv_num = 0
     for i, _, ve in mesh:
         cell_numbers = cell_number_tag[ve]
-        if type(cell_numbers) in (int, np.int32, np.int64):
+        if isinstance(cell_numbers, (int, np.int32, np.int64)):
             cell_numbers = [cell_numbers]
         for c, cell in enumerate(cell_numbers):
             if cell > 0 and len(cell_mats[cell].comp): #non-void cell

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -222,7 +222,12 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
     if sub_voxel:
         num_vol_elements = len(mesh)
         subvoxel_array = _get_subvoxel_array(mesh, cell_mats)
-        max_num_cells = \
+        # get max_num_cells
+        ve0_cell_number_tag = mesh.mesh.getTagHandle('cell_number')[ve0]
+        if type(ve0_cell_number_tag) in (int, np.int32, np.int64):
+            max_num_cells = 1
+        else:
+            max_num_cells = \
                 len(mesh.mesh.getTagHandle('cell_number')[ve0])
     else:
         max_num_cells = 1
@@ -844,7 +849,10 @@ def _get_subvoxel_array(mesh, cell_mats):
     # calculate the total number of non-void sub-voxel
     non_void_sv_num = 0
     for i, _, ve in mesh:
-        for c, cell in enumerate(cell_number_tag[ve]):
+        cell_numbers = cell_number_tag[ve]
+        if type(cell_numbers) in (int, np.int32, np.int64):
+            cell_numbers = [cell_numbers]
+        for c, cell in enumerate(cell_numbers):
             if cell > 0 and len(cell_mats[cell].comp): #non-void cell
                 temp_subvoxel[0] = (non_void_sv_num, i, c)
                 subvoxel_array = np.append(subvoxel_array, temp_subvoxel)

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -843,8 +843,7 @@ def _get_subvoxel_array(mesh, cell_mats):
     # calculate the total number of non-void sub-voxel
     non_void_sv_num = 0
     for i, _, ve in mesh:
-        cell_numbers = cell_number_tag[ve]
-        for c, cell in enumerate(np.atleast_1d(cell_numbers)):
+        for c, cell in enumerate(np.atleast_1d(cell_number_tag[ve])):
             if cell > 0 and len(cell_mats[cell].comp): #non-void cell
                 temp_subvoxel[0] = (non_void_sv_num, i, c)
                 subvoxel_array = np.append(subvoxel_array, temp_subvoxel)

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -217,20 +217,14 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
     # find number of energy groups
     with tb.open_file(filename) as h5f:
         num_e_groups = len(h5f.root.data[0][3])
-    max_num_cells = -1
+    max_num_cells = 1
     ve0 = next(mesh.iter_ve())
     if sub_voxel:
         num_vol_elements = len(mesh)
         subvoxel_array = _get_subvoxel_array(mesh, cell_mats)
         # get max_num_cells
-        ve0_cell_number_tag = mesh.mesh.getTagHandle('cell_number')[ve0]
-        if isinstance(ve0_cell_number_tag, (int, np.int32, np.int64)):
-            max_num_cells = 1
-        else:
-            max_num_cells = \
-                len(mesh.mesh.getTagHandle('cell_number')[ve0])
-    else:
-        max_num_cells = 1
+        max_num_cells = len(np.atleast_1d(mesh.mesh.getTagHandle(
+            'cell_number')[ve0]))
 
     # create a dict of tag handles for all keys of the tags dict
     tag_handles = {}
@@ -850,9 +844,7 @@ def _get_subvoxel_array(mesh, cell_mats):
     non_void_sv_num = 0
     for i, _, ve in mesh:
         cell_numbers = cell_number_tag[ve]
-        if isinstance(cell_numbers, (int, np.int32, np.int64)):
-            cell_numbers = [cell_numbers]
-        for c, cell in enumerate(cell_numbers):
+        for c, cell in enumerate(np.atleast_1d(cell_numbers)):
             if cell > 0 and len(cell_mats[cell].comp): #non-void cell
                 temp_subvoxel[0] = (non_void_sv_num, i, c)
                 subvoxel_array = np.append(subvoxel_array, temp_subvoxel)


### PR DESCRIPTION
In PR #971 , the problem of writing a (N, 1) shaped numpy array into IMeshTag was solved. However, there remains a problem of reading the tag data. When we write a (N, 1) array into a Tag, it is actually stored by a (N, ) list rather than (N, 1). 

The reason is that, we first initial an IMeshTag by: https://github.com/pyne/pyne/blob/b5fd890986e4179ac0975d19e796208015ba44a0/pyne/mesh.py#L873. And then set the data: https://github.com/pyne/pyne/blob/b5fd890986e4179ac0975d19e796208015ba44a0/pyne/mesh.py#L882

At the initial step, the (N, 1) and (N, ) array have the same `size=1`, and they are all initialized as (N, ). We can't differentiate them without another parameter, for example: `shape=(N, )` or `shape=(N, 1)`. 

Therefore, when we read the tag data, we need to add some special treating in case that it is a  (N, 1) tag. Becasue when the tag is (N, 1), we get a `int` or `double` rather than a list of `int` or list of `double`. 

This PR add this special treat for the (N, 1) shaped tag. 

Major changes:
1. Add special treat for (N, 1) tag in pyne/alara.py
2. Add a test function for a (N, 1) shaped tag 