### PR TITLE
[WIP] Add MaterialLibrary to the C++ API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PYNE_SRCS
   "jsoncpp.cpp"
   "jsoncustomwriter.cpp"
   "material.cpp"
+  "material_library.cpp"
   "nucname.cpp"
   "particle.cpp"
   "rxname.cpp"

--- a/src/material_library.cpp
+++ b/src/material_library.cpp
@@ -1,0 +1,130 @@
+#include <unistd.h>
+#include <iostream>
+
+
+#ifndef PYNE_IS_AMALGAMATED
+  #include "transmuters.h"
+  #include "material.h"
+#endif
+
+// Empty Constructor
+MaterialLibrary::MaterialLibrary() {
+};
+
+// Default constructor
+MaterialLibrary::MaterialLibrary(string filei, string datapath) {
+
+  if (!check_file_exists(file)) {
+    std::cerr << "The file " << file << " does not exist or is read protected" << std::endl;
+    exit(1);
+  }
+  if (!hdf5_path_exists(file, datapath)) {
+    std::cerr << "The datapath " << datapath << " in " << file << " empty." << std::endl;
+    exit(1);
+  }
+
+  // load materials
+  material_library = load_materials(full_filepath);
+
+};
+
+
+// Destructor
+MaterialLibrary::~MaterialLibrary() {
+};
+
+// convert convert a filename into path+filename (for pyne)
+std::string MaterialLibrary::get_full_filepath(char* filename) {
+  std::string file(filename);
+  return MaterialLibrary::get_full_filepath(file);
+}
+
+// convert convert a filename into path+filename (for pyne)
+std::string MaterialLibrary::get_full_filepath(std::string filename) {
+  // remove all extra whitespace
+  filename.erase(std::remove(filename.begin(), filename.end(), ' '), filename.end());
+  // use stdlib call
+  const char* full_filepath = realpath(filename.c_str(), NULL);
+  return std::string(full_filepath);
+}
+
+// see if file exists
+bool MaterialLibrary::check_file_exists(std::string filename) {
+  // from http://stackoverflow.com/questions/12774207/
+  // fastest-way-to-check-if-a-file-exist-using-standard-c-c11-c
+  std::ifstream infile(filename.c_str());
+  return infile.good();
+}
+
+// loads all materials into map
+
+std::map<std::string, pyne::Material> MaterialLibrary::load_pyne_materials(std::string filename, std::string datapath) {
+  std::map<std::string, pyne::Material> library; // material library
+
+  const char* data_path = datapath.c_str();
+
+  if (!hdf5_path_exists(filename, data_path))
+    return library;
+
+  num_materials = get_length_of_table(filename, datapath);
+
+  for (int i = 0 ; i < num_materials ; i++) {
+    pyne::Material mat; // from file
+    mat.from_hdf5(filename, datapath, i);
+    // renumber material number by position in the library
+    mat.metadata["mat_number"] = i + 1;
+    library[mat.metadata["name"].asString()] = mat;
+  }
+
+  return library;
+}
+
+
+// see if path exists before we go on
+bool MaterialLibrary::hdf5_path_exists(std::string filename, std::string datapath) {
+  // Turn off annoying HDF5 errors
+  herr_t status;
+  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+
+  //Set file access properties so it closes cleanly
+  hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+
+  hid_t db = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+
+  bool datapath_exists = h5wrap::path_exists(db, datapath.c_str());
+
+  status = H5Eclear(H5E_DEFAULT);
+
+  // Close the database
+  status = H5Fclose(db);
+
+  return datapath_exists;
+}
+
+int MaterialLibrary::get_length_of_table(std::string filename, std::string datapath) {
+  // Turn off annoying HDF5 errors
+  herr_t status;
+  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+
+  //Set file access properties so it closes cleanly
+  hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+
+  hid_t db = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+
+  hid_t ds = H5Dopen2(db, datapath.c_str(), H5P_DEFAULT);
+
+  // Initilize to dataspace, to find the indices we are looping over
+  hid_t arr_space = H5Dget_space(ds);
+
+  hsize_t arr_dims[1];
+  int arr_ndim = H5Sget_simple_extent_dims(arr_space, arr_dims, NULL);
+
+  status = H5Eclear(H5E_DEFAULT);
+
+  // Close the database
+  status = H5Fclose(db);
+
+  return arr_dims[0];
+}

--- a/src/material_library.cpp
+++ b/src/material_library.cpp
@@ -56,9 +56,8 @@ bool MaterialLibrary::check_file_exists(std::string filename) {
   return infile.good();
 }
 
-// loads all materials into map
-
-std::map<std::string, pyne::Material> MaterialLibrary::load_pyne_materials(std::string filename, std::string datapath) {
+// Load Material library from hdf5 file
+void MaterialLibrary::from_hdf5(std::string filename, std::string datapath, int protocol) {
   std::map<std::string, pyne::Material> library; // material library
 
   const char* data_path = datapath.c_str();
@@ -70,14 +69,22 @@ std::map<std::string, pyne::Material> MaterialLibrary::load_pyne_materials(std::
 
   for (int i = 0 ; i < num_materials ; i++) {
     pyne::Material mat; // from file
-    mat.from_hdf5(filename, datapath, i);
+    mat.from_hdf5(filename, datapath, i, protocol);
     // renumber material number by position in the library
     mat.metadata["mat_number"] = i + 1;
     library[mat.metadata["name"].asString()] = mat;
   }
 
-  return library;
+  material_library = library;
 }
+
+void write_hdf5(std::string filename, std::string datapath="/materials",
+                    std::string nucpath="/nucid", int chunksize=100){
+
+}
+
+
+
 
 
 // see if path exists before we go on

--- a/src/material_library.cpp
+++ b/src/material_library.cpp
@@ -1,37 +1,33 @@
 #include <unistd.h>
 #include <iostream>
 
-
 #ifndef PYNE_IS_AMALGAMATED
-  #include "material_library.h"
+#include "material_library.h"
 #endif
 
 namespace pyne {
 // Empty Constructor
-MaterialLibrary::MaterialLibrary() {
-};
+MaterialLibrary::MaterialLibrary(){};
 
 // Default constructor
 MaterialLibrary::MaterialLibrary(std::string file, std::string datapath) {
-
   if (!check_file_exists(file)) {
-    std::cerr << "The file " << file << " does not exist or is read protected" << std::endl;
+    std::cerr << "The file " << file << " does not exist or is read protected"
+              << std::endl;
     exit(1);
   }
   if (!hdf5_path_exists(file, datapath)) {
-    std::cerr << "The datapath " << datapath << " in " << file << " empty." << std::endl;
+    std::cerr << "The datapath " << datapath << " in " << file << " empty."
+              << std::endl;
     exit(1);
   }
 
   // load materials
   from_hdf5(file);
-
 };
-
 
 // Destructor
-MaterialLibrary::~MaterialLibrary() {
-};
+MaterialLibrary::~MaterialLibrary(){};
 
 // convert convert a filename into path+filename (for pyne)
 std::string MaterialLibrary::get_full_filepath(char* filename) {
@@ -42,7 +38,8 @@ std::string MaterialLibrary::get_full_filepath(char* filename) {
 // convert convert a filename into path+filename (for pyne)
 std::string MaterialLibrary::get_full_filepath(std::string filename) {
   // remove all extra whitespace
-  filename.erase(std::remove(filename.begin(), filename.end(), ' '), filename.end());
+  filename.erase(std::remove(filename.begin(), filename.end(), ' '),
+                 filename.end());
   // use stdlib call
   const char* full_filepath = realpath(filename.c_str(), NULL);
   return std::string(full_filepath);
@@ -56,70 +53,83 @@ bool MaterialLibrary::check_file_exists(std::string filename) {
   return infile.good();
 }
 
-// Load Material library from hdf5 file
-void MaterialLibrary::from_hdf5(std::string filename, std::string datapath, int protocol) {
-  std::map<std::string, pyne::Material> library; // material library
-
+// Append Material to the library from hdf5 file
+void MaterialLibrary::from_hdf5(std::string filename, std::string datapath,
+                                int protocol) {
   const char* data_path = datapath.c_str();
 
-  if (!hdf5_path_exists(filename, data_path))
-    return;
+  if (!hdf5_path_exists(filename, data_path)) return;
 
   int num_materials = get_length_of_table(filename, datapath);
 
-  for (int i = 0 ; i < num_materials ; i++) {
-    pyne::Material mat; // from file
+  for (int i = 0; i < num_materials; i++) {
+    pyne::Material mat;  // from file
+    // read new mat
     mat.from_hdf5(filename, datapath, i, protocol);
-    // renumber material number by position in the library
-    mat.metadata["mat_number"] = i + 1;
-    library[mat.metadata["name"].asString()] = mat;
-    // add new nuclides to the MaterialLibrary nuclist
-    append_to_nuclist(mat);
-  }
 
-  material_library = library;
+    append_to_nuclist(mat);
+    material_library[mat.metadata["name"].asString()] = mat;
+    matlist.insert(mat.metadata["name"].asString());
+  }
+}
+
+void MaterialLibrary::add_material(pyne::Material mat) {
+  std::string mat_name = mat.metadata["name"].asString();
+  std::pair<pyne::mat_iter, bool> ins = material_library.insert(
+      std::pair<std::string, pyne::Material>(mat_name, mat));
+
+  if (ins.second) {
+    append_to_nuclist(mat);
+    matlist.insert(mat.metadata["name"].asString());
+  }
+}
+
+void MaterialLibrary::del_material(pyne::Material mat) {
+  std::string mat_name = mat.metadata["name"].asString();
+  del_material(mat_name);
+}
+
+void MaterialLibrary::del_material(std::string mat_name) {
+  material_library.erase(mat_name);
+  matlist.erase(mat_name);
+}
+
+pyne::Material MaterialLibrary::get_material(std::string mat_name) {
+  pyne::mat_iter it = material_library.find(mat_name);
+  if (it != material_library.end()) {
+    return it->second;
+  } else {
+    return pyne::Material();
+  }
 }
 
 void MaterialLibrary::write_hdf5(std::string filename, std::string datapath,
-                    std::string nucpath, int chunksize){
-
+                                 std::string nucpath, int chunksize) {
   // Turn off annoying HDF5 errors
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-  //Set file access properties so it closes cleanly
+  // Set file access properties so it closes cleanly
   hid_t fapl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
-  H5Pset_fclose_degree(fapl,H5F_CLOSE_STRONG);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
   hid_t db;
   if (pyne::file_exists(filename)) {
     bool ish5 = H5Fis_hdf5(filename.c_str());
-    if (!ish5)
-      throw h5wrap::FileNotHDF5(filename);
+    if (!ish5) throw h5wrap::FileNotHDF5(filename);
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
-  }
-  else
+  } else
     db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
-  
-  
-  //
-  // Read in nuclist if available, write it out if not
-  //
-  bool nucpath_exists = h5wrap::path_exists(db, nucpath);
+
+  pyne::mat_map material_library_tmp = material_library;
+  std::set<int> nuclist_tmp = nuclist;
+  // We are using material_library and nuclist copy to allow adding exisitng
+  // nuclide/materials from the file
+
   std::vector<int> nuclides;
-
-  if (nucpath_exists) {
-    nuclides = h5wrap::h5_array_to_cpp_vector_1d<int>(db, nucpath, H5T_NATIVE_INT);
-  } 
-  
-  std::set<int> merged_nuclist = nuclist;
-  for (auto i = 0; i < nuclides.size(); i++){
-   merged_nuclist.insert(nuclides[i]);
-  }
-  // clean existing nuclides
   nuclides.clear();
-  std::copy(merged_nuclist.begin(), merged_nuclist.end(), inserter(nuclides, nuclides.begin()));
-
+  std::copy(nuclist_tmp.begin(), nuclist_tmp.end(),
+            inserter(nuclides, nuclides.begin()));
 
   int nuc_size;
   hsize_t nuc_dims[1];
@@ -134,7 +144,6 @@ void MaterialLibrary::write_hdf5(std::string filename, std::string datapath,
   }
   nuc_dims[0] = nuc_size;
 
-
   // Write Nuclist in the hdf5 file
   // Not sure if thsi will work with an existing nuclist in the file
   hid_t nuc_space = H5Screate_simple(1, nuc_dims, NULL);
@@ -144,16 +153,13 @@ void MaterialLibrary::write_hdf5(std::string filename, std::string datapath,
   H5Fflush(db, H5F_SCOPE_GLOBAL);
   // Close out the Dataset
   H5Tclose(db);
-  
+
   // Write the Materials in the file
-  //
-  
-  for (auto it = material_library.begin(); it != material_library.end(); it++) {
+  for (auto it = material_library_tmp.begin(); it != material_library_tmp.end();
+       it++) {
     (it->second).write_hdf5(filename, datapath, nucpath);
   }
-  
 }
-
 
 void MaterialLibrary::append_to_nuclist(pyne::Material mat) {
   pyne::comp_map mat_comp = mat.comp;
@@ -162,19 +168,14 @@ void MaterialLibrary::append_to_nuclist(pyne::Material mat) {
   }
 }
 
-std::set<int> MaterialLibrary::get_nuclist(){
-  return nuclist;
-}
-
-
-
 // see if path exists before we go on
-bool MaterialLibrary::hdf5_path_exists(std::string filename, std::string datapath) {
+bool MaterialLibrary::hdf5_path_exists(std::string filename,
+                                       std::string datapath) {
   // Turn off annoying HDF5 errors
   herr_t status;
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-  //Set file access properties so it closes cleanly
+  // Set file access properties so it closes cleanly
   hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
 
@@ -190,12 +191,13 @@ bool MaterialLibrary::hdf5_path_exists(std::string filename, std::string datapat
   return datapath_exists;
 }
 
-int MaterialLibrary::get_length_of_table(std::string filename, std::string datapath) {
+int MaterialLibrary::get_length_of_table(std::string filename,
+                                         std::string datapath) {
   // Turn off annoying HDF5 errors
   herr_t status;
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-  //Set file access properties so it closes cleanly
+  // Set file access properties so it closes cleanly
   hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
 

--- a/src/material_library.cpp
+++ b/src/material_library.cpp
@@ -3,16 +3,16 @@
 
 
 #ifndef PYNE_IS_AMALGAMATED
-  #include "transmuters.h"
-  #include "material.h"
+  #include "material_library.h"
 #endif
 
+namespace pyne {
 // Empty Constructor
 MaterialLibrary::MaterialLibrary() {
 };
 
 // Default constructor
-MaterialLibrary::MaterialLibrary(string filei, string datapath) {
+MaterialLibrary::MaterialLibrary(std::string file, std::string datapath) {
 
   if (!check_file_exists(file)) {
     std::cerr << "The file " << file << " does not exist or is read protected" << std::endl;
@@ -24,7 +24,7 @@ MaterialLibrary::MaterialLibrary(string filei, string datapath) {
   }
 
   // load materials
-  material_library = from_hdf5(full_filepath);
+  from_hdf5(file);
 
 };
 
@@ -63,9 +63,9 @@ void MaterialLibrary::from_hdf5(std::string filename, std::string datapath, int 
   const char* data_path = datapath.c_str();
 
   if (!hdf5_path_exists(filename, data_path))
-    return library;
+    return;
 
-  num_materials = get_length_of_table(filename, datapath);
+  int num_materials = get_length_of_table(filename, datapath);
 
   for (int i = 0 ; i < num_materials ; i++) {
     pyne::Material mat; // from file
@@ -80,8 +80,8 @@ void MaterialLibrary::from_hdf5(std::string filename, std::string datapath, int 
   material_library = library;
 }
 
-void write_hdf5(std::string filename, std::string datapath="/materials",
-                    std::string nucpath="/nucid", int chunksize=100){
+void MaterialLibrary::write_hdf5(std::string filename, std::string datapath,
+                    std::string nucpath, int chunksize){
 
   // Turn off annoying HDF5 errors
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
@@ -113,12 +113,12 @@ void write_hdf5(std::string filename, std::string datapath="/materials",
   } 
   
   std::set<int> merged_nuclist = nuclist;
-  for (auto i = 0; i < nuclides.size()l i++){
+  for (auto i = 0; i < nuclides.size(); i++){
    merged_nuclist.insert(nuclides[i]);
   }
   // clean existing nuclides
   nuclides.clear();
-  std::copy(merged_nuclist.begin(); merged_nuclist.end(), inserter(nuclides, nuclides.begin());
+  std::copy(merged_nuclist.begin(), merged_nuclist.end(), inserter(nuclides, nuclides.begin()));
 
 
   int nuc_size;
@@ -134,22 +134,6 @@ void write_hdf5(std::string filename, std::string datapath="/materials",
   }
   nuc_dims[0] = nuc_size;
 
-  // Turn off annoying HDF5 errors
-  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
-
-  // Set file access properties so it closes cleanly
-  hid_t fapl;
-  fapl = H5Pcreate(H5P_FILE_ACCESS);
-  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
-  // Create new/open datafile.
-  hid_t db;
-  if (pyne::file_exists(filename)) {
-    bool ish5 = H5Fis_hdf5(filename.c_str());
-    if (!ish5) throw h5wrap::FileNotHDF5(filename);
-    db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
-  } else {
-    db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
-  }
 
   // Write Nuclist in the hdf5 file
   // Not sure if thsi will work with an existing nuclist in the file
@@ -171,7 +155,7 @@ void write_hdf5(std::string filename, std::string datapath="/materials",
 }
 
 
-void append_to_nuclist(pyne::Material mat) {
+void MaterialLibrary::append_to_nuclist(pyne::Material mat) {
   pyne::comp_map mat_comp = mat.comp;
   for (auto it = mat_comp.begin(); it != mat_comp.end(); it++) {
     nuclist.insert(it->first);
@@ -232,3 +216,4 @@ int MaterialLibrary::get_length_of_table(std::string filename, std::string datap
 
   return arr_dims[0];
 }
+}  // end of pyne namespace

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -1,0 +1,58 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <map>
+#include <string>
+#include <stdlib.h>
+
+namespace pyne {
+class MaterialLibrary() {
+ protected:
+  // The actual library
+  std::map<std::string, pyne::Material> material_library;  // material library
+
+ private:
+  // turns the filename string into the full file path
+  std::string get_full_filepath(char* filename);
+  // turns the filename string into the full file path
+  std::string get_full_filepath(std::string filename);
+  // make sure the file, filename exists
+  bool check_file_exists(std::string filename);
+
+ public:
+  // materialLibrary constructor
+  MaterialLibrary();  //< empty constryctor
+
+  /// Constructor from file
+  /// \param filename path to file on disk, this file may be either in plaintext
+  ///                 or HDF5 format.
+  MaterialLibrary(string filename, std::string datapath = "/materials");
+
+  ~MaterialLibrary();  //< default destructor
+
+  /**
+   * \brief loads the pyne materials in map of name vs Material
+   * \param[in] filename of the h5m file
+   * \return std::map of material name vs Material object
+   */
+  void load_materials(std::string filename,
+                      std::string datapath = "/materials");
+
+  /**
+   * \brief determines in that datapath exists in the hdf5 file
+   * \param[in] filename of the h5m file
+   * \param[in] the datapath of we would like to test
+   * \return true/false
+   */
+  bool hdf5_path_exists(std::string filename, std::string datapath);
+
+  /**
+   * \brief determines the length of an hdf5 data table
+   * \param[in] filename of the h5m file
+   * \param[in] the datapath of we would like to read
+   * \return the number of elements to the array
+   */
+  int get_length_of_table(std::string filename, std::string datapath);
+
+}  // end MaterialLibrary class header
+}  // end of pyne namespace

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -4,13 +4,17 @@
 #include <map>
 #include <string>
 #include <stdlib.h>
+#include "material.h"
 
 namespace pyne {
+  
+  
+  
 class MaterialLibrary() {
  protected:
   // The actual library
   std::map<std::string, pyne::Material> material_library;  // material library
-
+  std::set<int> nuclist;
  private:
   // turns the filename string into the full file path
   std::string get_full_filepath(char* filename);
@@ -53,6 +57,9 @@ class MaterialLibrary() {
     */
     void write_hdf5(std::string filename, std::string datapath="/materials",
                     std::string nucpath="/nucid", int chunksize=100);
+    
+    std::set<int> get_nuclist();
+    
   /**
    * \brief determines in that datapath exists in the hdf5 file
    * \param[in] filename of the h5m file

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -23,9 +23,11 @@ class MaterialLibrary() {
   // materialLibrary constructor
   MaterialLibrary();  //< empty constryctor
 
-  /// Constructor from file
-  /// \param filename path to file on disk, this file may be either in plaintext
-  ///                 or HDF5 format.
+  /** 
+   * Constructor from file
+   * \param filename path to file on disk, this file may be either in plaintext
+   *                 or HDF5 format.
+  */
   MaterialLibrary(string filename, std::string datapath = "/materials");
 
   ~MaterialLibrary();  //< default destructor
@@ -34,10 +36,23 @@ class MaterialLibrary() {
    * \brief loads the pyne materials in map of name vs Material
    * \param[in] filename of the h5m file
    * \return std::map of material name vs Material object
-   */
-  void load_materials(std::string filename,
-                      std::string datapath = "/materials");
+  */
+  void from_hdf5(std::string filename,
+                      std::string datapath = "/materials", int protocol=1);
 
+    /** 
+     * Writes MaterialLibrary out to an HDF5 file.
+     *  This happens according to protocol 1.
+     *  \param filename Path on disk to the HDF5 file.
+     *  \param datapath Path to the the material in the file.
+     *  \param nucpath Path to the nuclides set in the file.
+     *  \param row The index to read out, may be negative. Also note that this is a
+     *             float.  A value of -0.0 indicates that the material should be
+     *             appended to the end of the dataset.
+     *  \param chunksize The chunksize for all material data on disk.
+    */
+    void write_hdf5(std::string filename, std::string datapath="/materials",
+                    std::string nucpath="/nucid", int chunksize=100);
   /**
    * \brief determines in that datapath exists in the hdf5 file
    * \param[in] filename of the h5m file

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -8,10 +8,15 @@
 
 namespace pyne {
 
+typedef std::map<std::string, pyne::Material> mat_map;
+typedef mat_map::iterator mat_iter;
+
+
 class MaterialLibrary {
  protected:
   // The actual library
-  std::map<std::string, pyne::Material> material_library;  // material library
+  mat_map material_library;  // material library
+  std::set<std::string> matlist;
   std::set<int> nuclist;
 
  private:
@@ -58,7 +63,12 @@ class MaterialLibrary {
   void write_hdf5(std::string filename, std::string datapath = "/materials",
                   std::string nucpath = "/nucid", int chunksize = 100);
 
-  std::set<int> get_nuclist();
+  void add_material(pyne::Material mat);
+  void del_material(pyne::Material mat);
+  void del_material(std::string mat_name);
+  pyne::Material get_material(std::string mat_name);
+  inline std::set<std::string> get_matlist() { return matlist; }
+  inline std::set<int> get_nuclist() { return nuclist; }
 
   void append_to_nuclist(pyne::Material mat);
   /**

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -26,6 +26,26 @@ class MaterialLibrary {
   std::string get_full_filepath(std::string filename);
   // make sure the file, filename exists
   bool check_file_exists(std::string filename);
+  /**
+   * \brief Add the nuclide form the material to the list of nuclides 
+   * \param material from which add the nuclide to the list
+  */
+  void append_to_nuclist(pyne::Material mat);
+  /**
+   * \brief determines in that datapath exists in the hdf5 file
+   * \param[in] filename of the h5m file
+   * \param[in] the datapath of we would like to test
+   * \return true/false
+   */
+  bool hdf5_path_exists(std::string filename, std::string datapath);
+
+  /**
+   * \brief determines the length of an hdf5 data table
+   * \param[in] filename of the h5m file
+   * \param[in] the datapath of we would like to read
+   * \return the number of elements to the array
+   */
+  int get_length_of_table(std::string filename, std::string datapath);
 
  public:
   // materialLibrary constructor
@@ -42,8 +62,9 @@ class MaterialLibrary {
 
   /**
    * \brief loads the pyne materials in map of name vs Material
-   * \param[in] filename of the h5m file
-   * \return std::map of material name vs Material object
+    /// \param filename Path on disk to the HDF5 file.
+    /// \param datapath Path to the materials in the file.
+    /// \param protocol Flag for layout of material on disk.
   */
   void from_hdf5(std::string filename, std::string datapath = "/materials",
                  int protocol = 1);
@@ -63,29 +84,37 @@ class MaterialLibrary {
   void write_hdf5(std::string filename, std::string datapath = "/materials",
                   std::string nucpath = "/nucid", int chunksize = 100);
 
+  /**
+   * \brief Add a material to the library 
+   * \param mat material to add 
+  */
   void add_material(pyne::Material mat);
+  /**
+   * \brief remove a material of the Library
+   * \param mat material to remove
+  */
   void del_material(pyne::Material mat);
+  /**
+   * \brief remove a material of the Library by name
+   * \param mat_name name of the material to remove
+  */
   void del_material(std::string mat_name);
+  /**
+   * \brief Get a material of the Library by name
+   * \param mat_name name of the material to return
+  */
   pyne::Material get_material(std::string mat_name);
+  /**
+   * \brief Get the list of materials in the Library
+   * \return std::set<std::string> 
+  */
   inline std::set<std::string> get_matlist() { return matlist; }
+  /**
+   * \brief Get the list of nuclides in the Library
+   * \return std::set<int> 
+  */
   inline std::set<int> get_nuclist() { return nuclist; }
 
-  void append_to_nuclist(pyne::Material mat);
-  /**
-   * \brief determines in that datapath exists in the hdf5 file
-   * \param[in] filename of the h5m file
-   * \param[in] the datapath of we would like to test
-   * \return true/false
-   */
-  bool hdf5_path_exists(std::string filename, std::string datapath);
-
-  /**
-   * \brief determines the length of an hdf5 data table
-   * \param[in] filename of the h5m file
-   * \param[in] the datapath of we would like to read
-   * \return the number of elements to the array
-   */
-  int get_length_of_table(std::string filename, std::string datapath);
 
 };  // end MaterialLibrary class header
 }  // end of pyne namespace

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -1,20 +1,19 @@
-#include <string>
-#include <vector>
+#include <stdlib.h>
 #include <iostream>
 #include <map>
 #include <string>
-#include <stdlib.h>
+#include <string>
+#include <vector>
 #include "material.h"
 
 namespace pyne {
-  
-  
-  
-class MaterialLibrary() {
+
+class MaterialLibrary {
  protected:
   // The actual library
   std::map<std::string, pyne::Material> material_library;  // material library
   std::set<int> nuclist;
+
  private:
   // turns the filename string into the full file path
   std::string get_full_filepath(char* filename);
@@ -27,12 +26,12 @@ class MaterialLibrary() {
   // materialLibrary constructor
   MaterialLibrary();  //< empty constryctor
 
-  /** 
+  /**
    * Constructor from file
    * \param filename path to file on disk, this file may be either in plaintext
    *                 or HDF5 format.
   */
-  MaterialLibrary(string filename, std::string datapath = "/materials");
+  MaterialLibrary(std::string filename, std::string datapath = "/materials");
 
   ~MaterialLibrary();  //< default destructor
 
@@ -41,25 +40,27 @@ class MaterialLibrary() {
    * \param[in] filename of the h5m file
    * \return std::map of material name vs Material object
   */
-  void from_hdf5(std::string filename,
-                      std::string datapath = "/materials", int protocol=1);
+  void from_hdf5(std::string filename, std::string datapath = "/materials",
+                 int protocol = 1);
 
-    /** 
-     * Writes MaterialLibrary out to an HDF5 file.
-     *  This happens according to protocol 1.
-     *  \param filename Path on disk to the HDF5 file.
-     *  \param datapath Path to the the material in the file.
-     *  \param nucpath Path to the nuclides set in the file.
-     *  \param row The index to read out, may be negative. Also note that this is a
-     *             float.  A value of -0.0 indicates that the material should be
-     *             appended to the end of the dataset.
-     *  \param chunksize The chunksize for all material data on disk.
-    */
-    void write_hdf5(std::string filename, std::string datapath="/materials",
-                    std::string nucpath="/nucid", int chunksize=100);
-    
-    std::set<int> get_nuclist();
-    
+  /**
+   * Writes MaterialLibrary out to an HDF5 file.
+   *  This happens according to protocol 1.
+   *  \param filename Path on disk to the HDF5 file.
+   *  \param datapath Path to the the material in the file.
+   *  \param nucpath Path to the nuclides set in the file.
+   *  \param row The index to read out, may be negative. Also note that this is
+   * a
+   *             float.  A value of -0.0 indicates that the material should be
+   *             appended to the end of the dataset.
+   *  \param chunksize The chunksize for all material data on disk.
+  */
+  void write_hdf5(std::string filename, std::string datapath = "/materials",
+                  std::string nucpath = "/nucid", int chunksize = 100);
+
+  std::set<int> get_nuclist();
+
+  void append_to_nuclist(pyne::Material mat);
   /**
    * \brief determines in that datapath exists in the hdf5 file
    * \param[in] filename of the h5m file
@@ -76,5 +77,5 @@ class MaterialLibrary() {
    */
   int get_length_of_table(std::string filename, std::string datapath);
 
-}  // end MaterialLibrary class header
+};  // end MaterialLibrary class header
 }  // end of pyne namespace


### PR DESCRIPTION
This is an attempt to add MaterialLibrary to the C++ API.

For the moment, the python API is not bind to it.

I also made some assumptions about how should behave the `write_hdf5` method. For the moment, I believe the behavior is very similar to the Python one: 
- if the file exists, try to write the materials in it regardless of what is in the file, 
- create the file otherwise.

For the `from_hdf5`, I made in in a way to in append the new material in the existing MaterialLibrary, allowing to merge multiple MaterialLibrary (form the file) into a single one.

To be done:
- [ ] Unit test
- [ ] Debug
- [ ] Improve the behavior when attempting to write in a file already containing some materials