### PR TITLE
Subvoxel r2s workflow support

### DIFF
--- a/news/subvoxel_r2s_workflow_support.rst
+++ b/news/subvoxel_r2s_workflow_support.rst
@@ -1,0 +1,17 @@
+**Added:**
+
+* Add subvoxel r2s workflow support in pyne/scripts/r2s.py
+
+**Changed:**
+
+* Keep cell_number, cell_fracs, cell_largest_frac_number and cell_largest_frac tag in r2s step1
+* Load geom and claculate cell_mats in r2s step2
+* Use subvoxel and normal r2s compatible workflow parameters
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -142,9 +142,10 @@ def step1():
         mesh = Mesh(structured=False, mesh=meshtal)
 
     ves = list(mesh.iter_ve())
+    tags_keep = ("cell_number", "cell_fracs",
+                 "cell_largest_frac_number", "cell_largest_frac")
     for tag in mesh.mesh.getAllTags(ves[0]):
-        if tag.name not in ("cell_number", "cell_fracs",\
-                            "cell_largest_frac_number", "cell_largest_frac"):
+        if tag.name not in tags_keep:
             mesh.mesh.destroyTag(tag, True)
     mesh.mesh.save('blank_mesh.h5m')
     print('The file blank_mesh.h5m has been saved to disk.')

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -175,7 +175,8 @@ def step2():
         print('Writing source for decay time: {0}'.format(dc))
         mesh = Mesh(structured=structured, mesh='blank_mesh.h5m')
         tags = {('TOTAL', dc): tag_name}
-        photon_source_hdf5_to_mesh(mesh, h5_file, tags)
+        photon_source_hdf5_to_mesh(mesh, h5_file, tags, sub_voxel=sub_voxel,
+                                   cell_mats=cell_mats)
         mesh.mesh.save('{0}_{1}.h5m'.format(output, i+1))
         intensity = total_photon_source_intensity(mesh, tag_name)
         intensities += "{0}: {1}\n".format(dc, intensity)

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -163,6 +163,10 @@ def step2():
     tot_phtn_src_intensities = config.get('step2', 'tot_phtn_src_intensities')
     tag_name = "source_density"
 
+    if sub_voxel:
+        geom = config.get('step1', 'geom')
+        load(geom)
+        cell_mats = cell_materials(geom)
     h5_file = 'phtn_src.h5'
     if not isfile(h5_file):
         photon_source_to_hdf5('phtn_src')

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -143,7 +143,9 @@ def step1():
 
     ves = list(mesh.iter_ve())
     for tag in mesh.mesh.getAllTags(ves[0]):
-        mesh.mesh.destroyTag(tag, True)
+        if tag.name not in ("cell_number", "cell_fracs",\
+                            "cell_largest_frac_number", "cell_largest_frac"):
+            mesh.mesh.destroyTag(tag, True)
     mesh.mesh.save('blank_mesh.h5m')
     print('The file blank_mesh.h5m has been saved to disk.')
     print('Do not delete this file; it is needed by r2s.py step2.\n')


### PR DESCRIPTION
This PR changes some code of `pyne/scripts/r2s.py` to add support for subvoxel r2s workflow. 
Now, this is a normal r2s and subvoxel r2s compatible workflow, with the normal r2s be the default. 

Major changes:
1. Keep the `cell_number`, `cell_fracs` tags in step2
2. Load geom and calculate cell_mats again in step2

This PR doesn't provide any test function because this change can't be tested within the framework of pyne itself. A simple subvoxel r2s calculation is used to test the workflow. 