### PR TITLE
Fix fnf

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -165,16 +165,16 @@ namespace pyne {
     /// Creates a helpful error message.
     virtual const char* what() const throw()
     {
-      FNFstr = "File not found: ";
+      FNF_message = "File not found: ";
       if (!filename.empty())
-        FNFstr += filename;
+        FNF_message += filename;
 
-      return (const char *) FNFstr.c_str();
+      return (const char *) FNF_message.c_str();
     };
 
   private:
     std::string filename; ///< unfindable filename.
-    std::string FNFstr; /// Message for exception
+    std::string FNF_message; /// Message for exception
   };
 
   /// Exception representing value errors of all kinds

--- a/src/utils.h
+++ b/src/utils.h
@@ -165,7 +165,7 @@ namespace pyne {
     /// Creates a helpful error message.
     virtual const char* what() const throw()
     {
-      std::string FNFstr ("File not found: ");
+      FNFstr = "File not found: ";
       if (!filename.empty())
         FNFstr += filename;
 
@@ -174,6 +174,7 @@ namespace pyne {
 
   private:
     std::string filename; ///< unfindable filename.
+    std::string FNFstr; /// Message for exception
   };
 
   /// Exception representing value errors of all kinds

--- a/src/utils.h
+++ b/src/utils.h
@@ -157,7 +157,7 @@ namespace pyne {
     ~FileNotFound () throw () {};
 
     /// constructor with the filename \a fname.
-    FileNotFound(std::string fname) : FNF_message("File not found")
+    FileNotFound(std::string fname) : FNF_message("File not found: ")
     {
       filename = fname;
     };
@@ -166,7 +166,7 @@ namespace pyne {
     virtual const char* what() const throw()
     {
       if (!filename.empty())
-        FNF_message += ": " + filename;
+        FNF_message += filename;
 
       return (const char *) FNF_message.c_str();
     };

--- a/src/utils.h
+++ b/src/utils.h
@@ -157,7 +157,7 @@ namespace pyne {
     ~FileNotFound () throw () {};
 
     /// constructor with the filename \a fname.
-    FileNotFound(std::string fname)
+    FileNotFound(std::string fname) : FNF_message("File not found")
     {
       filename = fname;
     };
@@ -165,9 +165,8 @@ namespace pyne {
     /// Creates a helpful error message.
     virtual const char* what() const throw()
     {
-      FNF_message = "File not found: ";
       if (!filename.empty())
-        FNF_message += filename;
+        FNF_message += ": " + filename;
 
       return (const char *) FNF_message.c_str();
     };

--- a/src/utils.h
+++ b/src/utils.h
@@ -157,22 +157,20 @@ namespace pyne {
     ~FileNotFound () throw () {};
 
     /// constructor with the filename \a fname.
-    FileNotFound(std::string fname) : FNF_message("File not found: ")
+    FileNotFound(std::string fname) 
     {
-      filename = fname;
+      FNF_message = "File not found";
+      if (!fname.empty())
+        FNF_message += ": " + fname;
     };
 
     /// Creates a helpful error message.
     virtual const char* what() const throw()
     {
-      if (!filename.empty())
-        FNF_message += filename;
-
-      return (const char *) FNF_message.c_str();
+      return FNF_message.c_str();
     };
 
   private:
-    std::string filename; ///< unfindable filename.
     std::string FNF_message; /// Message for exception
   };
 


### PR DESCRIPTION
The `FileNotFound` exception relied on a local scope `std::string` that went out of scope before returning its `(const char*)` contents.

This string has been moved to be a member variable of the exception.