### PR TITLE
Subvoxel r2s check sourceh5m

### DIFF
--- a/news/subvoxel_r2s_check_sourceh5m.rst
+++ b/news/subvoxel_r2s_check_sourceh5m.rst
@@ -4,7 +4,9 @@
 
 * Add test case to check wrong use of source.h5m.
 
-**Changed:** None
+**Changed:**
+
+* Use mode names to change integers in the test_source_sampling.py
 
 **Deprecated:** None
 

--- a/news/subvoxel_r2s_check_sourceh5m.rst
+++ b/news/subvoxel_r2s_check_sourceh5m.rst
@@ -1,0 +1,15 @@
+**Added:** 
+
+* Check 'cell_fracs' tag in source_sampling.cpp when sub_mode is DEFAULT. Prevent wrong use of source.h5m.
+
+* Add test case to check wrong use of source.h5m.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -278,7 +278,6 @@ void pyne::Sampler::mesh_tag_data(moab::Range ves,
                                   cell_number_tag);
       rval = mesh->tag_get_handle(cell_fracs_tag_name.c_str(),
                                   cell_fracs_tag);
-      std::cout<<"sub_mode: "<<sub_mode<<" cell_fracs rval: "<<rval<<std::endl;
       max_num_cells = num_groups(cell_fracs_tag);
       num_e_groups /= max_num_cells;
       cell_fracs.resize(num_ves*max_num_cells);
@@ -288,24 +287,14 @@ void pyne::Sampler::mesh_tag_data(moab::Range ves,
   } else {
       // check the existance of tag "cell_number", if there is, report error
       // "cell_number" tag shouldn't be there if sub_mode is DEFAULT
-        try {
-              std::cout<<"check point 0"<<std::endl;
-              rval = mesh->tag_get_handle(cell_fracs_tag_name.c_str(),
-                                          cell_fracs_tag);
-              std::cout<<"check point 0.1, ravl = "<<rval<<std::endl;
-              max_num_cells = num_groups(cell_fracs_tag);
-              std::cout<<"check point 0.15"<<std::endl;
-              num_e_groups /= max_num_cells;
-              cell_fracs.resize(num_ves*max_num_cells);
-              rval = mesh->tag_get_data(cell_fracs_tag, ves, &cell_fracs[0]);
-              std::cout<<"check point 0.2, rval = "<<rval<<std::endl;
-              throw std::invalid_argument("The source.h5m contains cell_fracs tag. Wrong source.h5m file used.");
-
-        } 
-        catch (const std::runtime_error& error1) {
-           // do nothing
-          std::cout<<"check point 0.3"<<std::endl;
-        }
+      moab::Tag cell_fracs_tag_test;
+      std::string cell_fracs_tag_name_test = "cell_fracs";
+      rval = mesh->tag_get_handle(cell_fracs_tag_name_test.c_str(),
+                                  cell_fracs_tag_test);
+      if (rval != moab::MB_TAG_NOT_FOUND) {
+         throw std::invalid_argument(
+             "The source.h5m contains cell_fracs tag. Wrong source.h5m file used.");
+      }
   }
   std::vector<double> pdf(num_ves*num_e_groups*max_num_cells);
   rval = mesh->tag_get_data(src_tag, ves, &pdf[0]);

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -278,12 +278,34 @@ void pyne::Sampler::mesh_tag_data(moab::Range ves,
                                   cell_number_tag);
       rval = mesh->tag_get_handle(cell_fracs_tag_name.c_str(),
                                   cell_fracs_tag);
+      std::cout<<"sub_mode: "<<sub_mode<<" cell_fracs rval: "<<rval<<std::endl;
       max_num_cells = num_groups(cell_fracs_tag);
       num_e_groups /= max_num_cells;
       cell_fracs.resize(num_ves*max_num_cells);
       rval = mesh->tag_get_data(cell_fracs_tag, ves, &cell_fracs[0]);
       cell_number.resize(num_ves*max_num_cells);
       rval = mesh->tag_get_data(cell_number_tag, ves, &cell_number[0]);
+  } else {
+      // check the existance of tag "cell_number", if there is, report error
+      // "cell_number" tag shouldn't be there if sub_mode is DEFAULT
+        try {
+              std::cout<<"check point 0"<<std::endl;
+              rval = mesh->tag_get_handle(cell_fracs_tag_name.c_str(),
+                                          cell_fracs_tag);
+              std::cout<<"check point 0.1, ravl = "<<rval<<std::endl;
+              max_num_cells = num_groups(cell_fracs_tag);
+              std::cout<<"check point 0.15"<<std::endl;
+              num_e_groups /= max_num_cells;
+              cell_fracs.resize(num_ves*max_num_cells);
+              rval = mesh->tag_get_data(cell_fracs_tag, ves, &cell_fracs[0]);
+              std::cout<<"check point 0.2, rval = "<<rval<<std::endl;
+              throw std::invalid_argument("The source.h5m contains cell_fracs tag. Wrong source.h5m file used.");
+
+        } 
+        catch (const std::runtime_error& error1) {
+           // do nothing
+          std::cout<<"check point 0.3"<<std::endl;
+        }
   }
   std::vector<double> pdf(num_ves*num_e_groups*max_num_cells);
   rval = mesh->tag_get_data(src_tag, ves, &pdf[0]);

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -20,6 +20,14 @@ warnings.simplefilter("ignore", QAWarning)
 from pyne.mesh import Mesh, IMeshTag
 from pyne.source_sampling import Sampler, AliasTable
 
+# Define modes
+DEFAULT_ANALOG = 0
+DEFAULT_UNIFORM = 1
+DEFAULT_USER = 2
+SUBVOXEL_ANALOG = 3
+SUBVOXEL_UNIFORM = 4
+SUBVOXEL_USER = 5
+
 def try_rm_file(filename):
     return lambda: os.remove(filename) if os.path.exists(filename) else None
 
@@ -44,16 +52,16 @@ def test_single_tet_tag_names_map():
     # right condition
     tag_names = {"src_tag_name": "src"}
     e_bounds = np.array([0, 1])
-    sampler = Sampler(filename, tag_names, e_bounds, 0)
+    sampler = Sampler(filename, tag_names, e_bounds, DEFAULT_ANALOG)
 
     # src_tag_name not given
     tag_names = {}
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 0)
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 1)
+    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_ANALOG)
+    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_UNIFORM)
 
     # bias_tag_name not given
     tag_names = {"src_tag_name": "src"}
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 2)
+    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_USER)
 
     # subvoxel r2s source.h5m used for r2s calculation
     cell_fracs = np.zeros(2, dtype=[('idx', np.int64),
@@ -66,13 +74,13 @@ def test_single_tet_tag_names_map():
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 0)
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 1)
+    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_ANALOG)
+    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_UNIFORM)
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name":"cell_number",
                  "cell_fracs_tag_name": "cell_fracs",
                  "bias_tag_name": "bias"}
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 2)
+    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_USER)
 
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_analog_single_hex():
@@ -90,7 +98,7 @@ def test_analog_single_hex():
     filename = "sampling_mesh.h5m"
     m.mesh.save(filename)
     tag_names = {"src_tag_name": "src"}
-    sampler = Sampler(filename, tag_names, np.array([0, 1]), 0)
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), DEFAULT_ANALOG)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -124,7 +132,7 @@ def test_analog_multiple_hex():
     filename = "sampling_mesh.h5m"
     m.mesh.save(filename)
     tag_names = {"src_tag_name": "src"}
-    sampler = Sampler(filename, tag_names, np.array([0, 0.5, 1]), 0)
+    sampler = Sampler(filename, tag_names, np.array([0, 0.5, 1]), DEFAULT_ANALOG)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -167,7 +175,7 @@ def test_analog_single_tet():
                [center, v1, v3, v4], 
                [center, v2, v3, v4]]
     tag_names = {"src_tag_name": "src"}
-    sampler = Sampler(filename, tag_names, np.array([0, 1]), 0)
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), DEFAULT_ANALOG)
     num_samples = 5000
     score = 1.0/num_samples
     tally = np.zeros(shape=(4))
@@ -200,7 +208,7 @@ def test_uniform():
     filename = "sampling_mesh.h5m"
     m.mesh.save(filename)
     tag_names = {"src_tag_name": "src"}
-    sampler = Sampler(filename, tag_names, e_bounds, 1)
+    sampler = Sampler(filename, tag_names, e_bounds, DEFAULT_UNIFORM)
 
     num_samples = 10000
     score = 1.0/num_samples
@@ -262,8 +270,7 @@ def test_single_hex_single_subvoxel_analog():
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
-    sampler = Sampler(filename, tag_names,
-                      np.array([0, 1]), 3)
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), SUBVOXEL_ANALOG)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -308,7 +315,7 @@ def test_single_hex_multiple_subvoxel_analog():
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
-    sampler = Sampler(filename, tag_names, np.array([0, 1]), 3)
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), SUBVOXEL_ANALOG)
     num_samples = 50000
     score = 1.0/num_samples
     num_divs = 2
@@ -352,7 +359,7 @@ def test_multiple_hex_multiple_subvoxel_analog():
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
-    sampler = Sampler(filename, tag_names, np.array([0, 0.5, 1]), 3)
+    sampler = Sampler(filename, tag_names, np.array([0, 0.5, 1]), SUBVOXEL_ANALOG)
     num_samples = 5000
     score = 1.0/num_samples
     num_divs = 2
@@ -394,7 +401,7 @@ def test_single_hex_subvoxel_uniform():
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
-    sampler = Sampler(filename, tag_names, np.array([0, 1]), 4)
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), SUBVOXEL_UNIFORM)
 
     num_samples = 5000
     score = 1.0/num_samples
@@ -439,7 +446,7 @@ def test_single_hex_multiple_subvoxel_uniform():
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
-    sampler = Sampler(filename, tag_names, np.array([0, 1]), 4)
+    sampler = Sampler(filename, tag_names, np.array([0, 1]), SUBVOXEL_UNIFORM)
     num_samples = 5000
     score = 1.0/num_samples
     num_divs = 2
@@ -487,7 +494,7 @@ def test_multiple_hex_multiple_subvoxel_uniform():
     tag_names = {"src_tag_name": "src",
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
-    sampler = Sampler(filename, tag_names, np.array([0, 0.5, 1]), 4)
+    sampler = Sampler(filename, tag_names, np.array([0, 0.5, 1]), SUBVOXEL_UNIFORM)
     num_samples = 50000
     score = 1.0/num_samples
     num_divs = 2
@@ -531,7 +538,7 @@ def test_bias():
     m.mesh.save(filename)
     tag_names = {"src_tag_name": "src",
                  "bias_tag_name": "bias"}
-    sampler = Sampler(filename, tag_names, e_bounds, 2)
+    sampler = Sampler(filename, tag_names, e_bounds, DEFAULT_USER)
 
     num_samples = 10000
     score = 1.0/num_samples
@@ -580,7 +587,7 @@ def test_bias_spatial():
     m.mesh.save(filename)
     tag_names = {"src_tag_name": "src",
                  "bias_tag_name": "bias"}
-    sampler = Sampler(filename, tag_names, e_bounds, 2)
+    sampler = Sampler(filename, tag_names, e_bounds, DEFAULT_USER)
 
     num_samples = 10000
     score = 1.0/num_samples
@@ -654,7 +661,7 @@ def test_subvoxel_multiple_hex_bias_1():
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs",
                  "bias_tag_name": "bias"}
-    sampler = Sampler(filename, tag_names, e_bounds, 5)
+    sampler = Sampler(filename, tag_names, e_bounds, SUBVOXEL_USER)
 
     num_samples = 50000
     score = 1.0/num_samples
@@ -728,7 +735,7 @@ def test_subvoxel_multiple_hex_bias_max_num_cells_num_e_groups():
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs",
                  "bias_tag_name": "bias"}
-    sampler = Sampler(filename, tag_names, e_bounds, 5)
+    sampler = Sampler(filename, tag_names, e_bounds, SUBVOXEL_USER)
 
     num_samples = 50000
     score = 1.0/num_samples
@@ -798,7 +805,7 @@ def test_subvoxel_multiple_hex_bias_e_groups():
                  "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs",
                  "bias_tag_name": "bias"}
-    sampler = Sampler(filename, tag_names, e_bounds, 5)
+    sampler = Sampler(filename, tag_names, e_bounds, SUBVOXEL_USER)
 
     num_samples = 50000
     score = 1.0/num_samples

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -45,31 +45,16 @@ def test_single_tet_tag_names_map():
     tag_names = {"src_tag_name": "src"}
     e_bounds = np.array([0, 1])
     sampler = Sampler(filename, tag_names, e_bounds, 0)
+
     # src_tag_name not given
     tag_names = {}
     assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 0)
     assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 1)
+
     # bias_tag_name not given
     tag_names = {"src_tag_name": "src"}
     assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 2)
 
-@with_setup(None, try_rm_file('tet.h5m'))
-def test_single_tet_r2s_using_subvoxel_source():
-    """This test tests uniform sampling within a single tetrahedron. This is
-    done by dividing the tetrahedron in 4 smaller tetrahedrons and ensuring
-    that each sub-tet is sampled equally.
-    """
-    seed(1953)
-    m = Mesh(structured=True,
-             structured_coords=[[0, 3, 3.5], [0, 1], [0, 1]],
-             mats = None)
-    m.src = IMeshTag(2, float)
-    m.src[:] = [[2.0, 1.0], [9.0, 3.0]]
-    e_bounds = np.array([0, 0.5, 1.0])
-    m.bias = IMeshTag(2, float)
-    m.bias[:] = [[1.0, 2.0], [3.0, 3.0]]
-    filename = "sampling_mesh.h5m"
- 
     # subvoxel r2s source.h5m used for r2s calculation
     cell_fracs = np.zeros(2, dtype=[('idx', np.int64),
                                     ('cell', np.int64),

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -79,7 +79,7 @@ def test_single_tet_r2s_using_subvoxel_source():
     m.tag_cell_fracs(cell_fracs)
     m.mesh.save(filename)
     tag_names = {"src_tag_name": "src",
-                 "cell_number_tag_name":"cell_number",
+                 "cell_number_tag_name": "cell_number",
                  "cell_fracs_tag_name": "cell_fracs"}
     assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 0)
     assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, 1)


### PR DESCRIPTION
A problem addressed in issue #1016 was solved in this PR. A check was added into `source_sampling.cpp` to prevent wrong use of `source.h5m`. By applying this PR, an error message will jump out when users run DEFAULT r2s with a `source.h5m` generated for SUBVOXEL r2s.