### PR TITLE
Use pyne data

### DIFF
--- a/pyne/dbgen/nuc_data_make.py
+++ b/pyne/dbgen/nuc_data_make.py
@@ -64,7 +64,7 @@ pyne_logo = """\
 def _fetch_prebuilt(args):
     nuc_data, build_dir = args.nuc_data, args.build_dir
     prebuilt_nuc_data = os.path.join(build_dir, 'prebuilt_nuc_data.h5')
-    prebuilt_nuc_data_url = "https://github.com/pyne/data/raw/move_data/prebuilt_nuc_data.h5"
+    prebuilt_nuc_data_url = "https://github.com/pyne/data/raw/e192adbcb95d11f49eebe6f943e4a188e73befd7/prebuilt_nuc_data.h5"
 
     if not os.path.exists(prebuilt_nuc_data):
         print("Fetching pre-built nuc_data.h5 from " + prebuilt_nuc_data_url)

--- a/pyne/dbgen/nuc_data_make.py
+++ b/pyne/dbgen/nuc_data_make.py
@@ -64,7 +64,7 @@ pyne_logo = """\
 def _fetch_prebuilt(args):
     nuc_data, build_dir = args.nuc_data, args.build_dir
     prebuilt_nuc_data = os.path.join(build_dir, 'prebuilt_nuc_data.h5')
-    prebuilt_nuc_data_url = "http://data.pyne.io/prebuilt_nuc_data.h5"
+    prebuilt_nuc_data_url = "https://github.com/pyne/data/raw/move_data/prebuilt_nuc_data.h5"
 
     if not os.path.exists(prebuilt_nuc_data):
         print("Fetching pre-built nuc_data.h5 from " + prebuilt_nuc_data_url)

--- a/pyne/dbgen/nuc_data_make.py
+++ b/pyne/dbgen/nuc_data_make.py
@@ -64,7 +64,7 @@ pyne_logo = """\
 def _fetch_prebuilt(args):
     nuc_data, build_dir = args.nuc_data, args.build_dir
     prebuilt_nuc_data = os.path.join(build_dir, 'prebuilt_nuc_data.h5')
-    prebuilt_nuc_data_url = "https://github.com/pyne/data/raw/e192adbcb95d11f49eebe6f943e4a188e73befd7/prebuilt_nuc_data.h5"
+    prebuilt_nuc_data_url = "https://github.com/pyne/data/raw/master/prebuilt_nuc_data.h5"
 
     if not os.path.exists(prebuilt_nuc_data):
         print("Fetching pre-built nuc_data.h5 from " + prebuilt_nuc_data_url)

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -42,7 +42,7 @@ O2HLS = None  # Origen Half-lives
 
 def setup():
     global MATS, O2HLS
-    o2benchurl = 'http://data.pyne.io/' + H5NAME
+    o2benchurl = 'https://github.com/pyne/data/raw/e3f20d8fc0823a6fe87879859b5c6f6eabde7252/' + H5NAME
     if not os.path.exists(H5NAME):
         sys.stderr.write("\nDownloading " + o2benchurl + ": ")
         sys.stderr.flush()

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -42,7 +42,7 @@ O2HLS = None  # Origen Half-lives
 
 def setup():
     global MATS, O2HLS
-    o2benchurl = 'https://github.com/pyne/data/raw/e3f20d8fc0823a6fe87879859b5c6f6eabde7252/' + H5NAME
+    o2benchurl = 'https://github.com/pyne/data/raw/master/' + H5NAME
     if not os.path.exists(H5NAME):
         sys.stderr.write("\nDownloading " + o2benchurl + ": ")
         sys.stderr.flush()


### PR DESCRIPTION
This PR fixes CI by relying on files served from the `pyne/data` repository. 

One thing **NOT** included here is a fix for builds of PyNE relying on the origen benchmark data for hdf5 v1.8.13. I couldn't find those in either of the PyNE docker images. 