### PR TITLE
add hdf5-tools in docker images for circleci

### DIFF
--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -38,6 +38,7 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             autoconf \
             libtool \
             doxygen \
+            hdf5-tools \
     && apt-get clean -y; \
     if [ "${py_version%.?}" -eq 3 ] ; \
        then \ 

--- a/news/add_hdf5_tools_docker_for_circleci.rst
+++ b/news/add_hdf5_tools_docker_for_circleci.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Add hdf5-tools as dependency for docker images used in CircleCI.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
As addressed in issue #1124, this PR adds the `hdf5-tools` (contains `h5diff`) in the docker images for CircleCI. Therefore, we can test codes in CircleCI with `h5diff` without request users to install `hdf5-tools`.