### PR TITLE
remove requirement that cmake has SSL support

### DIFF
--- a/cmake/DownloadAndExtract.cmake
+++ b/cmake/DownloadAndExtract.cmake
@@ -11,7 +11,7 @@ macro(download_and_extract _url _checkfile)
     if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_base}")
       message(STATUS "Downloading ${_url} -> ${_base}")
       file(DOWNLOAD "${_url}" "${CMAKE_CURRENT_SOURCE_DIR}/${_base}"
-           SHOW_PROGRESS STATUS _rtn TLS_VERIFY OFF)
+           SHOW_PROGRESS STATUS _rtn)
       list(GET _rtn 0 _rtncode)
       if(NOT 0 EQUAL _rtncode)
         message(FATAL_ERROR ${_rtn})

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -206,7 +206,7 @@ endmacro()
 
 macro(pyne_download_platform)
   # Download bateman solver from PyNE data
-  download_platform("https://raw.githubusercontent.com/pyne/data/master" "decay"
+  download_platform("http://raw.githubusercontent.com/pyne/data/master" "decay"
                       ".cpp" ".s")
 
   # Download CRAM solver from PyNE data


### PR DESCRIPTION
This quick fix allows Cmake to be used to download the data that does not have SSL support. Prior to this, I was not able to successfully download the decay and cram data due to lack of SSL support.