### PR TITLE
Pyne user passwd

### DIFF
--- a/docs/install/vb.rst
+++ b/docs/install/vb.rst
@@ -17,5 +17,5 @@ the VirtualBox follow these steps:
      /home/pyne-user/pyne.
   #. Email any questions to pyne-users@googlegroups.com.
 
-In case you need it, the default password for the user "pyne-user" is "pyne".
+The default password for the user "pyne-user" is "pyne".
 

--- a/docs/install/vb.rst
+++ b/docs/install/vb.rst
@@ -17,3 +17,5 @@ the VirtualBox follow these steps:
      /home/pyne-user/pyne.
   #. Email any questions to pyne-users@googlegroups.com.
 
+In case you need it, the default password for the user "pyne-user" is "pyne".
+


### PR DESCRIPTION
Add the password of the "pyne-user" for the VB on the website...

This was a problem in the [pyne mailing-list](https://groups.google.com/forum/#!topic/pyne-users/8Gg-g2dx4pk)