### PR TITLE
Total photon source intensities combine

### DIFF
--- a/news/total_photon_source_intensities_combine.rst
+++ b/news/total_photon_source_intensities_combine.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* Combine the subvoxel/voxel R2S loops to calculate the total photon source intensities.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -185,6 +185,7 @@ def total_photon_source_intensity(m, tag_name, sub_voxel=False):
     if sub_voxel:
         cell_fracs = m.cell_fracs[:]
     else:
+        # create a fake cell_fracs
         cell_fracs = np.ones(shape=(len(m), 1), dtype=float)
     max_num_cells = len(cell_fracs[0])
     num_e_groups = len(sd_tag[list(m.iter_ve())[0]]) / max_num_cells

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -184,17 +184,14 @@ def total_photon_source_intensity(m, tag_name, sub_voxel=False):
     intensity = 0.
     if sub_voxel:
         cell_fracs = m.cell_fracs[:]
-        max_num_cells = len(cell_fracs[0])
-        num_e_groups = len(sd_tag[list(m.iter_ve())[0]]) / max_num_cells
-        for idx, _, ve in m:
-            ve_data = sd_tag[ve]
-            for svid in range(max_num_cells):
-                vol = m.elem_volume(ve) * cell_fracs[idx][svid]
-                sv_data = ve_data[num_e_groups*svid:num_e_groups*(svid+1)]
-                intensity += vol * np.sum(sv_data)
     else:
-        for idx, _, ve in m:
-            vol = m.elem_volume(ve)
-            ve_data = sd_tag[ve]
-            intensity += vol*np.sum(ve_data)
+        cell_fracs = np.ones(shape=(len(m), 1), dtype=float)
+    max_num_cells = len(cell_fracs[0])
+    num_e_groups = len(sd_tag[list(m.iter_ve())[0]]) / max_num_cells
+    for idx, _, ve in m:
+        ve_data = sd_tag[ve]
+        for svid in range(max_num_cells):
+            vol = m.elem_volume(ve) * cell_fracs[idx][svid]
+            sv_data = ve_data[num_e_groups*svid:num_e_groups*(svid+1)]
+            intensity += vol * np.sum(sv_data)
     return intensity

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -185,7 +185,6 @@ def total_photon_source_intensity(m, tag_name, sub_voxel=False):
     if sub_voxel:
         cell_fracs = m.cell_fracs[:]
     else:
-        # create a local cell_fracs
         cell_fracs = np.ones(shape=(len(m), 1), dtype=float)
     max_num_cells = len(cell_fracs[0])
     num_e_groups = len(sd_tag[list(m.iter_ve())[0]]) / max_num_cells

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -185,6 +185,7 @@ def total_photon_source_intensity(m, tag_name, sub_voxel=False):
     if sub_voxel:
         cell_fracs = m.cell_fracs[:]
     else:
+        # create a local cell_fracs
         cell_fracs = np.ones(shape=(len(m), 1), dtype=float)
     max_num_cells = len(cell_fracs[0])
     num_e_groups = len(sd_tag[list(m.iter_ve())[0]]) / max_num_cells

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -185,7 +185,7 @@ def total_photon_source_intensity(m, tag_name, sub_voxel=False):
     if sub_voxel:
         cell_fracs = m.cell_fracs[:]
     else:
-        # create a fake cell_fracs
+        # create a cell_fracs
         cell_fracs = np.ones(shape=(len(m), 1), dtype=float)
     max_num_cells = len(cell_fracs[0])
     num_e_groups = len(sd_tag[list(m.iter_ve())[0]]) / max_num_cells


### PR DESCRIPTION
In voxel R2S, there isn't a `cell_fracs` tag, which exists in sub-voxel R2S. So the code for calculating the total photon source intensities are divided into two parts.
Now, a local `cell_fracs` tag for voxel R2S is created, then we can combine the two loops for calculating the total photon source intensities.