### PR TITLE
Update r2s doc

### DIFF
--- a/docs/usersguide/source_sampling.rst
+++ b/docs/usersguide/source_sampling.rst
@@ -90,7 +90,7 @@ named "source.h5m" with a tag named "source_density" of length 1.
   int main(){
   
     std::string filename("source.h5m");
-    std:;map<std::string, std::string> tag_names;
+    std::map<std::string, std::string> tag_names;
     tag_names.insert(std::pair<std::string, std::string>  ("src_tag_name",
     "source_density"));
     std::vector<double> e_bounds;
@@ -103,14 +103,14 @@ named "source.h5m" with a tag named "source_density" of length 1.
     int i;
     for(i=0; i<6; i++) rands.push_back((double)rand()/RAND_MAX);
   
-    SourceParticle s = sampler.particle_birth(rands);
+    pyne::SourceParticle s = sampler.particle_birth(rands);
   
-    std::cout<<"x: "<<s.x<<std::endl;
-    std::cout<<"y: "<<s.y<<std::endl;
-    std::cout<<"z: "<<s.z<<std::endl;
-    std::cout<<"e: "<<s.e<<std::endl;
-    std::cout<<"w: "<<s.w<<std::endl;
-    std::cout<<"c: "<<s.c<<std::endl;
+    std::cout<<"x: "<<s.get_x()<<std::endl;
+    std::cout<<"y: "<<s.get_y()<<std::endl;
+    std::cout<<"z: "<<s.get_z()<<std::endl;
+    std::cout<<"e: "<<s.get_e()<<std::endl;
+    std::cout<<"w: "<<s.get_w()<<std::endl;
+    std::cout<<"c: "<<s.get_c()<<std::endl;
   
    return 0;
   } 
@@ -119,7 +119,7 @@ This program can be complied with:
 
 .. code-block:: bash
 
-  g++ test.cpp -o test -lMOAB -lpyne
+  g++ test.cpp pyne/source_sampling.cpp pyne/measure.cpp -o test -lMOAB -lpyne
 
 
 ****************

--- a/docs/usersguide/source_sampling.rst
+++ b/docs/usersguide/source_sampling.rst
@@ -16,18 +16,18 @@ can then supply six pseudorandom numbers in order to generate a random sample
 of the particle birth parameters (position, energy, statistical weight).  The
 source sampling module is written in C++ and has fully-supported C++, Fortran,
 and Python interfaces, which facilitates its use within physics codes. The
-source sampling module allows for three sampling modes:
+source sampling module allows for six sampling modes:
 
-:analog:
+:DEFAULT_ANALOG (mode 0):
   Particle birth parameters are sampled directly from a unmodified 
-  probability distribution function created from the source density mesh 
+  probability distribution function created from the source density mesh voxels
   (i.e. positions/energies with high source density are sampled more often
   than those of low source density). 
-:uniform:
+:DEFAULT_UNIFORM (mode 1):
   All mesh volume elements are sampled with equal probability. Energy bins are
   sampled in analog from the distribution within a given mesh volume element.
   Statistical weights of particles are modified accordingly.
-:user:
+:DEFAULT_USER (mode 2):
   In addition to source densities, the user supplies (on the same mesh) biased
   source densities. Particle birth parameters are then sampled on the basis of
   the biased source densities, and the statistical weight of particles is
@@ -35,6 +35,17 @@ source sampling module allows for three sampling modes:
   source density tag. Alternatively, the tag may have a length of 1, in which
   case the bias is only applied spatially and energy groups are sampled in
   analog.
+:SUBVOXEL_ANALOG (mode 3):
+  Similar to DEFAULT_ANALOG, but the probability distribution function is
+  created from the source density of mesh subvoxels.
+:SUBVOXEL_UNIFORM (mode 4):
+  Similar to DEFAULT_UNIFORM, but the probability distribution function is
+  created from the source density of mesh subvoxels.
+:SUBVOXEL_USER (mode 5):
+  Similar to DEFAULT_USER, but the probability distribution function is
+  created from the source density of mesh subvoxels. The tag may have a length
+  of 1, number of photon energy groups, or maximum cells number in a voxel
+  multiplied by the number of photon energy groups.
 
 A complete description of the theory involved can be found in the 
 source_sampling entry in the PyNE theory manual.
@@ -44,35 +55,29 @@ source_sampling entry in the PyNE theory manual.
 C++ interface
 *************
 
-An object of the Sampler class is first instantiated using 1 of 2 constructors:
+An object of the Sampler class is first instantiated using a constructor:
 
-:analog and uniform constructor:
+:constructor:
     Sampler(std::string filename,
-            std::string src_tag_name,
+            std::map<std::string, std::string> tag_names,
             std::vector<double> e_bounds,
-            bool uniform)
-:user constructor:
-    Sampler(std::string filename,
-            std::string src_tag_name,
-            std::vector<double> e_bounds,
-            std::string bias_tag_name)
+            int mode)
 
-The "filename" is a MOAB mesh file (.h5m). The "src_tag_name" is the name
-of the tag on the mesh that stores the source densities. The source density can
-be specified for an arbitrary number of energy groups, stored as a MOAB vector
-tag. The "e_bounds" parameter describes the upper and lower bounds of these 
-energy groups. For example if the src_tag_name tag is a vector of length 175
-(for 175 energy groups), e_bounds should be of length 176. The final parameter
-differs for the two constructors. A bool can be supplied: false for analog
-sampling or true for uniform sampling. Alternatively, a string can be supplied
-to denote the name of a tag (on the same mesh) which supplies biased source
-densities.
+The "filename" is a MOAB mesh file (.h5m). The "tag_names" is a map that stores
+all the tag names need in the problem, such as the "src_tag_name" (required for
+all modes), "bias_tag_name" (required in mode 2 and 5), "cell_number_tag_name"
+(required for mode 3, 4, 5), "cell_fracs_tag_name" (required for mode 3, 4, 5).
+The source density can be specified for an arbitrary number of energy groups,
+stored as a MOAB vector tag. The "e_bounds" parameter describes the upper and
+lower bounds of these energy groups. For example if the src_tag_name tag is a
+vector of length 24 (for 24 energy groups), e_bounds should be of length 25.
+The final parameter determins the source sampling mode.
 
 Once a Sampler object is created the Sampler.particle_birth() method is called.
 This method takes a single argument: a vector of 6 pseudorandom number between
-0 and 1. This method returns a vector of length 5 containing the sampled x position, y position,
-z position, energy, and weight respectively.
-eight
+0 and 1. This method returns a source particle containing the sampled x
+position, y position, z position, energy, weight and cell number respectively.
+
 An example C++ program is supplied below. This program requires a mesh file
 named "source.h5m" with a tag named "source_density" of length 1.
 
@@ -85,24 +90,27 @@ named "source.h5m" with a tag named "source_density" of length 1.
   int main(){
   
     std::string filename("source.h5m");
-    std::string src_tag_name("source_density");
+    std:;map<std::string, std::string> tag_names;
+    tag_names.insert(std::pair<std::string, std::string>  ("src_tag_name",
+    "source_density"));
     std::vector<double> e_bounds;
     e_bounds.push_back(0); // 1 energy group, lower bound of 0 upper bound of 1
     e_bounds.push_back(1);
   
-    pyne::Sampler s(filename, src_tag_name, e_bounds, true);
+    pyne::Sampler sampler(filename, tag_names, e_bounds, 0);
   
     std::vector<double> rands;
     int i;
     for(i=0; i<6; i++) rands.push_back((double)rand()/RAND_MAX);
   
-    std::vector<double> samp = s.particle_birth(rands);
+    SourceParticle s = sampler.particle_birth(rands);
   
-    std::cout<<"x: "<<samp[0]<<std::endl;
-    std::cout<<"y: "<<samp[1]<<std::endl;
-    std::cout<<"z: "<<samp[2]<<std::endl;
-    std::cout<<"e: "<<samp[3]<<std::endl;
-    std::cout<<"w: "<<samp[4]<<std::endl;
+    std::cout<<"x: "<<s.x<<std::endl;
+    std::cout<<"y: "<<s.y<<std::endl;
+    std::cout<<"z: "<<s.z<<std::endl;
+    std::cout<<"e: "<<s.e<<std::endl;
+    std::cout<<"w: "<<s.w<<std::endl;
+    std::cout<<"c: "<<s.c<<std::endl;
   
    return 0;
   } 
@@ -125,13 +133,14 @@ with python.nose. It can be used in the same manner as the C++ class:
 
  import numpy as np
  from random import uniform
- from pyne.source_sampling import Sampler
+ from pyne.source_sampling import Sampler, SourceParticle
  
- s = Sampler("source.h5m", "source_density", np.array([0, 1]), True)
- samp = s.particle_birth([uniform(0, 1) for x in range(6)])
+ tag_names = {"src_tag_name", "source_density"}
+ sampler = Sampler("source.h5m", tag_names, np.array([0, 1]), 0)
+ s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
  
- print("x: {0}\ny: {1}\nz: {2}\ne: {3}\nw: {4}".format(
-           samp[0], samp[1], samp[2], samp[3], samp[4]))
+ print("x: {0}\ny: {1}\nz: {2}\ne: {3}\nw: {4}\nc: {5}".format(
+           s.x, s.y, s.z, s.e, s.w, s.c))
 
 
 *****************
@@ -141,11 +150,13 @@ Fortran Interface
 Because Fortran cannot store an instance of the Sampler class, to perform
 source sampling from Fortran, a free-standing function "sampling_setup" is
 called to create a global instance of the sampling class. This function takes
-a single argument: an integer representing the problem mode (0: analog, 1:
-uniform, 2: user). This function assumes the mesh file is "source.h5m" and
-that the tag names are "source_density" and "biased_source_density". In 
-addition, this function assumes that a file "e_bounds" is present which is
-a plain text file containing the energy boundaries.
+a single argument: an integer representing the problem mode (0: DEFAULT_USER, 1:
+DEFAULT_UNIFORM, 2: DEFAULT_USER, 3: SUBVOXEL_ANALOG, 4: SUBVOXEL_UNIFORM,
+5: SUBVOXEL_USER). This function assumes the mesh file is "source.h5m" and
+that the tag names are "source_density", "biased_source_density",
+"cell_number_tag_name" and "cell_fracs_tag_name". In addition, this function
+assumes that a file "e_bounds" is present which is a plain text file containing
+the energy boundaries.
 
 An example program using the Fortran interface is shown below:
 
@@ -155,7 +166,7 @@ An example program using the Fortran interface is shown below:
    implicit none
    double precision :: x, y, z, e, w
    double precision, dimension(6) :: rands
-   integer:: i, j, mode
+   integer:: i, j, mode, c
 
    mode = 1
    call sampling_setup(mode)
@@ -164,12 +175,13 @@ An example program using the Fortran interface is shown below:
      rands(j) = RAND()
    end do
 
-   call particle_birth(rands, x, y, z, e, w)
+   call particle_birth(rands, x, y, z, e, w, c)
    print*, "x: ", x
    print*, "y: ", y
    print*, "x: ", z
    print*, "e: ", e
    print*, "w: ", w
+   print*, "c: ", c
 
  end program test
 

--- a/docs/usersguide/source_sampling.rst
+++ b/docs/usersguide/source_sampling.rst
@@ -135,7 +135,7 @@ with python.nose. It can be used in the same manner as the C++ class:
  from random import uniform
  from pyne.source_sampling import Sampler, SourceParticle
  
- tag_names = {"src_tag_name", "source_density"}
+ tag_names = {"src_tag_name": "source_density"}
  sampler = Sampler("source.h5m", tag_names, np.array([0, 1]), 0)
  s = sampler.particle_birth([uniform(0, 1) for x in range(6)])
  

--- a/news/update_r2s_doc.rst
+++ b/news/update_r2s_doc.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* Documentation of R2S source_sampling method. Add descriptions about subvoxel R2S.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
As the subvoxel r2s is available for pyne now. The R2S documentation should be updated. This PR makes some changes to current r2s docs, adding descriptions according to the updated source_sampling method. 