### PR TITLE
Subvoxel cell num rejection fix

### DIFF
--- a/news/subvoxel_cell_num_rejection_fix.rst
+++ b/news/subvoxel_cell_num_rejection_fix.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* Change mode range of cell rejection from >3 to >2
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/share/source.F90
+++ b/share/source.F90
@@ -75,8 +75,9 @@ subroutine source
    cell_num = -1
    call particle_birth(rands, xxx, yyy, zzz, erg, wgt, cell_num)
    icl_tmp = find_cell()
-   if (idum(1) > 3) then
-       if (cell_num .ne. ncl(icl_tmp)) then
+   if (idum(1) > 2) then
+       if (cell_num .ne. ncl(icl_tmp) .and. tries < idum(2)) then
+           tries = tries + 1
            goto 200
        endif
    endif


### PR DESCRIPTION
This PR changes the mode arrangement for cell rejection of source sampling. Cell rejection should be on when the mode is SUBVOXEL, i.e. 3, 4, 5. 