### PR TITLE
DAGMC with the new pyne

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,14 @@ if(${MOAB_FOUND})
   endif(APPLE)
 endif(${MOAB_FOUND})
 
+# find DAGMC                                                                                                                        
+find_package(DAGMC)
+if(DAGMC_FOUND)
+  include_directories(${DAGMC_INCLUDE_DIRS})
+  set(LIBS ${LIBS} ${DAGMC_LIBRARIES})
+  link_directories(${DAGMC_LIBRARY_DIRS})
+
+endif(DAGMC_FOUND)
 
 # Find Python
 find_package(PythonInterp REQUIRED)

--- a/cmake/FindDAGMC.cmake
+++ b/cmake/FindDAGMC.cmake
@@ -1,0 +1,18 @@
+# Try to find DAGMC
+#
+# Once done this will define
+#
+#  DAGMC_FOUND - system has DAGMC
+#  DAGMC_INCLUDE_DIRS - the DAGMC include directory
+#  DAGMC_LIBRARIES - Link these to use DAGMC
+#  DAGMC_DEFINITIONS - Compiler switches required for using DAGMC
+
+find_path(DAGMC_CMAKE_CONFIG NAMES DAGMCConfig.cmake
+          HINTS ${DAGMC_ROOT} $ENV{DAGMC_ROOT}
+          PATHS ENV LD_LIBRARY_PATH
+          PATH_SUFFIXES lib Lib cmake lib/cmake
+          NO_DEFAULT_PATH)
+
+message(STATUS "Found DAGMC in ${DAGMC_CMAKE_CONFIG}")
+
+include(${DAGMC_CMAKE_CONFIG}/DAGMCConfig.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,12 @@ IF(BUILD_SPATIAL_SOLVER)
     target_link_libraries(pyne ${LIBS_HDF5} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 ENDIF(BUILD_SPATIAL_SOLVER)
 if(MOAB_FOUND)
+  if(DAGMC_FOUND)
+    message(status ${DAGMC_LIBRARIES})
     target_link_libraries(pyne dagmc MOAB)
+  else()
+    target_link_libraries(pyne MOAB)
+  endif(DAGMC_FOUND)
 endif(MOAB_FOUND)
 
 add_executable(alphad ${PROJECT_SOURCE_DIR}/src/ensdf_processing/ALPHAD/alphad.f

--- a/src/dagmc_bridge.cpp
+++ b/src/dagmc_bridge.cpp
@@ -13,23 +13,33 @@ using moab::CartVect;
 using moab::DagMC;
 using moab::EntityHandle;
 
+moab::DagMC *dag = NULL;
+
+moab::DagMC* get_dagmc_instance() {
+  if ( dag == NULL ) {
+    return dag = new moab::DagMC();
+  }  else {
+    return dag;
+ }
+}
+
 #define CHECKERR(err) \
     if((err) != moab::MB_SUCCESS) return err;
 
 namespace pyne {
 
 float dag_version(void) {
-    return DagMC::version();
+  return get_dagmc_instance()->version();
 }
 
 unsigned dag_rev_version(void) {
-    return DagMC::interface_revision();
+  return get_dagmc_instance()->interface_revision();
 }
 
 int dag_ent_handle_size(void) {
     return sizeof(EntityHandle);
 }
-
+  
 static std::vector<int> surfList;
 static std::vector<int> volList;
 
@@ -48,17 +58,17 @@ const int* geom_id_list(int dimension, int* number_of_items) {
 }
 
 EntityHandle handle_from_id(int dimension, int id) {
-    return DagMC::instance()->entity_by_id(dimension, id);
+    return get_dagmc_instance()->entity_by_id(dimension, id);
 }
 
 int id_from_handle(EntityHandle eh) {
-    return DagMC::instance()->get_entity_id(eh);
+    return get_dagmc_instance()->get_entity_id(eh);
 }
 
 ErrorCode dag_load(const char* filename){
     ErrorCode err;
 
-    DagMC* dag = DagMC::instance();
+    DagMC* dag = get_dagmc_instance();
 
     err = dag->load_file(filename);
     CHECKERR(err);
@@ -107,7 +117,7 @@ ErrorCode dag_ray_fire(EntityHandle vol, vec3 ray_start, vec3 ray_dir,
                         void* history, double distance_limit) {
     ErrorCode err;
 
-    DagMC*  dag = DagMC::instance();
+    DagMC*  dag = get_dagmc_instance();
 
     err = dag->ray_fire(vol, ray_start, ray_dir, *next_surf_ent, *next_surf_dist, 
                          static_cast<DagMC::RayHistory*>(history), distance_limit);
@@ -133,7 +143,7 @@ ErrorCode dag_ray_follow(EntityHandle firstvol, vec3 ray_start, vec3 ray_dir,
 
     ray_buffers* buf = new ray_buffers;
     ErrorCode err;
-    DagMC* dag = DagMC::instance();
+    DagMC* dag = get_dagmc_instance();
 
     EntityHandle vol = firstvol;
     double dlimit = distance_limit;
@@ -182,7 +192,7 @@ ErrorCode dag_pt_in_vol(EntityHandle vol, vec3 pt, int* result, vec3 dir, const 
     
     ErrorCode err;
 
-    DagMC* dag = DagMC::instance();
+    DagMC* dag = get_dagmc_instance();
     
     err = dag->point_in_volume(vol, pt, *result, dir, static_cast<const DagMC::RayHistory*>(history));
 
@@ -192,7 +202,7 @@ ErrorCode dag_pt_in_vol(EntityHandle vol, vec3 pt, int* result, vec3 dir, const 
 ErrorCode dag_next_vol(EntityHandle surface, EntityHandle volume, EntityHandle* next_vol) {
 
     ErrorCode err;
-    DagMC* dag = DagMC::instance();
+    DagMC* dag = get_dagmc_instance();
 
     err = dag->next_vol(surface, volume, *next_vol);
 
@@ -200,19 +210,19 @@ ErrorCode dag_next_vol(EntityHandle surface, EntityHandle volume, EntityHandle* 
 }
 
 int vol_is_graveyard(EntityHandle vol) {
-    return DagMC::instance()->has_prop(vol, "graveyard");
+    return get_dagmc_instance()->has_prop(vol, "graveyard");
 }
 
 /* int surf_is_spec_refl(EntityHandle surf); */
 /* int surf_is_white_refl(EntityHandle surf); */
 
 int vol_is_implicit_complement(EntityHandle vol){
-    return DagMC::instance()->is_implicit_complement(vol);
+    return get_dagmc_instance()->is_implicit_complement(vol);
 }
 
 ErrorCode get_volume_metadata(EntityHandle vol, int* material, double* density, double* importance) {
     ErrorCode err;
-    DagMC* dag = DagMC::instance();
+    DagMC* dag = get_dagmc_instance();
 
     // the defaults from DagMC's old get_volume_metadata: mat = 0, rho = 0, imp = 1
     int mat_id = 0;
@@ -253,7 +263,7 @@ ErrorCode get_volume_metadata(EntityHandle vol, int* material, double* density, 
 }
 
 ErrorCode get_volume_boundary(EntityHandle vol, vec3 minPt, vec3 maxPt) {
-    return DagMC::instance()->getobb(vol, minPt, maxPt);
+    return get_dagmc_instance()->getobb(vol, minPt, maxPt);
 }
 
 } // namespace pyne


### PR DESCRIPTION
This PR Allows DAGMC to built into pyne with MOABv5 or newer

modified file:   CMakeLists.txt now calls the finddagmc function
modified file:   src/CMakeLists.txt adds libraries for moab and dagmc if needed
modified file:   src/dagmc_bridge.cpp makes an get_dagmc_instance 
new file: FindDAGMC.cmake which is from OpenMC and finds dagmc