### PR TITLE
Openmc mat write

### DIFF
--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -38,6 +38,7 @@ cdef extern from "material.h" namespace "pyne":
 
         # Methods
         void norm_comp() except +
+        std_string openmc(std_string) except +
         std_string mcnp(std_string) except +
         std_string fluka(int, std_string) except +
         bool not_fluka_builtin(std_string) except +

--- a/pyne/cpp_nucname.pxd
+++ b/pyne/cpp_nucname.pxd
@@ -89,6 +89,13 @@ cdef extern from "nucname.h" namespace "pyne::nucname":
     int mcnp_to_id(char *) except +
     int mcnp_to_id(std_string) except +
 
+    # OpenMC Functions 
+    std_string openmc(int) except + 
+    std_string openmc(char *) except + 
+    std_string openmc(std_string) except + 
+    int openmc_to_id(char *) except +
+    int openmc_to_id(std_string) except +
+
     # FLUKA Functions 
     std_string fluka(int) except + 
     int fluka_to_id(char *) except + 

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -346,6 +346,14 @@ cdef class _Material:
         card = self.mat_pointer.mcnp(frac_type.encode())
         return card.decode()
 
+    def openmc(self, frac_type='mass'):
+        """openmc(frac_type)
+        Return an openmc xml element for the material
+        """
+        cdef std_string mat
+        mat = self.mat_pointer.openmc(frac_type)
+        return mat.decode()
+    
     def fluka(self, fid, frac_type='mass'):
         """fluka()
         Return a fluka material record if there is only one component,

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -351,7 +351,7 @@ cdef class _Material:
         Return an openmc xml element for the material
         """
         cdef std_string mat
-        mat = self.mat_pointer.openmc(frac_type)
+        mat = self.mat_pointer.openmc(frac_type.encode())
         return mat.decode()
     
     def fluka(self, fid, frac_type='mass'):

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1607,6 +1607,22 @@ class Material(_Material, collections.MutableMapping):
         with open(filename, 'a') as f:
             f.write(self.mcnp(frac_type))
 
+    def write_openmc(self, filename, frac_type='mass'):
+        """write_openmc(self, filename, frac_type='mass')
+        The method appends an OpenMC mass fraction definition, with
+        attributes to the file with the supplied filename.
+
+        Parameters
+        ----------
+        filename : str
+            The file to append the material definition to.
+        frac_type : str, optional
+            Either 'mass' or 'atom'. Speficies whether mass or atom fractions
+            are used to describe material composition.
+        """
+        with open(filename, 'a') as f:
+            f.write(self.openmc(frac_type))
+            
     def alara(self):
         """alara(self)
         This method returns an ALARA material in string form, with relevant

--- a/pyne/nucname.pyx
+++ b/pyne/nucname.pyx
@@ -458,15 +458,9 @@ def openmc(nuc):
 
     Returns
     -------
-    newnuc : int
+    newnuc : str
         Output nuclide in OpenMC form.
 
-    Notes
-    -----
-    Most metastables in this form add 300 + 100*m where
-    m is the isomeric state (U-236m = 92636).  However,
-    OpenMC special cases Am-242 and Am-242m by switching
-    the meaning. Thus Am-242m = 95242 and Am-242 = 95642.
 
     """
 
@@ -480,17 +474,17 @@ def openmc(nuc):
     return newnuc
 
 def openmc_to_id(nuc):
-    """Converts a nuclide directly from OpenMC form (92636) to
+    """Converts a nuclide directly from OpenMC form to
     the canonical identifier form.
 
     Parameters
     ----------
-    nuc : int or str
+    nuc : str
         Input nuclide in OpenMC form.
 
     Returns
     -------
-    newnuc : int
+    newnuc : id
         Output nuclide in identifier form.
 
     """

--- a/pyne/nucname.pyx
+++ b/pyne/nucname.pyx
@@ -448,6 +448,58 @@ def mcnp_to_id(nuc):
         raise NucTypeError(nuc)
     return newnuc
 
+def openmc(nuc):
+    """Converts a nuclide to its OpenMC form (92636).
+
+    Parameters
+    ----------
+    nuc : int or str
+        Input nuclide.
+
+    Returns
+    -------
+    newnuc : int
+        Output nuclide in OpenMC form.
+
+    Notes
+    -----
+    Most metastables in this form add 300 + 100*m where
+    m is the isomeric state (U-236m = 92636).  However,
+    OpenMC special cases Am-242 and Am-242m by switching
+    the meaning. Thus Am-242m = 95242 and Am-242 = 95642.
+
+    """
+
+    if isinstance(nuc, basestring):
+        nuc_bytes = nuc.encode()
+        newnuc = cpp_nucname.openmc(<char *> nuc_bytes)
+    elif isinstance(nuc, int):
+        newnuc = cpp_nucname.openmc(<int> nuc)
+    else:
+        raise NucTypeError(nuc)
+    return newnuc
+
+def openmc_to_id(nuc):
+    """Converts a nuclide directly from OpenMC form (92636) to
+    the canonical identifier form.
+
+    Parameters
+    ----------
+    nuc : int or str
+        Input nuclide in OpenMC form.
+
+    Returns
+    -------
+    newnuc : int
+        Output nuclide in identifier form.
+
+    """
+    if isinstance(nuc, basestring):
+        nuc_bytes = nuc.encode()
+        newnuc = cpp_nucname.openmc_to_id(<char *> nuc_bytes)
+    else:
+        raise NucTypeError(nuc)
+    return newnuc
 
 def fluka(nuc):
     """Converts a nuclide to its FLUKA name.

--- a/pyne/nucname.pyx
+++ b/pyne/nucname.pyx
@@ -449,7 +449,7 @@ def mcnp_to_id(nuc):
     return newnuc
 
 def openmc(nuc):
-    """Converts a nuclide to its OpenMC form (92636).
+    """Converts a nuclide to its OpenMC form (GND).
 
     Parameters
     ----------
@@ -471,7 +471,7 @@ def openmc(nuc):
         newnuc = cpp_nucname.openmc(<int> nuc)
     else:
         raise NucTypeError(nuc)
-    return newnuc
+    return newnuc.decode()
 
 def openmc_to_id(nuc):
     """Converts a nuclide directly from OpenMC form to
@@ -488,11 +488,8 @@ def openmc_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
-        nuc_bytes = nuc.encode()
-        newnuc = cpp_nucname.openmc_to_id(<char *> nuc_bytes)
-    else:
-        raise NucTypeError(nuc)
+    nuc_bytes = nuc.encode()
+    newnuc = cpp_nucname.openmc_to_id(<char *> nuc_bytes)
     return newnuc
 
 def fluka(nuc):

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -541,7 +541,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
     oss << std::endl;
   }
 
-
+  // other OpenMC material properties
   if(metadata.isMember("sab")) {
     oss << indent;
     oss << "<sab name=";
@@ -550,6 +550,30 @@ std::string pyne::Material::openmc(std::string frac_type) {
     oss << std::endl;
   }
 
+  if(metadata.isMember("temperature")) {
+    oss << indent;
+    oss << "<temperature>";
+    oss << new_quote << metadata["temperature"] << end_quote;
+    oss << "</temperature>";
+    oss << std::endl;
+  }
+
+  if(metadata.isMember("macroscopic")) {
+    oss << indent;
+    oss << "<macroscopic name=";
+    oss << new_quote << metadata["macroscropic"] << end_quote;
+    oss << "/>";
+    oss << std::endl;
+  }
+
+  if(metadata.isMember("isotropic")) {
+    oss << indent;
+    oss << "<isotropic>";
+    oss << new_quote << metadata["isotropic"] << end_quote;
+    oss << "</isotropic>";
+    oss << std::endl;
+  }
+  
   // close the material node
   oss << "</material>" << std::endl;
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -559,7 +559,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   if(temp_mat.metadata.isMember("sab")) {
     oss << indent;
     oss << "<sab name=";
-    oss << new_quote << temp_mat.metadata["sab"] << end_quote;
+    oss << new_quote << temp_mat.metadata["sab"].asString() << end_quote;
     oss << "/>";
     oss << std::endl;
   }
@@ -567,7 +567,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   if(temp_mat.metadata.isMember("temperature")) {
     oss << indent;
     oss << "<temperature>";
-    oss << new_quote << temp_mat.metadata["temperature"] << end_quote;
+    oss << new_quote << temp_mat.metadata["temperature"].asString() << end_quote;
     oss << "</temperature>";
     oss << std::endl;
   }
@@ -575,7 +575,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   if(temp_mat.metadata.isMember("macroscopic")) {
     oss << indent;
     oss << "<macroscopic name=";
-    oss << new_quote << temp_mat.metadata["macroscropic"] << end_quote;
+    oss << new_quote << temp_mat.metadata["macroscropic"].asString() << end_quote;
     oss << "/>";
     oss << std::endl;
   }
@@ -583,7 +583,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   if(temp_mat.metadata.isMember("isotropic")) {
     oss << indent;
     oss << "<isotropic>";
-    oss << new_quote << temp_mat.metadata["isotropic"] << end_quote;
+    oss << new_quote << temp_mat.metadata["isotropic"].asString() << end_quote;
     oss << "</isotropic>";
     oss << std::endl;
   }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -476,6 +476,77 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   delete[] mat_data;
 }
 
+std::string pyne::Material::openmc(std::string frac_type) {
+  std::ostringstream oss;
+
+  // vars for consistency
+  std::string new_quote = "\"";
+  std::string end_quote = "\" ";
+  std::string indent = "  ";
+  
+  // open the material element
+  oss << "<material id=" ;
+
+  // add the mat number
+  if(metadata.isMember("mat_number")) {
+    int mat_num = metadata["mat_number"].asInt();
+    oss << new_quote << mat_num << end_quote;
+  }
+  // mat numbers are required for openmc
+  else {
+    oss << new_quote << "?" << end_quote;
+  }
+  // close the material tag
+  oss << ">";
+  // new line
+  oss << std::endl;
+
+  //indent
+  oss << indent;
+
+  // specify density
+  oss << "<density ";
+  oss << "value=" << std::setprecision(2) << std::fixed << new_quote << density << end_quote;
+  oss << "units=" << new_quote << "g/cc" << end_quote << "/>";
+  // new line
+  oss << std::endl;
+
+  std::map<int, double> fracs;
+  fracs = to_atom_frac();
+  
+  // add nuclides
+  comp_map::iterator f;
+  for(f = fracs.begin(); f != fracs.end(); f++) {
+    //indent
+    oss << "  ";
+    // start a new nuclide element
+    oss << "<nuclide name=";
+    oss << new_quote << pyne::nucname::name(f->first) << end_quote;
+    oss << "ao=";
+    oss << std::setprecision(4) << std::scientific << new_quote << f->second << end_quote;
+    oss << "/>";
+    // new line
+    oss << std::endl;
+  }
+
+
+  if(metadata.isMember("sab")) {
+    oss << indent;
+    oss << "<sab name=";
+    oss << new_quote << metadata["sab"] << end_quote;
+    oss << "/>";
+    oss << std::endl;
+  }
+
+  // close the material node
+
+  oss << "</material>" << std::endl;
+
+  return oss.str();
+  
+}
+
+
 std::string pyne::Material::mcnp(std::string frac_type) {
   //////////////////// Begin card creation ///////////////////////
   std::ostringstream oss;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -512,7 +512,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   if (temp_mat.density < 0.0) {
     std::cout << "Warning: A density < 0.0 was found. This is not valid for use in OpenMC." << std::endl;
   }
-  oss << "value=" << std::setprecision(2) << std::fixed << new_quote << temp_mat.density << end_quote;
+  oss << "value=" <<  std::fixed << new_quote << temp_mat.density << end_quote;
   oss << "units=" << new_quote << "g/cc" << end_quote << "/>";
   // new line
   oss << std::endl;
@@ -529,8 +529,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
   
   // add nuclides
-  comp_map::iterator f;
-  for(f = fracs.begin(); f != fracs.end(); f++) {
+  for(comp_map::iterator f = fracs.begin(); f != fracs.end(); f++) {
     //indent
     oss << "  ";
     // start a new nuclide element

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -543,17 +543,9 @@ std::string pyne::Material::openmc(std::string frac_type) {
     //indent
     oss << "  ";
     // start a new nuclide element
-    oss << "<nuclide name=";
-    std::string nuclide_name_str = pyne::nucname::name(f->first);
-    // format metadata
-    if ('M' == nuclide_name_str.back()) {
-      nuclide_name_str.back() = '_';
-      nuclide_name_str.append("m");
-      int meta_id = pyne::nucname::snum(f->first);
-      std::string meta_str = std::to_string(meta_id);
-      nuclide_name_str.append(meta_str);
-    }
-    oss << new_quote << nuclide_name_str << end_quote;        
+    oss << "<nuclide name=" << new_quote;
+    oss << pyne::nucname::openmc(f->first);
+    oss << end_quote;        
     oss << frac_attrib;
     oss << std::setprecision(4) << std::scientific << new_quote << f->second << end_quote;
     oss << "/>";

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -490,7 +490,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   oss << "<material id=" ;
 
   // add the mat number
-  if(temp_mat.metadata.isMember("mat_number")) {
+  if (temp_mat.metadata.isMember("mat_number")) {
     int mat_num = temp_mat.metadata["mat_number"].asInt();
     oss << new_quote << mat_num << end_quote;
   }
@@ -499,6 +499,12 @@ std::string pyne::Material::openmc(std::string frac_type) {
     throw pyne::ValueError("No material number found in metadata. This is not valid for use in OpenMC.");
     oss << new_quote << "?" << end_quote;
   }
+
+  // add name if specified
+  if (temp_mat.metadata.isMember("mat_name")) {
+    oss << "name=" << new_quote << temp_mat.metadata["mat_name"].asString() << end_quote;
+  }
+  
   // close the material tag
   oss << ">";
   // new line

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -512,7 +512,10 @@ std::string pyne::Material::openmc(std::string frac_type) {
   if (temp_mat.density < 0.0) {
     std::cout << "Warning: A density < 0.0 was found. This is not valid for use in OpenMC." << std::endl;
   }
-  oss << "value=" <<  std::fixed << new_quote << temp_mat.density << end_quote;
+  std::string density_str = std::to_string(temp_mat.density);
+  // remove trailing zeros
+  density_str.erase( density_str.find_last_not_of('0') + 1, std::string::npos);
+  oss << "value=" <<  std::fixed << new_quote << density_str << end_quote;
   oss << "units=" << new_quote << "g/cc" << end_quote << "/>";
   // new line
   oss << std::endl;
@@ -534,7 +537,16 @@ std::string pyne::Material::openmc(std::string frac_type) {
     oss << "  ";
     // start a new nuclide element
     oss << "<nuclide name=";
-    oss << new_quote << pyne::nucname::name(f->first) << end_quote;
+    std::string nuclide_name_str = pyne::nucname::name(f->first);
+    // format metadata
+    if ('M' == nuclide_name_str.back()) {
+      nuclide_name_str.back() = '_';
+      nuclide_name_str.append("m");
+      int meta_id = pyne::nucname::snum(f->first);
+      std::string meta_str = std::to_string(meta_id);
+      nuclide_name_str.append(meta_str);
+    }
+    oss << new_quote << nuclide_name_str << end_quote;        
     oss << frac_attrib;
     oss << std::setprecision(4) << std::scientific << new_quote << f->second << end_quote;
     oss << "/>";

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -506,13 +506,25 @@ std::string pyne::Material::openmc(std::string frac_type) {
 
   // specify density
   oss << "<density ";
+    // if density is negtaive, report to user
+  if (density < 0.0) {
+    std::cout << "Warning: A density < 0.0 was found. This is not valid for use in OpenMC." << std::endl;
+  }
   oss << "value=" << std::setprecision(2) << std::fixed << new_quote << density << end_quote;
   oss << "units=" << new_quote << "g/cc" << end_quote << "/>";
   // new line
   oss << std::endl;
 
   std::map<int, double> fracs;
-  fracs = to_atom_frac();
+  std::string frac_attrib;
+  if(frac_type == "atom") {
+    fracs = to_atom_frac();
+    frac_attrib = "ao=";
+  }
+  else {
+    fracs = comp;
+    frac_attrib = "wo=";
+  }
   
   // add nuclides
   comp_map::iterator f;
@@ -522,7 +534,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
     // start a new nuclide element
     oss << "<nuclide name=";
     oss << new_quote << pyne::nucname::name(f->first) << end_quote;
-    oss << "ao=";
+    oss << frac_attrib;
     oss << std::setprecision(4) << std::scientific << new_quote << f->second << end_quote;
     oss << "/>";
     // new line
@@ -539,13 +551,10 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   // close the material node
-
   oss << "</material>" << std::endl;
 
   return oss.str();
-  
 }
-
 
 std::string pyne::Material::mcnp(std::string frac_type) {
   //////////////////// Begin card creation ///////////////////////

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -496,6 +496,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
   // mat numbers are required for openmc
   else {
+    throw pyne::ValueError("No material number found in metadata. This is not valid for use in OpenMC.");
     oss << new_quote << "?" << end_quote;
   }
   // close the material tag
@@ -510,7 +511,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   oss << "<density ";
     // if density is negtaive, report to user
   if (temp_mat.density < 0.0) {
-    std::cout << "Warning: A density < 0.0 was found. This is not valid for use in OpenMC." << std::endl;
+    throw pyne::ValueError("A density < 0.0 was found. This is not valid for use in OpenMC.");
   }
   std::string density_str = std::to_string(temp_mat.density);
   // remove trailing zeros

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -479,6 +479,8 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
 std::string pyne::Material::openmc(std::string frac_type) {
   std::ostringstream oss;
 
+  pyne::Material temp_mat = this->expand_elements();
+  
   // vars for consistency
   std::string new_quote = "\"";
   std::string end_quote = "\" ";
@@ -488,8 +490,8 @@ std::string pyne::Material::openmc(std::string frac_type) {
   oss << "<material id=" ;
 
   // add the mat number
-  if(metadata.isMember("mat_number")) {
-    int mat_num = metadata["mat_number"].asInt();
+  if(temp_mat.metadata.isMember("mat_number")) {
+    int mat_num = temp_mat.metadata["mat_number"].asInt();
     oss << new_quote << mat_num << end_quote;
   }
   // mat numbers are required for openmc
@@ -507,10 +509,10 @@ std::string pyne::Material::openmc(std::string frac_type) {
   // specify density
   oss << "<density ";
     // if density is negtaive, report to user
-  if (density < 0.0) {
+  if (temp_mat.density < 0.0) {
     std::cout << "Warning: A density < 0.0 was found. This is not valid for use in OpenMC." << std::endl;
   }
-  oss << "value=" << std::setprecision(2) << std::fixed << new_quote << density << end_quote;
+  oss << "value=" << std::setprecision(2) << std::fixed << new_quote << temp_mat.density << end_quote;
   oss << "units=" << new_quote << "g/cc" << end_quote << "/>";
   // new line
   oss << std::endl;
@@ -518,11 +520,11 @@ std::string pyne::Material::openmc(std::string frac_type) {
   std::map<int, double> fracs;
   std::string frac_attrib;
   if(frac_type == "atom") {
-    fracs = to_atom_frac();
+    fracs = temp_mat.to_atom_frac();
     frac_attrib = "ao=";
   }
   else {
-    fracs = comp;
+    fracs = temp_mat.comp;
     frac_attrib = "wo=";
   }
   
@@ -542,34 +544,34 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   // other OpenMC material properties
-  if(metadata.isMember("sab")) {
+  if(temp_mat.metadata.isMember("sab")) {
     oss << indent;
     oss << "<sab name=";
-    oss << new_quote << metadata["sab"] << end_quote;
+    oss << new_quote << temp_mat.metadata["sab"] << end_quote;
     oss << "/>";
     oss << std::endl;
   }
 
-  if(metadata.isMember("temperature")) {
+  if(temp_mat.metadata.isMember("temperature")) {
     oss << indent;
     oss << "<temperature>";
-    oss << new_quote << metadata["temperature"] << end_quote;
+    oss << new_quote << temp_mat.metadata["temperature"] << end_quote;
     oss << "</temperature>";
     oss << std::endl;
   }
 
-  if(metadata.isMember("macroscopic")) {
+  if(temp_mat.metadata.isMember("macroscopic")) {
     oss << indent;
     oss << "<macroscopic name=";
-    oss << new_quote << metadata["macroscropic"] << end_quote;
+    oss << new_quote << temp_mat.metadata["macroscropic"] << end_quote;
     oss << "/>";
     oss << std::endl;
   }
 
-  if(metadata.isMember("isotropic")) {
+  if(temp_mat.metadata.isMember("isotropic")) {
     oss << indent;
     oss << "<isotropic>";
-    oss << new_quote << metadata["isotropic"] << end_quote;
+    oss << new_quote << temp_mat.metadata["isotropic"] << end_quote;
     oss << "</isotropic>";
     oss << std::endl;
   }

--- a/src/material.h
+++ b/src/material.h
@@ -165,6 +165,9 @@ namespace pyne
     void write_hdf5(std::string filename, std::string datapath="/material",
                     std::string nucpath="/nucid", float row=-0.0, int chunksize=100);
 
+    /// Return an openmc xml material element as a string
+    std::string openmc(std::string fact_type = "mass");
+    
     /// Return an mcnp input deck record as a string
     std::string mcnp(std::string frac_type = "mass");
     ///

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -974,6 +974,12 @@ int pyne::nucname::mcnp_to_id(std::string nuc) {
 /************************/
 std::string pyne::nucname::openmc(int nuc) {
   std::string nucname = name(nuc);
+
+  // check aaa value
+  int aaa = anum(nuc);
+  if (aaa == 0) {
+    nucname.append("0");
+  }
   // format metadata
   if ('M' == nucname.back()) {
     nucname.back() = '_';
@@ -1000,7 +1006,6 @@ std::string pyne::nucname::openmc(std::string nuc) {
 int pyne::nucname::openmc_to_id(const char * nuc) {
   return openmc_to_id(std::string(nuc));
 }
-
 
 int pyne::nucname::openmc_to_id(std::string nuc) {
   std::string nucname;

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -969,6 +969,76 @@ int pyne::nucname::mcnp_to_id(std::string nuc) {
   return mcnp_to_id(pyne::to_int(nuc));
 }
 
+/************************/
+/*** openmc functions ***/
+/************************/
+std::string pyne::nucname::openmc(int nuc) {
+
+  std::stringstream ss;
+  std::string nuclide_name_str = name(nuc);
+  // format metadata
+  if ('M' == nuclide_name_str.back()) {
+    nuclide_name_str.back() = '_';
+    nuclide_name_str.append("m");
+    int meta_id = snum(nuc);
+    std::string meta_str = std::to_string(meta_id);
+    nuclide_name_str.append(meta_str);
+  }
+ return ss.str();
+}
+
+std::string pyne::nucname::openmc(const char * nuc) {
+  std::string newnuc (nuc);
+  return openmc(newnuc);
+}
+
+std::string pyne::nucname::openmc(std::string nuc) {
+  return openmc(id(nuc));
+}
+
+//
+// OPENMC -> id
+//
+int pyne::nucname::openmc_to_id(const char * nuc) {
+  return openmc_to_id(std::string(nuc));
+}
+
+
+int pyne::nucname::openmc_to_id(std::string nuc) {
+  std::string nucname;
+  name_zz_t zznames = get_name_zz();
+
+  // first two characters
+  std::string::iterator aaa_start;
+  int zzz = 0;
+  if (zznames.count(nuc.substr(0,2)) == 1) {
+    aaa_start = nuc.begin() + 2;
+    zzz = zznames[nuc.substr(0,2)];
+  }
+  // then try only the first
+  else if (zznames.count(nuc.substr(0,1)) == 1) {
+    aaa_start = nuc.begin() + 1;
+    zzz = zznames[nuc.substr(0,1)];
+  } else {
+    throw NotANuclide(nuc, "Not in the OpenMC format");
+  }
+
+  // set aaa - stop on "-" if the character exists
+  std::string::iterator aaa_end = nuc.begin() + nuc.find("-");
+  int aaa = pyne::to_int(nuc.substr(aaa_start - nuc.begin(), aaa_end - aaa_start));
+
+  // check for metastable state
+  int m = 0;
+  if (aaa_end != nuc.end()) {
+    std::string::iterator m_start = aaa_end + 1; // move forward once to skip "m" character
+    m = pyne::to_int(nuc.substr(m_start - nuc.begin(), nuc.end() - m_start));
+  }
+
+  // form integer id and return
+  return (zzz * 10000000) + (aaa * 10000) + m;
+    
+}
+
 
 /**********************/
 /*** fluka functions ***/

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -973,8 +973,6 @@ int pyne::nucname::mcnp_to_id(std::string nuc) {
 /*** openmc functions ***/
 /************************/
 std::string pyne::nucname::openmc(int nuc) {
-
-  std::stringstream ss;
   std::string nucname = name(nuc);
   // format metadata
   if ('M' == nucname.back()) {
@@ -1024,13 +1022,13 @@ int pyne::nucname::openmc_to_id(std::string nuc) {
   }
 
   // set aaa - stop on "-" if the character exists
-  std::string::iterator aaa_end = nuc.begin() + nuc.find("-");
+  std::string::iterator aaa_end = std::find(nuc.begin(), nuc.end(), '_');
   int aaa = pyne::to_int(nuc.substr(aaa_start - nuc.begin(), aaa_end - aaa_start));
 
   // check for metastable state
   int m = 0;
   if (aaa_end != nuc.end()) {
-    std::string::iterator m_start = aaa_end + 1; // move forward once to skip "m" character
+    std::string::iterator m_start = aaa_end + 2; // move forward once to skip "_m" characters
     m = pyne::to_int(nuc.substr(m_start - nuc.begin(), nuc.end() - m_start));
   }
 

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -975,16 +975,16 @@ int pyne::nucname::mcnp_to_id(std::string nuc) {
 std::string pyne::nucname::openmc(int nuc) {
 
   std::stringstream ss;
-  std::string nuclide_name_str = name(nuc);
+  std::string nucname = name(nuc);
   // format metadata
-  if ('M' == nuclide_name_str.back()) {
-    nuclide_name_str.back() = '_';
-    nuclide_name_str.append("m");
+  if ('M' == nucname.back()) {
+    nucname.back() = '_';
+    nucname.append("m");
     int meta_id = snum(nuc);
     std::string meta_str = std::to_string(meta_id);
-    nuclide_name_str.append(meta_str);
+    nucname.append(meta_str);
   }
- return ss.str();
+  return nucname;
 }
 
 std::string pyne::nucname::openmc(const char * nuc) {

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -424,6 +424,29 @@ namespace nucname
   int mcnp_to_id(std::string nuc);
   /// \}
 
+  /// \name OPENMC Form Functions
+  /// \{
+  /// This is the naming convention used by the OpenMC code.
+  /// The OpenMC format for entering nuclides uses a GND format.
+  /// For information on how metastable isotopes are named, please consult the
+  /// OpenMC documentation for more information.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  std::string openmc(int nuc);
+  std::string openmc(const char * nuc);
+  std::string openmc(std::string nuc);
+  /// \}
+
+  /// \name OPENMC Form to Identifier Form Functions
+  /// \{
+  /// This converts from the OPENMC nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in OPENMC form.
+  /// \return an integer id nuclide identifier.
+  int openmc_to_id(const char * nuc);
+  int openmc_to_id(std::string nuc);
+  /// \}
+  
   /// \name FLUKA Form Functions
   /// \{
   /// This is the naming convention used by the FLUKA suite of codes.

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1113,6 +1113,79 @@ def test_deepcopy():
     assert_equal(x, Material({'H1': 1.0}, mass=2.0, density=3.0, atoms_per_molecule=4.0,
                              metadata={'name': 'loki'}))
 
+
+def test_openmc():
+
+    leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
+                   metadata={'mat_number': 2,
+                          'table_ids': {'92235':'15c', '92238':'25c'},
+                          'mat_name':'LEU',
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          'name':'leu'},
+                   density=19.1)
+
+    mass = leu.openmc()
+    mass_exp = ('<material id="2">\n'
+                '  <density value="19.1" units="g/cc"/>\n'
+                '  <nuclide name="U235" wo="4.0000e-02" />\n'
+                '  <nuclide name="U238" wo="6.0000e-01" />\n'
+                '</material>\n')
+    # mass_exp = ('C name: leu\n'
+    #             'C density = 19.1\n'
+    #             'C source: Some URL\n'
+    #             'C comments: this is a long comment that will definitly go over the 80 character\n'
+    #             'C  limit, for science\n'
+    #             'm2\n'
+    #             '     92235.15c -4.0000e-02\n'
+    #             '     92238.25c -9.6000e-01\n')
+    assert_equal(mass, mass_exp)
+
+    atom = leu.openmc(frac_type='atom')
+    atom_exp = ('<material id="2">\n'
+                '  <density value="19.1" units="g/cc"/>\n'
+                '  <nuclide name="U235" ao="4.0491e-02" />\n'
+                '  <nuclide name="U238" ao="9.5951e-01" />\n'
+                '</material>\n')
+    # atom_exp = ('C name: leu\n'
+    #             'C density = 19.1\n'
+    #             'C source: Some URL\n'
+    #             'C comments: this is a long comment that will definitly go over the 80 character\n'
+    #             'C  limit, for science\n'
+    #             'm2\n'
+    #             '     92235.15c 4.0491e-02\n'
+    #             '     92238.25c 9.5951e-01\n')
+    assert_equal(atom, atom_exp)
+
+def test_openmc_mat0():
+
+    leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238': 0.96},
+                   metadata={'mat_number': 2,
+                          'table_ids': {'92235':'15c', '92236':'15c', '92238':'25c'},
+                          'mat_name':'LEU',
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          'name':'leu'},
+                   density=19.1)
+
+    mass = leu.openmc()
+    mass_exp = ('<material id="2">\n'
+                '  <density value="19.1" units="g/cc"/>\n'
+                '  <nuclide name="U235" wo="4.0000e-02" />\n'
+                '  <nuclide name="U238" wo="6.0000e-01" />\n'
+                '</material>\n')
+    # mass_exp = ('C name: leu\n'
+    #             'C density = 19.1\n'
+    #             'C source: Some URL\n'
+    #             'C comments: this is a long comment that will definitly go over the 80 character\n'
+    #             'C  limit, for science\n'
+    #             'm2\n'
+    #             '     92235.15c -4.0000e-02\n'
+    #             '     92238.25c -9.6000e-01\n')
+    assert_equal(mass, mass_exp)
+    
 def test_mcnp():
 
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
@@ -1146,7 +1219,7 @@ def test_mcnp():
                 '     92235.15c 4.0491e-02\n'
                 '     92238.25c 9.5951e-01\n')
     assert_equal(atom, atom_exp)
-
+    
 def test_mcnp_mat0():
 
     leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238': 0.96},
@@ -1170,6 +1243,8 @@ def test_mcnp_mat0():
                 '     92238.25c -9.6000e-01\n')
     assert_equal(mass, mass_exp)
 
+
+    
 
 def test_alara():
 
@@ -1204,6 +1279,40 @@ def test_alara():
                 '     u:238 9.6000E+01 92\n')
     assert_equal(written, expected)
 
+def test_write_openmc():
+    if 'openmc_mass_fracs.txt' in os.listdir('.'):
+        os.remove('openmc_mass_fracs.txt')
+
+    leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
+                   metadata={'mat_number': 2,
+                          'table_ids': {'92235':'15c', '92238':'25c'},
+                          'mat_name':'LEU',
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          'name':'leu'},
+                   density=19.1)
+
+    leu.write_openmc('openmc_mass_fracs.txt')
+    leu.write_openmc('openmc_mass_fracs.txt', frac_type='atom')
+
+
+    
+    with open('openmc_mass_fracs.txt') as f:
+        written = f.read()
+    expected = ('<material id="2">\n'
+                '  <density value="19.1" units="g/cc"/>\n'
+                '  <nuclide name="U235" wo="4.0000e-02" />\n'
+                '  <nuclide name="U238" wo="6.0000e-01" />\n'
+                '</material>\n'
+                '<material id="2">\n'
+                '  <density value="19.1" units="g/cc"/>\n'
+                '  <nuclide name="U235" ao="4.0491e-02" />\n'
+                '  <nuclide name="U238" ao="9.5951e-01" />\n'
+                '</material>\n')
+    assert_equal(written, expected)
+    os.remove('openmc_mass_fracs.txt')
+    
 def test_write_mcnp():
     if 'mcnp_mass_fracs.txt' in os.listdir('.'):
         os.remove('mcnp_mass_fracs.txt')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1128,9 +1128,9 @@ def test_openmc():
 
     mass = leu.openmc()
     mass_exp = ('<material id="2" >\n'
-                '  <density value="19.1" units="g/cc"/>\n'
+                '  <density value="19.10" units="g/cc"/>\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
-                '  <nuclide name="U238" wo="6.0000e-01" />\n'
+                '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')
     # mass_exp = ('C name: leu\n'
     #             'C density = 19.1\n'
@@ -1144,7 +1144,7 @@ def test_openmc():
 
     atom = leu.openmc(frac_type='atom')
     atom_exp = ('<material id="2" >\n'
-                '  <density value="19.1" units="g/cc" />\n'
+                '  <density value="19.10" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
                 '</material>\n')
@@ -1172,9 +1172,10 @@ def test_openmc_mat0():
 
     mass = leu.openmc()
     mass_exp = ('<material id="2" >\n'
-                '  <density value="19.1" units="g/cc" />\n'
+                '  <density value="19.10" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
-                '  <nuclide name="U238" wo="6.0000e-01" />\n'
+                '  <nuclide name="U236" wo="0.0000e-02" />\n'
+                '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')
     # mass_exp = ('C name: leu\n'
     #             'C density = 19.1\n'
@@ -1301,12 +1302,12 @@ def test_write_openmc():
     with open('openmc_mass_fracs.txt') as f:
         written = f.read()
     expected = ('<material id="2" >\n'
-                '  <density value="19.1" units="g/cc" />\n'
+                '  <density value="19.10" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
-                '  <nuclide name="U238" wo="6.0000e-01" />\n'
+                '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n'
                 '<material id="2" >\n'
-                '  <density value="19.1" units="g/cc" />\n'
+                '  <density value="19.10" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
                 '</material>\n')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1127,7 +1127,7 @@ def test_openmc():
                    density=19.1)
 
     mass = leu.openmc()
-    mass_exp = ('<material id="2" >\n'
+    mass_exp = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
@@ -1135,7 +1135,7 @@ def test_openmc():
     assert_equal(mass, mass_exp)
 
     atom = leu.openmc(frac_type='atom')
-    atom_exp = ('<material id="2" >\n'
+    atom_exp = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
@@ -1155,7 +1155,7 @@ def test_openmc_mat0():
                    density=19.1)
 
     mass = leu.openmc()
-    mass_exp = ('<material id="2" >\n'
+    mass_exp = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U236" wo="0.0000e+00" />\n'
@@ -1168,7 +1168,7 @@ def test_openmc_sab():
     leu = Material(nucvec={'H1': 0.66, 'O16': 0.33},
                    metadata={'mat_number': 2,
                              'sab': 'c_H_in_H2O',
-                             'mat_name':'LEU',
+                             'mat_name':'Water',
                              'source':'Some URL',
                              'comments': ('this is a long comment that will definitly '
                                           'go over the 80 character limit, for science'),
@@ -1176,13 +1176,12 @@ def test_openmc_sab():
                    density=1.001)
 
     mass = leu.openmc()
-    mass_exp = ('<material id="2" >\n'
+    mass_exp = ('<material id="2" name="Water" >\n'
                 '  <density value="1.001" units="g/cc" />\n'
                 '  <nuclide name="H1" wo="6.6667e-01" />\n'
                 '  <nuclide name="O16" wo="3.3333e-01" />\n'
                 '  <sab name="c_H_in_H2O" />\n'
                 '</material>\n')
-    print(mass_exp)
     assert_equal(mass, mass_exp)
 
 def test_mcnp():
@@ -1299,12 +1298,12 @@ def test_write_openmc():
     
     with open('openmc_mass_fracs.txt') as f:
         written = f.read()
-    expected = ('<material id="2" >\n'
+    expected = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n'
-                '<material id="2" >\n'
+                '<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1163,25 +1163,26 @@ def test_openmc_mat0():
                 '</material>\n')
     assert_equal(mass, mass_exp)
 
-def test_openmc_mat1():
+def test_openmc_sab():
 
-    leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238': 0.96},
+    leu = Material(nucvec={'H1': 0.66, 'O16': 0.33},
                    metadata={'mat_number': 2,
-                          'table_ids': {'92235':'15c', '92236':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
-                          'source':'Some URL',
-                          'comments': ('this is a long comment that will definitly '
-                                       'go over the 80 character limit, for science'),
+                             'sab': 'c_H_in_H2O',
+                             'mat_name':'LEU',
+                             'source':'Some URL',
+                             'comments': ('this is a long comment that will definitly '
+                                          'go over the 80 character limit, for science'),
                           'name':'leu'},
-                   density=19.101)
+                   density=1.001)
 
     mass = leu.openmc()
     mass_exp = ('<material id="2" >\n'
-                '  <density value="19.101" units="g/cc" />\n'
-                '  <nuclide name="U235" wo="4.0000e-02" />\n'
-                '  <nuclide name="U236" wo="0.0000e+00" />\n'
-                '  <nuclide name="U238" wo="9.6000e-01" />\n'
+                '  <density value="1.001" units="g/cc" />\n'
+                '  <nuclide name="H1" wo="6.6667e-01" />\n'
+                '  <nuclide name="O16" wo="3.3333e-01" />\n'
+                '  <sab name="c_H_in_H2O" />\n'
                 '</material>\n')
+    print(mass_exp)
     assert_equal(mass, mass_exp)
 
 def test_mcnp():

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1174,7 +1174,7 @@ def test_openmc_mat0():
     mass_exp = ('<material id="2" >\n'
                 '  <density value="19.10" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
-                '  <nuclide name="U236" wo="0.0000e-02" />\n'
+                '  <nuclide name="U236" wo="0.0000e+00" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')
     # mass_exp = ('C name: leu\n'

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1127,7 +1127,7 @@ def test_openmc():
                    density=19.1)
 
     mass = leu.openmc()
-    mass_exp = ('<material id="2">\n'
+    mass_exp = ('<material id="2" >\n'
                 '  <density value="19.1" units="g/cc"/>\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="6.0000e-01" />\n'
@@ -1143,8 +1143,8 @@ def test_openmc():
     assert_equal(mass, mass_exp)
 
     atom = leu.openmc(frac_type='atom')
-    atom_exp = ('<material id="2">\n'
-                '  <density value="19.1" units="g/cc"/>\n'
+    atom_exp = ('<material id="2" >\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
                 '</material>\n')
@@ -1171,8 +1171,8 @@ def test_openmc_mat0():
                    density=19.1)
 
     mass = leu.openmc()
-    mass_exp = ('<material id="2">\n'
-                '  <density value="19.1" units="g/cc"/>\n'
+    mass_exp = ('<material id="2" >\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="6.0000e-01" />\n'
                 '</material>\n')
@@ -1300,13 +1300,13 @@ def test_write_openmc():
     
     with open('openmc_mass_fracs.txt') as f:
         written = f.read()
-    expected = ('<material id="2">\n'
-                '  <density value="19.1" units="g/cc"/>\n'
+    expected = ('<material id="2" >\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="6.0000e-01" />\n'
                 '</material>\n'
-                '<material id="2">\n'
-                '  <density value="19.1" units="g/cc"/>\n'
+                '<material id="2" >\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
                 '</material>\n')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1128,7 +1128,7 @@ def test_openmc():
 
     mass = leu.openmc()
     mass_exp = ('<material id="2" >\n'
-                '  <density value="19.10" units="g/cc" />\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')
@@ -1136,7 +1136,7 @@ def test_openmc():
 
     atom = leu.openmc(frac_type='atom')
     atom_exp = ('<material id="2" >\n'
-                '  <density value="19.10" units="g/cc" />\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
                 '</material>\n')
@@ -1144,7 +1144,7 @@ def test_openmc():
 
 def test_openmc_mat0():
 
-    leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238': 0.96},
+    leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238M': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92236':'15c', '92238':'25c'},
                           'mat_name':'LEU',
@@ -1156,13 +1156,34 @@ def test_openmc_mat0():
 
     mass = leu.openmc()
     mass_exp = ('<material id="2" >\n'
-                '  <density value="19.10" units="g/cc" />\n'
+                '  <density value="19.1" units="g/cc" />\n'
+                '  <nuclide name="U235" wo="4.0000e-02" />\n'
+                '  <nuclide name="U236" wo="0.0000e+00" />\n'
+                '  <nuclide name="U238_m1" wo="9.6000e-01" />\n'
+                '</material>\n')
+    assert_equal(mass, mass_exp)
+
+def test_openmc_mat1():
+
+    leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238': 0.96},
+                   metadata={'mat_number': 2,
+                          'table_ids': {'92235':'15c', '92236':'15c', '92238':'25c'},
+                          'mat_name':'LEU',
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          'name':'leu'},
+                   density=19.101)
+
+    mass = leu.openmc()
+    mass_exp = ('<material id="2" >\n'
+                '  <density value="19.101" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U236" wo="0.0000e+00" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')
     assert_equal(mass, mass_exp)
-    
+
 def test_mcnp():
 
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
@@ -1278,12 +1299,12 @@ def test_write_openmc():
     with open('openmc_mass_fracs.txt') as f:
         written = f.read()
     expected = ('<material id="2" >\n'
-                '  <density value="19.10" units="g/cc" />\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n'
                 '<material id="2" >\n'
-                '  <density value="19.10" units="g/cc" />\n'
+                '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
                 '</material>\n')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1128,7 +1128,7 @@ def test_openmc():
 
     mass = leu.openmc()
     mass_exp = ('<material id="2" >\n'
-                '  <density value="19.10" units="g/cc"/>\n'
+                '  <density value="19.10" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1132,14 +1132,6 @@ def test_openmc():
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')
-    # mass_exp = ('C name: leu\n'
-    #             'C density = 19.1\n'
-    #             'C source: Some URL\n'
-    #             'C comments: this is a long comment that will definitly go over the 80 character\n'
-    #             'C  limit, for science\n'
-    #             'm2\n'
-    #             '     92235.15c -4.0000e-02\n'
-    #             '     92238.25c -9.6000e-01\n')
     assert_equal(mass, mass_exp)
 
     atom = leu.openmc(frac_type='atom')
@@ -1148,14 +1140,6 @@ def test_openmc():
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
                 '  <nuclide name="U238" ao="9.5951e-01" />\n'
                 '</material>\n')
-    # atom_exp = ('C name: leu\n'
-    #             'C density = 19.1\n'
-    #             'C source: Some URL\n'
-    #             'C comments: this is a long comment that will definitly go over the 80 character\n'
-    #             'C  limit, for science\n'
-    #             'm2\n'
-    #             '     92235.15c 4.0491e-02\n'
-    #             '     92238.25c 9.5951e-01\n')
     assert_equal(atom, atom_exp)
 
 def test_openmc_mat0():
@@ -1177,14 +1161,6 @@ def test_openmc_mat0():
                 '  <nuclide name="U236" wo="0.0000e+00" />\n'
                 '  <nuclide name="U238" wo="9.6000e-01" />\n'
                 '</material>\n')
-    # mass_exp = ('C name: leu\n'
-    #             'C density = 19.1\n'
-    #             'C source: Some URL\n'
-    #             'C comments: this is a long comment that will definitly go over the 80 character\n'
-    #             'C  limit, for science\n'
-    #             'm2\n'
-    #             '     92235.15c -4.0000e-02\n'
-    #             '     92238.25c -9.6000e-01\n')
     assert_equal(mass, mass_exp)
     
 def test_mcnp():

--- a/tests/test_nucname.py
+++ b/tests/test_nucname.py
@@ -327,6 +327,11 @@ def test_openmc():
     assert_equal(nucname.openmc(2420950), "Am242")
     assert_equal(nucname.openmc(2360921), "U236_m1")
 
+    # natural elements
+    assert_equal(nucname.openmc(20000000), "He0")
+    assert_equal(nucname.openmc(920000000), "U0")
+    assert_equal(nucname.openmc(930000000), "Np0")
+    
 def test_openmc_to_id():
     vals = ["He4", "He4", "Cm244", "Pu239", "Am242_m1", "He4",
             "Am242", "Am242_m1", "U236_m1", "Am242_m4", "Am242_m1",

--- a/tests/test_nucname.py
+++ b/tests/test_nucname.py
@@ -328,9 +328,11 @@ def test_openmc():
     assert_equal(nucname.openmc(2360921), "U236_m1")
 
 def test_openmc_to_id():
-    vals = ["He4", "Cm244", "Pu239", "Am242", "Am242_m1"]
-    ids = [20040000, 962440000, 942390000, 952420000, 952420001]
-    for val, id in set(zip(vals, ids)):
+    vals = ["He4", "He4", "Cm244", "Pu239", "Am242_m1", "He4",
+            "Am242", "Am242_m1", "U236_m1", "Am242_m4", "Am242_m1",
+            "He0", "U0", "Np0", "He4", "Cm244", "Pu239", "Am242",
+            "He4", "Cm244_m1", "Pu239", "Am242", "U0"]
+    for val, id in set(zip(vals, caseids)):
         if val is None:
             continue
         yield check_cases, nucname.openmc_to_id, val, id

--- a/tests/test_nucname.py
+++ b/tests/test_nucname.py
@@ -310,6 +310,23 @@ def test_openmc():
     assert_equal(nucname.openmc(952420), "Am242")
     assert_equal(nucname.openmc(922361), "U236_m1")
 
+    assert_equal(nucname.openmc("H1"), "H1")
+    assert_equal(nucname.openmc("AM242M"), "Am242_m1")
+    assert_equal(nucname.openmc("AM242"), "Am242")
+    assert_equal(nucname.openmc("U236M"), "U236_m1")    
+ 
+    assert_equal(nucname.openmc(1001),  "H1")
+    assert_equal(nucname.openmc(95642), "Am242")
+
+    assert_equal(nucname.openmc("Am-242"),  "Am242")
+    assert_equal(nucname.openmc("Am-242m"), "Am242_m1")
+    assert_equal(nucname.openmc("U-236m"),  "U236_m1")
+
+    assert_equal(nucname.openmc(10010),  "H1")
+    assert_equal(nucname.openmc(2420951), "Am242_m1")
+    assert_equal(nucname.openmc(2420950), "Am242")
+    assert_equal(nucname.openmc(2360921), "U236_m1")
+
 def test_openmc_to_id():
     vals = ["He4", "Cm244", "Pu239", "Am242", "Am242_m1"]
     ids = [20040000, 962440000, 942390000, 952420000, 952420001]

--- a/tests/test_nucname.py
+++ b/tests/test_nucname.py
@@ -304,6 +304,22 @@ def test_mcnp_to_id():
     # tests for invalid inputs
     yield assert_raises, RuntimeError, nucname.mcnp_to_id, 92
 
+def test_openmc():
+    assert_equal(nucname.openmc(10010),  "H1")
+    assert_equal(nucname.openmc(952421), "Am242_m1")
+    assert_equal(nucname.openmc(952420), "Am242")
+    assert_equal(nucname.openmc(922361), "U236_m1")
+
+def test_openmc_to_id():
+    vals = ["He4", "Cm244", "Pu239", "Am242", "Am242_m1"]
+    ids = [20040000, 962440000, 942390000, 952420000, 952420001]
+    for val, id in set(zip(vals, ids)):
+        if val is None:
+            continue
+        yield check_cases, nucname.openmc_to_id, val, id
+
+    # tests for invalid inputs
+    yield assert_raises, Exception, nucname.openmc_to_id, 92
 
 def test_fluka():
     assert_equal(nucname.fluka(  40000000), 'BERYLLIU')


### PR DESCRIPTION
This PR implements an OpenMC writer in the Material class. 

One thing this writer is not robust to is densities, which optional in PyNE, but required in OpenMC. A warning is shown to the user for an invalid (negative) density.

If there is a recommendation on how to approach this better, I'm all ears! 

I think it will be a useful tool for OpenMC users looking to at least avoid a lot of the more tedious work of creating a materials.xml file, if not fully generating one with all of the proper data in place on the Material.


