### PR TITLE
Speed up r2s step2 1

### DIFF
--- a/news/speed_up_r2s_step2_1.rst
+++ b/news/speed_up_r2s_step2_1.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Simplify the method to get the list of decay/cooling times
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -233,8 +233,12 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
     # creat a list of decay times (strings) in the source file
     phtn_src_dc = []
     with tb.open_file(filename) as h5f:
+#        import pdb; pdb.set_trace()
         for row in h5f.root.data:
-            phtn_src_dc.append(row[2])
+            if row[2] not in phtn_src_dc:
+                phtn_src_dc.append(row[2])
+            else:
+                break
     phtn_src_dc = list(set(phtn_src_dc))
 
     # iterate through each requested nuclide/dectay time

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -233,13 +233,11 @@ def photon_source_hdf5_to_mesh(mesh, filename, tags, sub_voxel=False,
     # creat a list of decay times (strings) in the source file
     phtn_src_dc = []
     with tb.open_file(filename) as h5f:
-#        import pdb; pdb.set_trace()
         for row in h5f.root.data:
             if row[2] not in phtn_src_dc:
                 phtn_src_dc.append(row[2])
             else:
                 break
-    phtn_src_dc = list(set(phtn_src_dc))
 
     # iterate through each requested nuclide/dectay time
     for cond in tags.keys():


### PR DESCRIPTION
The changes in this PR intend to speed up the r2s step2.
Using the "line_profile" tool, I found that 87.1% CPU time of `photon_source_hdf5_to_mesh` is used in the code block to get the `phtn_src_dc` (from line number 236 to 240). It iterates in the ranges of `number of cooling times` \* `number of nulicdes`  \* `number of voxels` to get the list of cooling times. This is the hotspot of the function.

The changes of this PR reduce the iteration time. By applying this PR, the CPU time of the code block to get the `phtn_src_dc` takes about 0.2% of the function `photon_source_hdf5_to_mesh`.

Major changes:
- Change the method of getting `phtn_src_dc`, speed up the r2s step2.