### PR TITLE
disable check

### DIFF
--- a/news/disable_cell_fracs_check.rst
+++ b/news/disable_cell_fracs_check.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:**
+
+* Input check of cell_fracs tag under voxel mode. As the cell_fracs tag is there for voxel/sub-voxel mode.
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -284,17 +284,6 @@ void pyne::Sampler::mesh_tag_data(moab::Range ves,
       rval = mesh->tag_get_data(cell_fracs_tag, ves, &cell_fracs[0]);
       cell_number.resize(num_ves*max_num_cells);
       rval = mesh->tag_get_data(cell_number_tag, ves, &cell_number[0]);
-  } else {
-      // check the existance of tag "cell_number", if there is, report error
-      // "cell_number" tag shouldn't be there if sub_mode is DEFAULT
-      moab::Tag cell_fracs_tag_test;
-      std::string cell_fracs_tag_name_test = "cell_fracs";
-      rval = mesh->tag_get_handle(cell_fracs_tag_name_test.c_str(),
-                                  cell_fracs_tag_test);
-      if (rval != moab::MB_TAG_NOT_FOUND) {
-         throw std::invalid_argument(
-             "The source.h5m contains cell_fracs tag. Wrong source.h5m file used.");
-      }
   }
   std::vector<double> pdf(num_ves*num_e_groups*max_num_cells);
   rval = mesh->tag_get_data(src_tag, ves, &pdf[0]);

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -63,25 +63,6 @@ def test_single_tet_tag_names_map():
     tag_names = {"src_tag_name": "src"}
     assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_USER)
 
-    # subvoxel r2s source.h5m used for r2s calculation
-    cell_fracs = np.zeros(2, dtype=[('idx', np.int64),
-                                    ('cell', np.int64),
-                                    ('vol_frac', np.float64),
-                                    ('rel_error', np.float64)])
-    cell_fracs[:] = [(0, 11, 1.0, 0.0), (1, 11, 1.0, 0.0)]
-    m.tag_cell_fracs(cell_fracs)
-    m.mesh.save(filename)
-    tag_names = {"src_tag_name": "src",
-                 "cell_number_tag_name": "cell_number",
-                 "cell_fracs_tag_name": "cell_fracs"}
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_ANALOG)
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_UNIFORM)
-    tag_names = {"src_tag_name": "src",
-                 "cell_number_tag_name":"cell_number",
-                 "cell_fracs_tag_name": "cell_fracs",
-                 "bias_tag_name": "bias"}
-    assert_raises(ValueError, Sampler, filename, tag_names, e_bounds, DEFAULT_USER)
-
     # wrong bias_tag data (non-zero source_density biased to zero -> NAN weight)
     m.src = IMeshTag(2, float)
     m.src[:] = [[1.0, 1.0]]


### PR DESCRIPTION
The 'cell_fracs' and 'cell_number' tags are kept for both voxel and subvoxel mode of R2S after the PR #1072 . Therefore, this PR disables the code to check the cell_fracs tag under voxel mode. 