### PR TITLE
Add input check ebins

### DIFF
--- a/news/add_input_check_ebins.rst
+++ b/news/add_input_check_ebins.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Check for the existence of the e_bounds file. Print error message when it's missing.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -59,6 +59,9 @@ std::vector<double> pyne::read_e_bounds(std::string e_bounds_file){
     while (inputFile >> value)
       e_bounds.push_back(value);
   }
+  else {
+    throw std::invalid_argument("File e_bounds not found or no read permission");
+  }
   return e_bounds;
 }
 

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -60,7 +60,7 @@ std::vector<double> pyne::read_e_bounds(std::string e_bounds_file){
       e_bounds.push_back(value);
   }
   else {
-    throw std::invalid_argument("File e_bounds not found or no read permission");
+    throw std::runtime_error("File " + e_bounds_file + " not found or no read permission");
   }
   return e_bounds;
 }


### PR DESCRIPTION
This PR is originally pulled in #1099, which is closed by mistake.
There are four input files for r2s photon transport (input, geom.h5m, source.h5m and e_bounds). Users sometimes forget to put `e_bounds` in the working directory and therefore cause a segmentation fault without the message of missing `e_bounds`.

This PR adds error message when the `e_bounds` is missing (or no read permission).
Now the error message:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  File e_bounds not found or no read permission

Program received signal SIGABRT: Process abort signal.

Backtrace for this error:
#0  0x7FDF1A83AE08
#1  0x7FDF1A839F90
#2  0x7FDF19BE94AF
#3  0x7FDF19BE9428
#4  0x7FDF19BEB029
#5  0x7FDF1A22384C
#6  0x7FDF1A2216B5
#7  0x7FDF1A221700
#8  0x7FDF1A221918
#9  0x408CBC in read_e_bounds
#10  0x40B902 in sampling_setup_
#11  0x460AFF in source_
#12  0x5365EC in startp_
#13  0x41BC35 in hstory_
#14  0x42CD98 in trnspt_
#15  0x504BD7 in mcrun_
#16  0x420616 in MAIN__ at main.F90:?
Aborted (core dumped)
```