### PR TITLE
OpenMC mat fix

### DIFF
--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -71,7 +71,7 @@ cdef extern from "material.h" namespace "pyne":
         map[int, double] dose_per_g(std_string, int) except +
         double molecular_mass() except +
         double molecular_mass(double) except +
-        Material expand_elements() except +
+        Material expand_elements(std_set[int]) except +
         Material collapse_elements(std_set[int]) except +
         double mass_density() except +
         double mass_density(double) except +

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -680,7 +680,7 @@ cdef class _Material:
         """
         return self.mat_pointer.molecular_mass(atoms_per_molecule)
 
-    def expand_elements(self, nucset = set()):
+    def expand_elements(self, nucset=set()):
         """expand_elements(self)
         Exapnds the elements ('U', 'C', etc) in the material by
         replacing them with their natural isotopic distributions with

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -353,7 +353,7 @@ cdef class _Material:
         cdef std_string mat
         mat = self.mat_pointer.openmc(frac_type.encode())
         return mat.decode()
-    
+
     def fluka(self, fid, frac_type='mass'):
         """fluka()
         Return a fluka material record if there is only one component,
@@ -618,7 +618,7 @@ cdef class _Material:
     def decay_heat(self):
         """This provides the decay heat using the comp of the the Material. It
         assumes that the composition of material is given in units of [grams]
-        and returns decay heat in units of [MW].  
+        and returns decay heat in units of [MW].
 
         Returns
         -------
@@ -687,6 +687,12 @@ cdef class _Material:
         the exception of the ids in nucset. This function returns a
         copy.
 
+        Parameters
+        ----------
+	nucset : set, optional
+            A set of integers representing nucids which should not
+            be expanded.
+
         Returns
         -------
         newmat : Material
@@ -701,6 +707,12 @@ cdef class _Material:
         """collapse_elements(self, nucset)
         Collapses the elements in the material, excluding the nucids in
 	the set nucset. This function returns a copy of the material.
+
+        Parameters
+        ----------
+	nucset : set, optional
+            A set of integers representing nucids which should not
+            be collapsed.
 
         Returns
         -------
@@ -1624,7 +1636,7 @@ class Material(_Material, collections.MutableMapping):
         """
         with open(filename, 'a') as f:
             f.write(self.openmc(frac_type))
-            
+
     def alara(self):
         """alara(self)
         This method returns an ALARA material in string form, with relevant

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -682,14 +682,14 @@ cdef class _Material:
 
     def expand_elements(self, nucset=set()):
         """expand_elements(self)
-        Exapnds the elements ('U', 'C', etc) in the material by
+        Expands the elements ('U', 'C', etc) in the material by
         replacing them with their natural isotopic distributions with
         the exception of the ids in nucset. This function returns a
         copy.
 
         Parameters
         ----------
-	nucset : set, optional
+        nucset : set, optional
             A set of integers representing nucids which should not
             be expanded.
 
@@ -710,7 +710,7 @@ cdef class _Material:
 
         Parameters
         ----------
-	nucset : set, optional
+        nucset : set, optional
             A set of integers representing nucids which should not
             be collapsed.
 

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -680,10 +680,12 @@ cdef class _Material:
         """
         return self.mat_pointer.molecular_mass(atoms_per_molecule)
 
-    def expand_elements(self):
+    def expand_elements(self, nucset = set()):
         """expand_elements(self)
-        Exapnds the elements ('U', 'C', etc) in the material by replacing them
-        with their natural isotopic distributions.  This function returns a copy.
+        Exapnds the elements ('U', 'C', etc) in the material by
+        replacing them with their natural isotopic distributions with
+        the exception of the ids in nucset. This function returns a
+        copy.
 
         Returns
         -------
@@ -692,7 +694,7 @@ cdef class _Material:
 
         """
         cdef _Material newmat = Material()
-        newmat.mat_pointer[0] = self.mat_pointer.expand_elements()
+        newmat.mat_pointer[0] = self.mat_pointer.expand_elements(nucset)
         return newmat
 
     def collapse_elements(self, nucset):

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -540,6 +540,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   
   // add nuclides
   for(comp_map::iterator f = fracs.begin(); f != fracs.end(); f++) {
+    if (f->second == 0.0) { continue; }
     //indent
     oss << "  ";
     // start a new nuclide element

--- a/src/material.h
+++ b/src/material.h
@@ -251,7 +251,9 @@ namespace pyne
     comp_map dose_per_g(std::string dose_type, int source=0);
     /// Returns a copy of the current material where all natural elements in the
     /// composition are expanded to their natural isotopic abundances.
-    Material expand_elements();
+    Material expand_elements(std::set<int> exception_ids);
+    // Wrapped version to facilitate calling from python
+    Material expand_elements(int **int_ptr_arry = NULL);
     // Returns a copy of the current material where all the isotopes of the elements
     // are added up, atomic-fraction-wise, unless they are in the exception set
     Material collapse_elements(std::set<int> exception_znum);

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -974,12 +974,12 @@ int pyne::nucname::mcnp_to_id(std::string nuc) {
 /************************/
 std::string pyne::nucname::openmc(int nuc) {
   std::string nucname = name(nuc);
-
+  
   // check aaa value
-  int aaa = anum(nuc);
-  if (aaa == 0) {
+  if (iselement(nuc)) {
     nucname.append("0");
   }
+
   // format metadata
   if ('M' == nucname.back()) {
     nucname.back() = '_';

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1158,7 +1158,6 @@ def test_openmc_mat0():
     mass_exp = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
-                '  <nuclide name="U236" wo="0.0000e+00" />\n'
                 '  <nuclide name="U238_m1" wo="9.6000e-01" />\n'
                 '</material>\n')
     assert_equal(mass, mass_exp)

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1142,6 +1142,18 @@ def test_openmc():
                 '</material>\n')
     assert_equal(atom, atom_exp)
 
+    # check write/read consistency
+    leu.write_hdf5('leu.h5')
+
+    leu_read = Material()
+    leu_read.from_hdf5('leu.h5', '/material')
+
+    mass = leu.openmc()
+    assert_equal(mass, mass_exp)
+
+    atom = leu.openmc(frac_type='atom')
+    assert_equal(atom, atom_exp)
+
 def test_openmc_mat0():
 
     leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238M': 0.96},

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -283,6 +283,13 @@ def test_expand_elements2():
     assert_almost_equal(data.natural_abund(60120000), afrac[60120000])
     assert_almost_equal(data.natural_abund(60130000), afrac[60130000])
 
+def test_expand_elements3():
+    natmat = Material({'C': 1.0})
+    exception_ids = {nucname.id("C")}
+    expmat = natmat.expand_elements(exception_ids)
+    afrac = expmat.to_atom_frac()
+    assert_almost_equal(natmat[60000000], afrac[60000000])
+    
 def test_collapse_elements1():
     """ Very simple test to combine nucids"""
     nucvec = {10010000:  1.0,
@@ -1195,6 +1202,25 @@ def test_openmc_sab():
                 '</material>\n')
     assert_equal(mass, mass_exp)
 
+def test_openmc_c():
+
+    csi = Material()
+    csi.from_atom_frac({'C': 0.5, 'Si': 0.5})
+    csi.metadata= {'mat_number': 2,
+                   'mat_name':'silicon carbide',
+                   'name':'leu'}
+    csi.density = 3.16
+
+    atom = csi.openmc(frac_type='atom')
+    atom_exp = ('<material id="2" name="silicon carbide" >\n'
+                '  <density value="3.16" units="g/cc" />\n'
+                '  <nuclide name="C0" ao="5.0000e-01" />\n'                
+                '  <nuclide name="Si28" ao="4.6112e-01" />\n'
+                '  <nuclide name="Si29" ao="2.3425e-02" />\n'
+                '  <nuclide name="Si30" ao="1.5460e-02" />\n'
+                '</material>\n')
+    assert_equal(atom, atom_exp)
+    
 def test_mcnp():
 
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},


### PR DESCRIPTION
This PR updates OpenMC material writing in the following ways:

  - no longer expands elements, but writes them in the GND format
  - ignores compositions with zero weight/atom fractions in the material composition
 
It adds tests which: 

  - ensure that reading/writing of materials is consistent for the OpenMC format
  - verify the correct output for compositions containing natural elements