### PR TITLE
Fixing an error with _find_phsrc_dc function in alara.py

### DIFF
--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -869,25 +869,39 @@ def _convert_unit_to_s(dc):
 
 def _find_phsrc_dc(idc, phtn_src_dc):
     """
-    This function return a string representing a time in phsrc_dc.
+    This function returns a string representing a time in phsrc_dc.
+
     Parameters
     ----------
-    idc : string. Represent a time, input decay time
-    phtn_src_dc : list of string. Decay times in phtn_src file.
+    idc : string
+        Represents a time, input decay time
+    phtn_src_dc : list of strings
+        Decay times in phtn_src file
 
-    return : odc, string. output mathched decay time.
-    """ 
+    Returns
+    -------
+    string from phtn_src_dc list that mathches idc
+    """
+    # Check the existence of idc in phtn_src_dc list.
     if idc in phtn_src_dc:
-        # if idc exist in phtn_src_dc, directly return idc
         return idc
+    # Direct matching cannot be found. Convert units to [s] and compare.
     else:
-        # the idc doesn't exist in phtn_src_dc, convert the unit to `s`,
+        # convert idc to [s]
         idc_s = _convert_unit_to_s(idc)
-        phtn_src_dc_s = []
-        for i, dc in enumerate(phtn_src_dc):
+        # Loop over decay times in phtn_src_dc list and compare to idc_s.
+        for dc in phtn_src_dc:
+            # Skip "shutdown" string in list.
+            if dc == 'shutdown':
+                continue
+            # Convert to [s].
             dc_s = _convert_unit_to_s(dc)
-            if (abs(idc_s - dc_s)/dc_s) < 1e-6:
-                return phtn_src_dc[i]
+            if idc_s == dc_s:
+                # idc_s matches dc_s. return original string, dc.
+                return dc
+            elif dc_s != 0.0 and (abs(idc_s - dc_s)/dc_s) < 1e-6:
+                return dc
+        # if idc doesn't match any string in phtn_src_dc list, raise an error.    
         raise ValueError('Decay time {0} not found in phtn_src file'.format(idc)) 
 
 


### PR DESCRIPTION
This PR fixes an error with _find_phsrc_dc function in alara.py that arises sometimes when writing photon sources to hdf5 files in r2s step2.
For each decay time read from the config file, r2s.py step2 calls photon_source_hdf5_to_mesh function that creates a list of all decay times read from phtn_src.h5 file and then loops over that list to find the matching decay time to write the source file for that time.
The issue is demonstrated by the following example:
- Input decay times from r2s config file: 
decay_times: 0 s,1e2 s,1e4 s,1e6 s,1e8 s,1e10 s
- List of decay times retrieved from phtn_src.h5 in photon_source_hdf5_to_mesh function:
['0 s', '1e+10 s', '1e+08 s', 'shutdown', '100 s', '1e+06 s', '10000 s']

It can be seen that an exact match using string comparison cannot be found for most of the decay times. The two sources of errors arise when an exact match cannot be found; 
1- looping over the list to convert units to seconds and compare where an error is raised for "shutdown"
2- trying to find the nearest value where dividing by the first value in the list, '0', causes an error.

This PR fixes these issues.