### PR TITLE
Improve source sampling

### DIFF
--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -192,6 +192,7 @@ namespace pyne {
     std::string bias_tag_name; ///< Biased source density distribution
     std::string cell_number_tag_name; ///< Cell number tag
     std::string cell_fracs_tag_name; ///< Cell volume fraction tag
+    std::map<std::string, std::string> tag_names; /// < tag names
     std::vector<double> e_bounds;  ///< Energy boundaries
     int num_e_groups; ///< Number of groups in tag \a _src_tag_name
     int num_bias_groups; ///< Number of groups tag \a _bias_tag_name


### PR DESCRIPTION
As addressed in #1109, the efficiency of photon source sampling could be improved if we pass cell list back to fortran side. The imporvement  works for both voxel/sub-voxel R2S. This PR is trying to implement this improvement. 

Things to do:
- [x]: Unify the sampler, There are two types of sampler exist and used in source_sampling: (old) sampler for only voxel case, and (new) sampler for both voxel and sub-voxel cases. Old sampler is currently used for voxel R2S, and the new sampler is used for sub-voxel mode. Change to use new sampler for both voxel/sub-voxel modes.
- [ ]: Add test files (input and output files for test problem.
- [ ]: Modify the setup and sampler functions to pass cell_list to fortran.
- [ ]: Allow user to turn off void rejection in source sampling routine, #1111 

NOTICE: This PR is based on #1097, should be rebased when #1097 get merged.