### PR TITLE
use new sampler for both default and subvoxel r2s

### DIFF
--- a/news/improve_source_sampling.rst
+++ b/news/improve_source_sampling.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Use new sampler for both voxel and sub-voxel R2S.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -64,7 +64,6 @@ pyne::Sampler::Sampler(std::string filename,
                  bool uniform)
   : filename(filename), src_tag_name(src_tag_name), e_bounds(e_bounds) {
   bias_mode = (uniform) ? UNIFORM : ANALOG;
-  sub_mode = DEFAULT;
   setup();
 }
 
@@ -77,7 +76,6 @@ pyne::Sampler::Sampler(std::string filename,
     e_bounds(e_bounds), 
     bias_tag_name(bias_tag_name) {
   bias_mode = USER;
-  sub_mode = DEFAULT;
   setup();
 }
 
@@ -88,25 +86,19 @@ pyne::Sampler::Sampler(std::string filename,
   : filename(filename),
     tag_names(tag_names),
     e_bounds(e_bounds) {
-  // determine the bias_mode and sub_mode
+  // determine the bias_mode
   if (mode == 0){
     bias_mode = ANALOG; 
-    sub_mode = DEFAULT;
   } else if (mode == 1) {
     bias_mode = UNIFORM;
-    sub_mode = DEFAULT;
   } else if (mode == 2) {
     bias_mode = USER;
-    sub_mode = DEFAULT;
   } else if (mode == 3) {
     bias_mode = ANALOG;
-    sub_mode = SUBVOXEL;
   } else if (mode == 4) {
     bias_mode = UNIFORM;
-    sub_mode = SUBVOXEL;
   } else if (mode == 5) {
     bias_mode = USER;
-    sub_mode = SUBVOXEL;
   }
 
   // find out the src_tag_name and bias_tag_name
@@ -148,8 +140,8 @@ pyne::SourceParticle pyne::Sampler::particle_birth(std::vector<double> rands) {
   xyz_rands.push_back(rands[4]);
   moab::CartVect pos = sample_xyz(ve_idx, xyz_rands);
   // cell_number
-  if (sub_mode == SUBVOXEL) {
-     cell_id = cell_number[ve_idx*max_num_cells + c_idx];
+  if (ve_type == moab::MBHEX) {
+  cell_id = cell_number[ve_idx*max_num_cells + c_idx];
   } else {
      cell_id = -1;
   }

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -192,6 +192,7 @@ namespace pyne {
     std::string bias_tag_name; ///< Biased source density distribution
     std::string cell_number_tag_name; ///< Cell number tag
     std::string cell_fracs_tag_name; ///< Cell volume fraction tag
+    std::map<std::string, std::string> tag_names; /// < tag names
     std::vector<double> e_bounds;  ///< Energy boundaries
     int num_e_groups; ///< Number of groups in tag \a _src_tag_name
     int num_bias_groups; ///< Number of groups tag \a _bias_tag_name

--- a/src/source_sampling.h
+++ b/src/source_sampling.h
@@ -130,7 +130,6 @@ namespace pyne {
   
   /// Problem modes
   enum BiasMode {USER, ANALOG, UNIFORM};
-  enum SubMode {DEFAULT, SUBVOXEL};
   
   /// Mesh based Monte Carlo source sampling.
   class Sampler {
@@ -198,7 +197,6 @@ namespace pyne {
     int num_bias_groups; ///< Number of groups tag \a _bias_tag_name
     int max_num_cells; /// Max number of cells in voxels
     BiasMode bias_mode; ///< Bias mode: ANALOG, UNIFORM, USER
-    SubMode sub_mode; ///< Subvoxel/Voxel mode: DEFAULT, SUBVOXEL
     // mesh
     moab::Interface* mesh; ///< MOAB mesh
     int num_ves; ///< Number of mesh volume elements on \a mesh.

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -1034,32 +1034,6 @@ def test_template_examples():
     """
     An example of using source_sampling test template to do the test
     """
-    # DEFAULT
-#    for mode in (DEFAULT_ANALOG, DEFAULT_UNIFORM, DEFAULT_USER):
-#        for num_e_groups in (1, 2):
-#            # num_bias_groups could be:
-#            # 1, num_e_groups, and max_num_cells*num_e_groups
-#            # test case: 1 voxel, 1 subvoxel
-#            cell_fracs_list = [(0, 1, 1.0, 0.0)]
-#            src_tag = [[1.0]*num_e_groups]
-#            if mode == DEFAULT_USER:
-#                for num_bias_groups in (1, num_e_groups):
-#                    bias_tag = [[1.0]*num_bias_groups]
-#                    _source_sampling_test_template(
-#                        mode, cell_fracs_list, src_tag, bias_tag)
-#            else:
-#                _source_sampling_test_template(mode, cell_fracs_list, src_tag)
-#           # test case: 2 voxel, 2 subvoxels
-#            cell_fracs_list = [(0, 1, 1.0, 0.0), (1, 2, 1.0, 0.0)]
-#            src_tag = [[1.0]*num_e_groups, [1.0]*num_e_groups]
-#            if mode == DEFAULT_USER:
-#                for num_bias_groups in (1, num_e_groups):
-#                    bias_tag = [[1.0]*num_bias_groups, [1.0]*num_bias_groups]
-#                    _source_sampling_test_template(
-#                        mode, cell_fracs_list, src_tag, bias_tag)
-#            else:
-#                _source_sampling_test_template(mode, cell_fracs_list, src_tag)
-#
     # DEFAULT and SUBVOXEL
     for mode in (DEFAULT_ANALOG, DEFAULT_UNIFORM, DEFAULT_USER,
                  SUBVOXEL_ANALOG, SUBVOXEL_UNIFORM, SUBVOXEL_USER):

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -1333,11 +1333,8 @@ def _cal_exp_w_c(s, mode, cell_fracs, src_tag, bias_tag):
     if svid == -1:
         raise ValueError("x coordinate not in the voxel, s.x = {0}"
                          .format(str(s.x)))
-    if mode in (3, 4, 5):
-        # get the cell_number
-        exp_c = set(list(current_cell_fracs['cell']))
-    else:
-        exp_c = set([-1])
+    # get the cell_number
+    exp_c = set(list(current_cell_fracs['cell']))
 
     # calculate eid
     num_e_groups = len(src_tag[0])/max_num_cells

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -40,7 +40,7 @@ def try_rm_file(filename):
     return lambda: os.remove(filename) if os.path.exists(filename) else None
 
 
-@with_setup(None, try_rm_file('tet.h5m'))
+@with_setup(None, try_rm_file('sampling_mesh.h5m'))
 def test_single_hex_tag_names_map():
     """This test tests uniform sampling within a single hex volume element.
     This is done by dividing the volume element in 4 smaller hex and ensuring


### PR DESCRIPTION
There are two types of sampler exist and used in source_sampling:
- Old: sampler for only voxel case, and 
- New: sampler for both voxel and sub-voxel cases.

Old sampler is currently used only for voxel R2S, and the new sampler is used for sub-voxel mode. As the correctness of sub-voxel mode has been proved using tests and benchmark, it's better to unify the sampler, use the new sampler for both voxel and sub-voxel mode.

This PR is part of #1110. I split it into small PRs to make review process easier.