### PR TITLE
Add some diagnostic information when source cell not found.

### DIFF
--- a/share/source.F90
+++ b/share/source.F90
@@ -37,7 +37,9 @@ function find_cell() result(icl_tmp)
     ! icl is now set
 
     if(icl_tmp .le. 0) then
-      write(*,*) 'Nonsense cell number stopping'
+       write(*,*) 'Nonsense cell number: ', icl_tmp
+       write(*,*) 'Looking for cell at position: ', xxx, yyy, zzz
+       write(*,*) 'Stopping'
       stop
     endif
     ! icl now set to be valid cell

--- a/share/source.F90
+++ b/share/source.F90
@@ -38,7 +38,7 @@ function find_cell() result(icl_tmp)
 
     if(icl_tmp .le. 0) then
        write(*,*) 'Nonsense cell number: ', icl_tmp
-       write(*,*) 'Looking for cell at position: ', xxx, yyy, zzz
+       write(*,*) 'Looking for cell at position: ', xxx, yyy, zzz, ' for history ', nps
        write(*,*) 'Stopping'
       stop
     endif


### PR DESCRIPTION
In rare circumstances, an MCNP job will fail when sampling a mesh-based source with the message "Nonsense source cell stopping".  It currently offers no additional information.

This PR adds some output information to help understand when and why this is happening, including the particle history number and x,y,z coordinates of the point in question