### PR TITLE
add cell_fracs tag for the default r2s

### DIFF
--- a/news/add_cell_fracs_tag_default_r2s.r2st
+++ b/news/add_cell_fracs_tag_default_r2s.r2st
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Add cell_fracs and cell_number tags for both default and subvoxel r2s modes
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -99,9 +99,8 @@ def irradiation_setup(flux_mesh, cell_mats, alara_params, tally_num=4,
 
     if m.structured:
         cell_fracs = discretize_geom(m, num_rays=num_rays, grid=grid)
-        # tag cell fracs
-        if sub_voxel:
-            m.tag_cell_fracs(cell_fracs)
+        # tag cell fracs for both default and subvoxel r2s modes
+        m.tag_cell_fracs(cell_fracs)
     else:
         cell_fracs = discretize_geom(m)
 


### PR DESCRIPTION
Adding the `cell_number` and `cell_fracs` tag for default R2S is helpful for people to check the cells in a voxel and to do better visualization. Therefore, the `cell_number` and `cell_fracs` tags are added for default R2S in this PR.
Users can use `mesh.cell_number[:]` and `mesh.cell_fracs[:]` to see their contents after they are added in the r2s `step1` and `step2`.