### PR TITLE
add more guidance to the required format of the MCNP meshtal file

### DIFF
--- a/scripts/meshtal_to_mesh
+++ b/scripts/meshtal_to_mesh
@@ -8,7 +8,8 @@ def main():
              'Reads an MCNP meshtal file and creates an h5m mesh file '
              'for each meshtally within the file. The output mesh files are '
              'named <filename>_tally_<tally_num>.h5m. Note that this script '
-             'only works for Cartesian meshes.'))
+             'only works for Cartesian meshes, and only with the default '
+             'setting for OUT=COL format.'))
     parser.add_argument('filename', help='Name of the MCNP meshtal file.')
     parser.add_argument('-o', dest='output', 
                         help=('Base name of the output files:  output files '


### PR DESCRIPTION
The meshtal reader only supports a particular format of mesh tally output - this PR makes that clear in the help string of this script.