### PR TITLE
read_wwinp() check photon bins != 0

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1652,7 +1652,7 @@ class Wwinp(Mesh):
 
             self._read_wwlb('n', f)
 
-        if len(self.ne) == 2:
+        if len(self.ne) == 2 and self.ne[1] != 0:
             self.e.append([])
             while len(self.e[-1]) < self.ne[1]:
                 self.e[-1] += [float(x) for x in f.readline().split()]


### PR DESCRIPTION
It is possible that the first lines of a wwinp file specify a number of photon bins to be 0 (which means it does not exist in the file). ADVANTG writes out wwinp files like this. Currently, when using `read_wwinp()` if there is a number there, it assumes the values exist in the file. This pr just adds a check to make sure the number of photon energy bins is not 0 even if a number exists there (just like the neutron bin check in the lines above).