### PR TITLE
Fix formulas rendering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.doctest',
-#              'sphinx.ext.imgmath',
               'sphinx.ext.inheritance_diagram',
               'sphinx.ext.autosummary',  # autosummary doesn't work with numpydoc...
               'sphinx.ext.viewcode',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.doctest',
-              'sphinx.ext.imgmath',
+#              'sphinx.ext.imgmath',
               'sphinx.ext.inheritance_diagram',
               'sphinx.ext.autosummary',  # autosummary doesn't work with numpydoc...
               'sphinx.ext.viewcode',


### PR DESCRIPTION
@gonuke 

the `imgmat` extension prevent the proper rendering of the formulas... (see the http://pyne.io/theorymanual/variance_reduction.html?highlight=variance)

I tested this locally, I got the formulas back...

