### PR TITLE
R2s step2 keep phtn src option

### DIFF
--- a/news/r2s_step2_keep_phtn_src_option.rst
+++ b/news/r2s_step2_keep_phtn_src_option.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Add a option in r2s step2: keep_phtn_src, allow user to delete this phtn_src file.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
+import  os
 from os.path import isfile
 
 from pyne.mesh import Mesh, NativeMeshTag
@@ -62,6 +63,8 @@ output: source
 # The name of the output files containing the total photon source intensities for
 # each decay time
 tot_phtn_src_intensities : total_photon_source_intensities.txt
+# Keep phtn_src file?
+keep_phtn_src: True
 """
 
 alara_params =\
@@ -166,6 +169,7 @@ def step2():
     output = config.get('step2', 'output')
     tot_phtn_src_intensities = config.get('step2', 'tot_phtn_src_intensities')
     tag_name = "source_density"
+    keep_phtn_src = config.get('step2', 'keep_phtn_src')
 
     if sub_voxel:
         geom = config.get('step1', 'geom')
@@ -176,6 +180,8 @@ def step2():
     h5_file = 'phtn_src.h5'
     if not isfile(h5_file):
         photon_source_to_hdf5('phtn_src')
+    if isfile('phtn_src') and keep_phtn_src == False:
+        os.remove('phtn_src')
     intensities = "Total photon source intensities (p/s)\n"
     for i, dc in enumerate(decay_times):
         print('Writing source for decay time: {0}'.format(dc))

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -169,7 +169,7 @@ def step2():
     output = config.get('step2', 'output')
     tot_phtn_src_intensities = config.get('step2', 'tot_phtn_src_intensities')
     tag_name = "source_density"
-    keep_phtn_src = config.get('step2', 'keep_phtn_src')
+    keep_phtn_src = config.getboolean('step2', 'keep_phtn_src')
 
     if sub_voxel:
         geom = config.get('step1', 'geom')
@@ -180,7 +180,7 @@ def step2():
     h5_file = 'phtn_src.h5'
     if not isfile(h5_file):
         photon_source_to_hdf5('phtn_src')
-    if isfile('phtn_src') and keep_phtn_src == False:
+    if isfile('phtn_src') and not keep_phtn_src:
         os.remove('phtn_src')
     intensities = "Total photon source intensities (p/s)\n"
     for i, dc in enumerate(decay_times):

--- a/tests/files_test_r2s/r2s_examples/r2s_run/config.ini
+++ b/tests/files_test_r2s/r2s_examples/r2s_run/config.ini
@@ -41,3 +41,5 @@ output: source
 # The name of the output files containing the total photon source intensities for
 # each decay time
 tot_phtn_src_intensities : total_photon_source_intensities.txt
+# Keep phtn_src file?
+keep_phtn_src: True

--- a/tests/files_test_r2s/r2s_examples/subvoxel_r2s_run/config.ini
+++ b/tests/files_test_r2s/r2s_examples/subvoxel_r2s_run/config.ini
@@ -41,3 +41,5 @@ output: source
 # The name of the output files containing the total photon source intensities for
 # each decay time
 tot_phtn_src_intensities : total_photon_source_intensities.txt
+# Keep phtn_src file?
+keep_phtn_src: True

--- a/tests/files_test_r2s/r2s_examples/unstructured_r2s_run/config.ini
+++ b/tests/files_test_r2s/r2s_examples/unstructured_r2s_run/config.ini
@@ -41,3 +41,5 @@ output: source
 # The name of the output files containing the total photon source intensities for
 # each decay time
 tot_phtn_src_intensities : total_photon_source_intensities.txt
+# Keep phtn_src file?
+keep_phtn_src: True


### PR DESCRIPTION
In the process of PyNE R2S, phtn_src is an output file of ALARA. It contains photon source for each volume element, nuclide, cooling time. This file is read by r2s step2 for writing `phtn_src.h5`. Once the `phtn_src.h5` is written, `phtn_src` is no longer useful.

However, the `phtn_src` occupies too much disk space, sometimes cause `segmentation falut`. Therefore, it's better to delete it when `phtn_src.h5` exists.

This PR adds an option in `config.ini` to allow user to delete `phtn_src` if they want.