### PR TITLE
Fix expand element

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1314,6 +1314,8 @@ pyne::Material pyne::Material::expand_elements(std::set<int> exception_ids) {
       }
       while(zabund <= znuc) {
         nabund = (*abund_itr).first;
+        zabund = nucname::znum(nabund);
+
         if (zabund == znuc && 0 != nucname::anum(nabund) && 0.0 != (*abund_itr).second)
           newcomp[nabund] = (*abund_itr).second * (*nuc).second * \
                             atomic_mass(nabund) / atomic_mass(n);
@@ -1324,7 +1326,6 @@ pyne::Material pyne::Material::expand_elements(std::set<int> exception_ids) {
           zabund = INT_MAX;
           break;
         }
-        zabund = nucname::znum(nabund);
       }
     } else
       newcomp.insert(*nuc);

--- a/tests/test_material_data_external.py
+++ b/tests/test_material_data_external.py
@@ -1,4 +1,4 @@
-#65;5403;1c"""PyNE Material expand elements test under the presence of data or no data tests"""
+"""PyNE Material expand elements test under the presence of data or no data tests"""
 import os
 import math
 import warnings

--- a/tests/test_material_data_external.py
+++ b/tests/test_material_data_external.py
@@ -1,4 +1,4 @@
-"""PyNE Material expand elements test under the presence of data or no data tests"""
+#65;5403;1c"""PyNE Material expand elements test under the presence of data or no data tests"""
 import os
 import math
 import warnings
@@ -27,27 +27,11 @@ nucvec = {'H':  1.0,
           'Fe': 60.0,
           'Mn': 39.0
           }
-
-def test_with_no_data():
-    orig = pyne_conf.NUC_DATA_PATH
-    pyne_conf.NUC_DATA_PATH = b'thisisanonsensedatapath'
-
-    mat = Material(nucvec,density=7.8)
-    mat = mat.expand_elements()
-    assert_equal(id('He3') in mat.comp,False)
-    assert_equal(id('Co58') in mat.comp,False)
-    assert_equal(id('Ni58') in mat.comp,False)
-
-    assert_equal(id('H1') in mat.comp,True)
-    assert_equal(id('Fe56') in mat.comp,True)
-    assert_equal(id('Mn55') in mat.comp,True)
+def test_with_external_data():
     
-    pyne_conf.NUC_DATA_PATH = orig
-
-def test_with_data():
     mat = Material(nucvec,density=7.8)
     mat = mat.expand_elements()
-
+    
     assert_equal(id('He3') in mat.comp,False)
     assert_equal(id('Co58') in mat.comp,False)
     assert_equal(id('Ni58') in mat.comp,False)
@@ -55,6 +39,7 @@ def test_with_data():
     assert_equal(id('H1') in mat.comp,True)
     assert_equal(id('Fe56') in mat.comp,True)
     assert_equal(id('Mn55') in mat.comp,True)
+
 
 # Run as script
 #

--- a/tests/test_material_data_internal.py
+++ b/tests/test_material_data_internal.py
@@ -1,4 +1,4 @@
-#65;5403;1c"""PyNE Material expand elements test under the presence of data or no data tests"""
+"""PyNE Material expand elements test under the presence of data or no data tests"""
 import os
 import math
 import warnings

--- a/tests/test_material_data_internal.py
+++ b/tests/test_material_data_internal.py
@@ -1,0 +1,50 @@
+#65;5403;1c"""PyNE Material expand elements test under the presence of data or no data tests"""
+import os
+import math
+import warnings
+
+import nose
+from nose.tools import assert_equal, assert_in, assert_true, assert_almost_equal
+import numpy as np
+import numpy.testing as npt
+
+from pyne.utils import QAWarning
+from pyne.pyne_config import pyne_conf
+
+warnings.simplefilter("ignore", QAWarning)
+
+import pyne
+from pyne.material import Material
+from pyne import data, nucname
+from pyne import utils
+
+from pyne.nucname import id
+
+if utils.use_warnings():
+    utils.toggle_warnings()
+
+nucvec = {'H':  1.0,
+          'Fe': 60.0,
+          'Mn': 39.0
+          }
+
+def test_with_internal_data():
+    orig = pyne_conf.NUC_DATA_PATH
+    pyne_conf.NUC_DATA_PATH = b'thisisanonsensedatapath'
+
+    mat = Material(nucvec,density=7.8)
+    mat = mat.expand_elements()
+    assert_equal(id('He3') in mat.comp,False)
+    assert_equal(id('Co58') in mat.comp,False)
+    assert_equal(id('Ni58') in mat.comp,False)
+
+    assert_equal(id('H1') in mat.comp,True)
+    assert_equal(id('Fe56') in mat.comp,True)
+    assert_equal(id('Mn55') in mat.comp,True)
+   
+
+
+# Run as script
+#
+if __name__ == "__main__":
+    nose.runmodule()

--- a/tests/test_material_data_no_data.py
+++ b/tests/test_material_data_no_data.py
@@ -14,15 +14,18 @@ from pyne.pyne_config import pyne_conf
 warnings.simplefilter("ignore", QAWarning)
 
 import pyne
+from pyne.material import Material
 from pyne import data, nucname
 from pyne import utils
+
+from pyne.nucname import id
 
 if utils.use_warnings():
     utils.toggle_warnings()
 
 nucvec = {'H':  1.0,
           'Fe': 60.0,
-          'Mn': 29.0
+          'Mn': 39.0
           }
 
 def test_with_no_data():
@@ -30,21 +33,28 @@ def test_with_no_data():
     pyne_conf.NUC_DATA_PATH = b'thisisanonsensedatapath'
 
     mat = Material(nucvec,density=7.8)
-    assert_equal(mat.comp.has_key('He3'),False)
-    assert_equal(mat.comp.has_key('Co58'),False)
-    assert_equal(mat.comp.has_key('H1'),True)
-    assert_equal(mat.comp.has_key('Mn55'),True)
-    assert_equal(mat.comp.has_key('Fe56'),True)
+    mat = mat.expand_elements()
+    assert_equal(id('He3') in mat.comp,False)
+    assert_equal(id('Co58') in mat.comp,False)
+    assert_equal(id('Ni58') in mat.comp,False)
 
+    assert_equal(id('H1') in mat.comp,True)
+    assert_equal(id('Fe56') in mat.comp,True)
+    assert_equal(id('Mn55') in mat.comp,True)
+    
     pyne_conf.NUC_DATA_PATH = orig
 
 def test_with_data():
     mat = Material(nucvec,density=7.8)
-    assert_equal(mat.comp.has_key('He3'),False)
-    assert_equal(mat.comp.has_key('Co58'),False)
-    assert_equal(mat.comp.has_key('H1'),True)
-    assert_equal(mat.comp.has_key('Mn55'),True)
-    assert_equal(mat.comp.has_key('Fe56'),True)
+    mat = mat.expand_elements()
+
+    assert_equal(id('He3') in mat.comp,False)
+    assert_equal(id('Co58') in mat.comp,False)
+    assert_equal(id('Ni58') in mat.comp,False)
+
+    assert_equal(id('H1') in mat.comp,True)
+    assert_equal(id('Fe56') in mat.comp,True)
+    assert_equal(id('Mn55') in mat.comp,True)
 
 # Run as script
 #

--- a/tests/test_material_data_no_data.py
+++ b/tests/test_material_data_no_data.py
@@ -1,0 +1,52 @@
+"""PyNE Material expand elements test under the presence of data or no data tests"""
+import os
+import math
+import warnings
+
+import nose
+from nose.tools import assert_equal, assert_in, assert_true, assert_almost_equal
+import numpy as np
+import numpy.testing as npt
+
+from pyne.utils import QAWarning
+from pyne.pyne_config import pyne_conf
+
+warnings.simplefilter("ignore", QAWarning)
+
+import pyne
+from pyne import data, nucname
+from pyne import utils
+
+if utils.use_warnings():
+    utils.toggle_warnings()
+
+nucvec = {'H':  1.0,
+          'Fe': 60.0,
+          'Mn': 29.0
+          }
+
+def test_with_no_data():
+    orig = pyne_conf.NUC_DATA_PATH
+    pyne_conf.NUC_DATA_PATH = b'thisisanonsensedatapath'
+
+    mat = Material(nucvec,density=7.8)
+    assert_equal(mat.comp.has_key('He3'),False)
+    assert_equal(mat.comp.has_key('Co58'),False)
+    assert_equal(mat.comp.has_key('H1'),True)
+    assert_equal(mat.comp.has_key('Mn55'),True)
+    assert_equal(mat.comp.has_key('Fe56'),True)
+
+    pyne_conf.NUC_DATA_PATH = orig
+
+def test_with_data():
+    mat = Material(nucvec,density=7.8)
+    assert_equal(mat.comp.has_key('He3'),False)
+    assert_equal(mat.comp.has_key('Co58'),False)
+    assert_equal(mat.comp.has_key('H1'),True)
+    assert_equal(mat.comp.has_key('Mn55'),True)
+    assert_equal(mat.comp.has_key('Fe56'),True)
+
+# Run as script
+#
+if __name__ == "__main__":
+    nose.runmodule()


### PR DESCRIPTION
Fix a bug where if the nuc_data.h5 were not present, the expand_elements() method would introduce nuclides that did not exist, due entirely to a badly placed loop iterator. The added tests and fix ensure that this can not longer happen.

The tests have to happen in two files due to that fact that setting and unsetting the pyne.NUC_PATH variable cannot be changed inside a single script, since the loading of the data is actually done in the C++ layer. 