### PR TITLE
gammaspec.py has a new  function read_SPEC_ID_file

### DIFF
--- a/pyne/gammaspec.py
+++ b/pyne/gammaspec.py
@@ -250,7 +250,7 @@ def calc_e_eff(energy, eff_coeff, eff_fit=1):
     return eff
 #
 
-def read_SPEC_ID_file(spec_file_path):
+def read_spec_id_file(spec_file_path):
     """Reads a .spe file with the $SPEC_ID format
     """
     with open(spec_file_path, "r") as spec_file:
@@ -307,3 +307,4 @@ def read_SPEC_ID_file(spec_file_path):
     spectrum.calc_ebins()
     
     return spectrum
+

--- a/tests/test_spectrometry.py
+++ b/tests/test_spectrometry.py
@@ -91,7 +91,21 @@ def test_gross_counts():
 def test_net_count():
     nc=sa.net_counts(gspec1, 475, 484, 1)
 
-
+def test_read_spec_id_file():
+    assert_equal(gspec2.spec_name, "No sample description was entered.")
+    assert_equal(gspec2.file_name, "gv_format_spect.spe")
+    assert_equal(gspec2.real_time, 209)
+    assert_equal(gspec2.live_time, 199)
+    assert_equal(gspec2.start_time, "11:43:41")
+    assert_equal(gspec2.start_date, "08/01/2014")
+    assert_equal(gspec2.dead_time, 10.0)
+    assert_equal(gspec2.det_id, "2")
+    assert_equal(gspec2.det_descp, "DSPEC1")
+    assert_equal(gspec2.start_chan_num, 0)
+    assert_equal(gspec2.num_channels, 1024)
+    assert_equal(len(gspec2.channels), 1024)
+    assert_equal(len(gspec2.counts), 1024)
+    assert_equal(len(gspec2.ebin), 1024)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
read_SPEC_ID_file is a new function that allows files that begin with '$SPEC_ID:' to be read. Prior to this function .spe files that began with '$SPEC_ID:' lead to a RuntimeError('Spe file format is not supported by this function'). 
The next goal is to clean up GammaSpectrum() and add onto spectanalysis.py