### PR TITLE
Remove alara params decay times

### DIFF
--- a/docs/usersguide/r2s.rst
+++ b/docs/usersguide/r2s.rst
@@ -90,7 +90,7 @@ command:
 
 .. code-block:: bash
 
-   >> alara alara_geom > out.txt
+   >> alara alara_inp > out.txt
 
 For large problems (i.e large meshes, many decay times), this process may take
 a large amount of processor time and RAM. Once this process is complete,

--- a/news/remove_alara_params_decay_times.rst
+++ b/news/remove_alara_params_decay_times.rst
@@ -1,0 +1,19 @@
+**Added:** None
+
+**Changed:** 
+
+* Read decay times from r2s config.ini, and then write them into alara_inp.
+
+* Change some default names of alara_inp.
+
+* Modify test funcitons of pyne/test_r2s.py.
+
+**Deprecated:** None
+
+**Removed:** 
+
+* Decay times in the alara_params.txt.
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -14,7 +14,7 @@ warn(__name__ + " is not yet QA compliant.", QAWarning)
 def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
                       geom=None, num_rays=10, grid=False, flux_tag="n_flux",
                       fluxin="alara_fluxin", reverse=False,
-                      alara_inp="alara_geom", alara_matlib="alara_matlib",
+                      alara_inp="alara_inp", alara_matlib="alara_matlib",
                       output_mesh="r2s_step1.h5m", output_material=False,
                       sub_voxel=False):
     """This function is used to setup the irradiation inputs after the first

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -64,7 +64,7 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
     output_material : bool, optional
         If true, output mesh will have materials as determined by
         dagmc.discretize_geom()
-    decay_times: list 
+    decay_times: list
         List of the decay times.
     sub_voxel : bool, optional
         If true, sub-voxel r2s work flow  will be used.
@@ -119,7 +119,7 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
         decay_str = ''.join([decay_str,'    ', dc, '\n'])
     decay_str = ''.join([decay_str, 'end\n'])
     with open(alara_inp, 'a') as f:
-        f.write(+ decay_str)
+        f.write(decay_str)
 
     if isfile(alara_params):
         with open(alara_params, 'r') as f:

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -16,7 +16,7 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
                       fluxin="alara_fluxin", reverse=False,
                       alara_inp="alara_inp", alara_matlib="alara_matlib",
                       output_mesh="r2s_step1.h5m", output_material=False,
-                      decay_times=['1 s'], sub_voxel=False):
+                      decay_times=None, sub_voxel=False):
     """This function is used to setup the irradiation inputs after the first
     R2S transport step.
 
@@ -65,7 +65,7 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
         If true, output mesh will have materials as determined by
         dagmc.discretize_geom()
     decay_times: list
-        List of the decay times.
+        List of the decay times. If no decay times given, use '1 s'.
     sub_voxel : bool, optional
         If true, sub-voxel r2s work flow  will be used.
     """
@@ -114,9 +114,11 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
                    sub_voxel=sub_voxel)
 
     # write decay times into alara_inp
+    if decay_times == None:
+        decay_times = ['1 s']
     decay_str = 'cooling\n'
     for dc in decay_times:
-        decay_str = ''.join([decay_str,'    ', dc, '\n'])
+        decay_str = ''.join([decay_str, '    ', dc, '\n'])
     decay_str = ''.join([decay_str, 'end\n'])
     with open(alara_inp, 'a') as f:
         f.write(decay_str)

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -16,7 +16,7 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
                       fluxin="alara_fluxin", reverse=False,
                       alara_inp="alara_inp", alara_matlib="alara_matlib",
                       output_mesh="r2s_step1.h5m", output_material=False,
-                      sub_voxel=False):
+                      decay_times=['1 s'], sub_voxel=False):
     """This function is used to setup the irradiation inputs after the first
     R2S transport step.
 
@@ -64,6 +64,8 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
     output_material : bool, optional
         If true, output mesh will have materials as determined by
         dagmc.discretize_geom()
+    decay_times: list 
+        List of the decay times.
     sub_voxel : bool, optional
         If true, sub-voxel r2s work flow  will be used.
     """
@@ -110,6 +112,14 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
                    sub_voxel, cell_fracs, cell_mats)
     record_to_geom(m, cell_fracs, cell_mats, alara_inp, alara_matlib,
                    sub_voxel=sub_voxel)
+
+    # write decay times into alara_inp
+    decay_str = 'cooling\n'
+    for dc in decay_times:
+        decay_str = ''.join([decay_str,'    ', dc, '\n'])
+    decay_str = ''.join([decay_str, 'end\n'])
+    with open(alara_inp, 'a') as f:
+        f.write(+ decay_str)
 
     if isfile(alara_params):
         with open(alara_params, 'r') as f:

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -111,6 +111,7 @@ def step1():
     meshtal = config.get('step1', 'meshtal')
     tally_num = config.getint('step1', 'tally_num')
     flux_tag = config.get('step1', 'flux_tag')
+    decay_times = config.get('step2', 'decay_times').split(',')
 
     if structured:
         meshtal = Meshtal(meshtal,
@@ -127,7 +128,8 @@ def step1():
     cell_mats = cell_materials(geom)
     irradiation_setup(meshtal, cell_mats, alara_params_filename, tally_num,
                       num_rays=num_rays, grid=grid, reverse=reverse,
-                      flux_tag=flux_tag,sub_voxel=sub_voxel)
+                      flux_tag=flux_tag, decay_times=decay_times,
+                      sub_voxel=sub_voxel)
 
     # create a blank mesh for step 2:
     if structured:
@@ -181,7 +183,7 @@ def step2():
     with open(tot_phtn_src_intensities, 'w') as f:
         f.write(intensities)
 
-    e_bounds = phtn_src_energy_bounds("alara_geom")
+    e_bounds = phtn_src_energy_bounds("alara_inp")
     e_bounds_str = ""
     for e in e_bounds:
         e = e/1e6 # convert unit to MeV

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -65,12 +65,6 @@ alara_params =\
 element_lib nuclib
 data_library alaralib fendl3bin
 
-cooling
-    1E3 s
-    12 h
-    3.0 d
-end
-
 output zone
        integrate_energy
        # Energy group upper bounds. The lower bound is always zero.

--- a/tests/files_test_r2s/exp_alara_inp
+++ b/tests/files_test_r2s/exp_alara_inp
@@ -19,5 +19,8 @@ mixture mix_0
     material mat_12 1 0.962963
 end
 
+cooling
+    1 s
+end
 
 Bogus line for testing

--- a/tests/files_test_r2s/exp_alara_inp_un
+++ b/tests/files_test_r2s/exp_alara_inp_un
@@ -18,5 +18,8 @@ mixture mix_0
     material mat_12 1 1.0
 end
 
+cooling
+    1 s
+end
 
 Bogus line for testing


### PR DESCRIPTION
Users need to define decay times in both `config.ini` and `alara_params.txt` for running r2s before this PR.
This PR keeps the decay times definition in "config.ini" and remove them from the "alara_params.txt".  
By the way, some names of `alara_geom` are changed into `alara_inp`.
Major changes:
- Remove decay times definition from `alara_params.txt`
- Change`alara_geom` to `alara_inp` at some places
