### PR TITLE
Add include guards around measure.h for amalgamated pyne

### DIFF
--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -25,7 +25,9 @@
 
 #include <math.h>
 
+#ifndef PYNE_IS_AMALGAMATED
 #include "measure.h"
+#endif
 
 class CartVect {
   private:

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -37,7 +37,9 @@
 
 #include "moab/Range.hpp"
 #include "moab/Core.hpp"
+#ifndef PYNE_IS_AMALGAMATED
 #include "measure.h"
+#endif
 #include "moab/CartVect.hpp"
 
 #ifdef __cplusplus


### PR DESCRIPTION
`measure` cannot be added to amalgamated pyne without adding include guards.