### PR TITLE
Source sampling all zero bias check

### DIFF
--- a/news/source_sampling_all_zero_bias_check.rst
+++ b/news/source_sampling_all_zero_bias_check.rst
@@ -1,0 +1,15 @@
+**Added:** 
+
+* Check for bias_tag data. Report error when bias tag data are all zero
+
+* A test function to test the check
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -446,6 +446,12 @@ std::vector<double> pyne::Sampler::read_bias_pdf(moab::Range ves,
                                 "  max_num_cells*num_e_group, num_e_groups, or 1.");
       }
      }
+    double q_in_all = 0.0;
+    for (int i=0; i<bias_pdf.size(); i++)
+      q_in_all += bias_pdf[i];
+    if (q_in_all <= 0.0) {
+      throw std::runtime_error("Bias data are ALL ZERO!");
+    }
  return bias_pdf;
 }
 

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -82,6 +82,20 @@ def test_single_tet_tag_names_map():
                  "bias_tag_name": "bias"}
     assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_USER)
 
+    # wrong bias_tag data (non-zero source_density biased to zero -> NAN weight)
+    m.src = IMeshTag(2, float)
+    m.src[:] = [[1.0, 1.0]]
+    m.bias = IMeshTag(2, float)
+    m.bias[:] = [[0.0, 0.0]]
+    m.mesh.save(filename)
+    tag_names = {"src_tag_name": "src",
+                 "cell_number_tag_name":"cell_number",
+                 "cell_fracs_tag_name": "cell_fracs",
+                 "bias_tag_name": "bias"}
+    assert_raises(RuntimeError, Sampler, filename, tag_names, e_bounds, SUBVOXEL_USER)
+
+
+
 @with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_analog_single_hex():
     """This test tests that particles of sampled evenly within the phase-space 


### PR DESCRIPTION
This PR adds a check for bias tag used by the source_sampling. When a bias tag is set to all zeros (wrong bias  tag), throw an error. Otherwise, the weight will be NAN and lead to wrong results.


