### PR TITLE
Isolate iMesh imports and calls to pyne.mesh

### DIFF
--- a/news/imesh_isolation.rst
+++ b/news/imesh_isolation.rst
@@ -1,0 +1,16 @@
+**Added:** 
+
+* a mesh_iterate function in mesh.py 
+  
+**Changed:** 
+
+* removal of itaps imports and references from modules outside of mesh.py
+* HAVE_PYTAPS value is now imported from the mesh module
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -74,7 +74,8 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
     tag_flux = flux_mesh.mesh.getTagHandle(flux_tag)
 
     # find number of e_groups
-    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(mesh_iterate(flux_mesh.mesh))[0]]
+    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(
+        mesh_iterate(flux_mesh.mesh))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
 

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -19,7 +19,7 @@ except NameError:
 from pyne.mesh import Mesh, MeshError, HAVE_PYTAPS
 
 if HAVE_PYTAPS:
-    from pyne.mesh import iBase, iMesh, iMeshExtensions
+    from pyne.mesh import iBase, iMesh, iMeshExtensions, iterate_wrapper
     
 from pyne.material import Material, from_atom_frac
 from pyne import nucname
@@ -74,9 +74,7 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
     tag_flux = flux_mesh.mesh.getTagHandle(flux_tag)
 
     # find number of e_groups
-    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(
-        flux_mesh.mesh.iterate(iBase.Type.region,
-                               iMesh.Topology.all))[0]]
+    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(iterate_wrapper(flux_mesh.mesh))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
 

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -16,7 +16,11 @@ try:
 except NameError:
     basestring = str
 
-from pyne.mesh import Mesh, MeshError
+from pyne.mesh import Mesh, MeshError, HAVE_PYTAPS
+
+if HAVE_PYTAPS:
+    from pyne.mesh import iBase, iMesh, iMeshExtensions
+    
 from pyne.material import Material, from_atom_frac
 from pyne import nucname
 from pyne.nucname import serpent, alara, znum, anum

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -19,7 +19,7 @@ except NameError:
 from pyne.mesh import Mesh, MeshError, HAVE_PYTAPS
 
 if HAVE_PYTAPS:
-    from pyne.mesh import iterate_wrapper
+    from pyne.mesh import mesh_iterate
     
 from pyne.material import Material, from_atom_frac
 from pyne import nucname
@@ -74,7 +74,7 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
     tag_flux = flux_mesh.mesh.getTagHandle(flux_tag)
 
     # find number of e_groups
-    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(iterate_wrapper(flux_mesh.mesh))[0]]
+    e_groups = flux_mesh.mesh.getTagHandle(flux_tag)[list(mesh_iterate(flux_mesh.mesh))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
 

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -16,13 +16,6 @@ try:
 except NameError:
     basestring = str
 
-try:
-    from itaps import iMesh, iBase, iMeshExtensions
-except ImportError:
-    warn("the PyTAPS optional dependency could not be imported. "
-                  "Some aspects of the alara module may be incomplete.",
-                  QAWarning)
-
 from pyne.mesh import Mesh, MeshError
 from pyne.material import Material, from_atom_frac
 from pyne import nucname

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -19,7 +19,7 @@ except NameError:
 from pyne.mesh import Mesh, MeshError, HAVE_PYTAPS
 
 if HAVE_PYTAPS:
-    from pyne.mesh import iBase, iMesh, iMeshExtensions, iterate_wrapper
+    from pyne.mesh import iterate_wrapper
     
 from pyne.material import Material, from_atom_frac
 from pyne import nucname

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -407,7 +407,7 @@ def mesh_to_geom(mesh, geom_file, matlib_file):
     """This function reads the materials of a PyNE mesh object and prints the
     geometry and materials portion of an ALARA input file, as well as a
     corresponding matlib file. If the mesh is structured, xyz ordering is used
-    (z changing fastest). If the mesh is unstructured iMesh.iterate order is
+    (z changing fastest). If the mesh is unstructured the mesh_iterate order is
     used.
 
     Parameters

--- a/pyne/cccc.py
+++ b/pyne/cccc.py
@@ -651,17 +651,13 @@ class Rtflux(object):
              The tag name to use to tag the fluxes onto the mesh.
         """
 
-        try:
-            from itaps import iMesh
-            HAVE_PYTAPS = True
-        except ImportError:
-            warn("the PyTAPS optional dependency could not be imported. "
-                          "All aspects of the partisn module are not imported.",
-                          QAWarning)
-            HAVE_PYTAPS = False
-        
+        from pyne.mesh import HAVE_PYTAPS
         if HAVE_PYTAPS:
             from pyne.mesh import Mesh, IMeshTag
+        else:
+            warn("the PyTAPS optional dependency could not be imported. "
+                 "All aspects of the partisn module are not imported.",
+                 QAWarning)
 
         if not m.structured:
             raise ValueError("Only structured mesh is supported.")

--- a/pyne/dagmc.pyx
+++ b/pyne/dagmc.pyx
@@ -21,12 +21,11 @@ if sys.version_info[0] >= 3:
     unichr = chr
 
 # Mesh specific imports
-try:
-    from itaps import iMesh
-except ImportError:
+from pyne.mesh import HAVE_PYTAPS
+if not HAVE_PYTAPS:
     warn("the PyTAPS optional dependency could not be imported. "
-                  "Some aspects of dagmc module may be incomplete",
-                  QAWarning)
+         "Some aspects of dagmc module may be incomplete",
+         QAWarning)
 
 # Globals
 VOL_FRAC_TOLERANCE = 1E-10 # The maximum volume fraction to be considered valid

--- a/pyne/dagmc.pyx
+++ b/pyne/dagmc.pyx
@@ -22,7 +22,9 @@ if sys.version_info[0] >= 3:
 
 # Mesh specific imports
 from pyne.mesh import HAVE_PYTAPS
-if not HAVE_PYTAPS:
+if HAVE_PYTAPS:
+    from pyne.mesh import iMesh
+else:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of dagmc module may be incomplete",
          QAWarning)

--- a/pyne/fluka.py
+++ b/pyne/fluka.py
@@ -17,17 +17,14 @@ from warnings import warn
 from pyne.utils import QAWarning
 
 # Mesh specific imports
-try:
-    from itaps import iMesh
-    HAVE_PYTAPS = True
-except ImportError:
+from pyne.mesh import HAVE_PYTAPS
+
+if HAVE_PYTAPS:
+    from pyne.mesh import Mesh, StatMesh, MeshError, IMeshTag
+else:
     warn("the PyTAPS optional dependency could not be imported. "
-                  "Some aspects of the mcnp module may be incomplete.",
-                  QAWarning)
-    HAVE_PYTAPS = False
-
-from pyne.mesh import Mesh, StatMesh, MeshError, IMeshTag
-
+         "Some aspects of the fluka module may be incomplete.",
+         QAWarning)
 
 class Usrbin(object):
     """This class is the wrapper class for UsrbinTally. This class stores

--- a/pyne/fluka.py
+++ b/pyne/fluka.py
@@ -17,10 +17,11 @@ from warnings import warn
 from pyne.utils import QAWarning
 
 # Mesh specific imports
-from pyne.mesh import HAVE_PYTAPS
+from pyne.mesh import Mesh, StatMesh, MeshError
 
+from pyne.mesh import HAVE_PYTAPS
 if HAVE_PYTAPS:
-    from pyne.mesh import Mesh, StatMesh, MeshError, IMeshTag
+    from pyne.mesh import IMeshTag
 else:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the fluka module may be incomplete.",

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -32,9 +32,11 @@ from pyne.binaryreader import _BinaryReader, _FortranRecord
 warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 # Mesh specific imports
+from pyne.mesh import Mesh, StatMesh
+
 from pyne.mesh import HAVE_PYTAPS
 if HAVE_PYTAPS:
-    from pyne.mesh import Mesh, StatMesh, IMeshTag
+    from pyne.mesh import IMeshTag
 else:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the mcnp module may be incomplete.",

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -32,16 +32,13 @@ from pyne.binaryreader import _BinaryReader, _FortranRecord
 warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 # Mesh specific imports
-try:
-    from itaps import iMesh
-    HAVE_PYTAPS = True
-except ImportError:
+from pyne.mesh import HAVE_PYTAPS
+if HAVE_PYTAPS:
+    from pyne.mesh import Mesh, StatMesh, IMeshTag
+else:
     warn("the PyTAPS optional dependency could not be imported. "
-                  "Some aspects of the mcnp module may be incomplete.",
-                  QAWarning)
-    HAVE_PYTAPS = False
-
-from pyne.mesh import Mesh, StatMesh, IMeshTag
+         "Some aspects of the mcnp module may be incomplete.",
+         QAWarning)
 
 if sys.version_info[0] > 2:
     def cmp(a, b):

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -1408,5 +1408,6 @@ class StatMesh(Mesh):
         return mesh_1
 
 if HAVE_PYTAPS:
-    def mesh_iterate(mesh, mesh_type = iBase.Type.region, topo_type = iMesh.Topology.all):
+    def mesh_iterate(mesh, mesh_type = iBase.Type.region,
+                     topo_type = iMesh.Topology.all):
         return mesh.iterate(mesh_type, topo_type)    

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -13,9 +13,11 @@ warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 try:
     from itaps import iMesh, iBase, iMeshExtensions
+    HAVE_PYTAPS = True
 except ImportError:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the mesh module may be incomplete.", QAWarning)
+    HAVE_PYTAPS = False
 
 from pyne.material import Material, MaterialLibrary, MultiMaterial
 

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -1408,5 +1408,5 @@ class StatMesh(Mesh):
         return mesh_1
 
 if HAVE_PYTAPS:
-    def iterate_wrapper(mesh, mesh_type = iBase.Type.region, topo_type = iMesh.Topology.all):
+    def mesh_iterate(mesh, mesh_type = iBase.Type.region, topo_type = iMesh.Topology.all):
         return mesh.iterate(mesh_type, topo_type)    

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -14,6 +14,7 @@ warn(__name__ + " is not yet QA compliant.", QAWarning)
 try:
     from itaps import iMesh, iBase, iMeshExtensions
     HAVE_PYTAPS = True
+
 except ImportError:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the mesh module may be incomplete.", QAWarning)
@@ -1405,3 +1406,7 @@ class StatMesh(Mesh):
                              other.mesh.getTagHandle(tag)[ve_2])
 
         return mesh_1
+
+if HAVE_PYTAPS:
+    def iterate_wrapper(mesh, mesh_type = iBase.Type.region, topo_type = iMesh.Topology.all):
+        return mesh.iterate(mesh_type, topo_type)    

--- a/pyne/partisn.py
+++ b/pyne/partisn.py
@@ -37,18 +37,15 @@ from pyne.binaryreader import _BinaryReader, _FortranRecord
 warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 # Mesh specific imports
-try:
-    from itaps import iMesh
-    HAVE_PYTAPS = True
-except ImportError:
-    warn("the PyTAPS optional dependency could not be imported. "
-                  "All aspects of the partisn module are not imported.",
-                  QAWarning)
-    HAVE_PYTAPS = False
+from pyne.mesh import HAVE_PYTAPS
 
 if HAVE_PYTAPS:
     from pyne.mesh import Mesh, StatMesh, MeshError, IMeshTag
     from pyne import dagmc
+else:
+    warn("the PyTAPS optional dependency could not be imported. "
+         "All aspects of the partisn module are not imported.",
+         QAWarning)
 
 def write_partisn_input(mesh, hdf5, ngroup, **kwargs):
     """This function reads a material-laden geometry file and a pre-made PyNE 

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -45,7 +45,7 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
         rays. If true, a grid of sqrt(num_rays) x sqrt(num_rays) rays is used
         for each mesh row.
     flux_tag : str, optional
-        The iMesh tag for the neutron flux.
+        The mesh tag for the neutron flux.
     fluxin : str, optional
         The name of the ALARA fluxin file to be created.
     reverse : bool, optional
@@ -141,7 +141,7 @@ def photon_sampling_setup(mesh, phtn_src, tags):
     Parameters
     ----------
     mesh : PyNE Mesh
-       The object containing the iMesh instance to be tagged.
+       The object containing the mesh instance to be tagged.
     phtn_src : str
         The path of the ALARA phtn_file.
     tags: dict

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -14,7 +14,7 @@ from pyne.mesh import HAVE_PYTAPS
 
 
 if HAVE_PYTAPS:
-    from pyne.mesh import iBase, iMesh, iMeshExtensions
+    from pyne.mesh import iBase, iMesh, iMeshExtensions, iterate_wrapper
 else:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the variance reduction module may be incomplete.",
@@ -66,16 +66,12 @@ def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,
     """
 
     # find number of energy groups
-    e_groups = adj_flux_mesh.mesh.getTagHandle(adj_flux_tag)[list(
-                adj_flux_mesh.mesh.iterate(iBase.Type.region,
-                                           iMesh.Topology.all))[0]]
+    e_groups = adj_flux_mesh.mesh.getTagHandle(adj_flux_tag)[list(iterate_wrapper(adj_flux_mesh.mesh))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
 
     # verify source (q) mesh has the same number of energy groups
-    q_e_groups = q_mesh.mesh.getTagHandle(q_tag)[list(
-                  q_mesh.mesh.iterate(iBase.Type.region,
-                                      iMesh.Topology.all))[0]]
+    q_e_groups = q_mesh.mesh.getTagHandle(q_tag)[list(iterate_wrapper(q_mesh.mesh))[0]]
     q_e_groups = np.atleast_1d(q_e_groups)
     num_q_e_groups = len(q_e_groups)
 
@@ -86,8 +82,8 @@ def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,
                                                                q_mesh, q_tag))
 
     # create volume element (ve) iterators
-    adj_ves = adj_flux_mesh.mesh.iterate(iBase.Type.region, iMesh.Topology.all)
-    q_ves = q_mesh.mesh.iterate(iBase.Type.region, iMesh.Topology.all)
+    adj_ves = iterate_wrapper(adj_flux_mesh.mesh)
+    q_ves = iterate_wrapper(q_mesh.mesh)
 
     # calculate total source strength
     q_tot = 0
@@ -111,9 +107,9 @@ def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,
 
     # generate weight windows and biased source densities using R
     tag_ww = ww_mesh.mesh.createTag(ww_tag, num_e_groups, float)
-    ww_ves = ww_mesh.mesh.iterate(iBase.Type.region, iMesh.Topology.all)
+    ww_ves = iterate_wrapper(ww_mesh.mesh)
     tag_q_bias = q_bias_mesh.mesh.createTag(q_bias_tag, num_e_groups, float)
-    q_bias_ves = q_bias_mesh.mesh.iterate(iBase.Type.region, iMesh.Topology.all)
+    q_bias_ves = iterate_wrapper(q_bias_mesh.mesh)
     # reset previously created iterators
     q_ves.reset()
     adj_ves.reset()

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -12,6 +12,7 @@ warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 from pyne.mesh import HAVE_PYTAPS
 
+
 if not HAVE_PYTAPS:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the variance reduction module may be incomplete.",

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -10,9 +10,9 @@ import numpy as np
 
 warn(__name__ + " is not yet QA compliant.", QAWarning)
 
-try:
-    from itaps import iMesh, iBase, iMeshExtensions
-except ImportError:
+from pyne.mesh import HAVE_PYTAPS
+
+if not HAVE_PYTAPS:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the variance reduction module may be incomplete.",
          QAWarning)

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -13,7 +13,9 @@ warn(__name__ + " is not yet QA compliant.", QAWarning)
 from pyne.mesh import HAVE_PYTAPS
 
 
-if not HAVE_PYTAPS:
+if HAVE_PYTAPS:
+    from pyne.mesh import iBase, iMesh, iMeshExtensions
+else:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the variance reduction module may be incomplete.",
          QAWarning)

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -14,7 +14,7 @@ from pyne.mesh import HAVE_PYTAPS
 
 
 if HAVE_PYTAPS:
-    from pyne.mesh import iBase, iMesh, iMeshExtensions, iterate_wrapper
+    from pyne.mesh import iterate_wrapper
 else:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the variance reduction module may be incomplete.",

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -14,7 +14,7 @@ from pyne.mesh import HAVE_PYTAPS
 
 
 if HAVE_PYTAPS:
-    from pyne.mesh import iterate_wrapper
+    from pyne.mesh import mesh_iterate
 else:
     warn("the PyTAPS optional dependency could not be imported. "
          "Some aspects of the variance reduction module may be incomplete.",
@@ -66,12 +66,12 @@ def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,
     """
 
     # find number of energy groups
-    e_groups = adj_flux_mesh.mesh.getTagHandle(adj_flux_tag)[list(iterate_wrapper(adj_flux_mesh.mesh))[0]]
+    e_groups = adj_flux_mesh.mesh.getTagHandle(adj_flux_tag)[list(mesh_iterate(adj_flux_mesh.mesh))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
 
     # verify source (q) mesh has the same number of energy groups
-    q_e_groups = q_mesh.mesh.getTagHandle(q_tag)[list(iterate_wrapper(q_mesh.mesh))[0]]
+    q_e_groups = q_mesh.mesh.getTagHandle(q_tag)[list(mesh_iterate(q_mesh.mesh))[0]]
     q_e_groups = np.atleast_1d(q_e_groups)
     num_q_e_groups = len(q_e_groups)
 
@@ -82,8 +82,8 @@ def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,
                                                                q_mesh, q_tag))
 
     # create volume element (ve) iterators
-    adj_ves = iterate_wrapper(adj_flux_mesh.mesh)
-    q_ves = iterate_wrapper(q_mesh.mesh)
+    adj_ves = mesh_iterate(adj_flux_mesh.mesh)
+    q_ves = mesh_iterate(q_mesh.mesh)
 
     # calculate total source strength
     q_tot = 0
@@ -107,9 +107,9 @@ def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,
 
     # generate weight windows and biased source densities using R
     tag_ww = ww_mesh.mesh.createTag(ww_tag, num_e_groups, float)
-    ww_ves = iterate_wrapper(ww_mesh.mesh)
+    ww_ves = mesh_iterate(ww_mesh.mesh)
     tag_q_bias = q_bias_mesh.mesh.createTag(q_bias_tag, num_e_groups, float)
-    q_bias_ves = iterate_wrapper(q_bias_mesh.mesh)
+    q_bias_ves = mesh_iterate(q_bias_mesh.mesh)
     # reset previously created iterators
     q_ves.reset()
     adj_ves.reset()

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -66,12 +66,14 @@ def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,
     """
 
     # find number of energy groups
-    e_groups = adj_flux_mesh.mesh.getTagHandle(adj_flux_tag)[list(mesh_iterate(adj_flux_mesh.mesh))[0]]
+    e_groups = adj_flux_mesh.mesh.getTagHandle(adj_flux_tag)[list(
+        mesh_iterate(adj_flux_mesh.mesh))[0]]
     e_groups = np.atleast_1d(e_groups)
     num_e_groups = len(e_groups)
 
     # verify source (q) mesh has the same number of energy groups
-    q_e_groups = q_mesh.mesh.getTagHandle(q_tag)[list(mesh_iterate(q_mesh.mesh))[0]]
+    q_e_groups = q_mesh.mesh.getTagHandle(q_tag)[list(
+        mesh_iterate(q_mesh.mesh))[0]]
     q_e_groups = np.atleast_1d(q_e_groups)
     num_q_e_groups = len(q_e_groups)
 


### PR DESCRIPTION
This PR isolates as many references to iMesh as possible in preparation for a pyne.mesh implementation supported by pymoab. 

This addresses issues #951 #952 #953 #954 #949 #957 #980 #956.