### PR TITLE
fix cell_mats in r2s step2

### DIFF
--- a/news/subvoxel_r2s_workflow_cell_mats.rst
+++ b/news/subvoxel_r2s_workflow_cell_mats.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Define cell_mats for subvoxel equals False
+
+**Security:** None

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -168,6 +168,8 @@ def step2():
         geom = config.get('step1', 'geom')
         load(geom)
         cell_mats = cell_materials(geom)
+    else:
+        cell_mats = None
     h5_file = 'phtn_src.h5'
     if not isfile(h5_file):
         photon_source_to_hdf5('phtn_src')


### PR DESCRIPTION
Fix a bug in subvoxel r2s workflow. 
`cell_mats` is used as a parameter for both r2s and subvoxel r2s for the purpose of compatibility. 
```
photon_source_hdf5_to_mesh(mesh, h5_file, tags, sub_voxel=sub_voxel,
                                    cell_mats=cell_mats)
```
I made a mistake in PR #1013, where I set the `cell_mats` for only `subvoxel` is `True`. That breaks the normal r2s, because the `cell_mats` is not set. 
