### PR TITLE
Update docker for circleci

### DIFF
--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -38,6 +38,7 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             autoconf \
             libtool \
             doxygen \
+            hdf5-tools \
     && apt-get clean -y; \
     if [ "${py_version%.?}" -eq 3 ] ; \
        then \ 

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -54,7 +54,8 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             nbconvert \
             numpy \
             nose \
-            cython
+            cython \
+            future
 
 
 # make starting directory

--- a/news/add_hdf5_tools_docker_for_circleci.rst
+++ b/news/add_hdf5_tools_docker_for_circleci.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Add hdf5-tools as dependency for docker images used in CircleCI.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/update_docker_for_circleci.rst
+++ b/news/update_docker_for_circleci.rst
@@ -1,6 +1,7 @@
 **Added:**
 
-* Add hdf5-tools and future as dependency for docker images used in CircleCI.
+* Add hdf5-tools as dependency for docker images used in CircleCI, for better nose test comparing h5 files
+* Add future as dependency for docker images used in CircleCI, for python2 and python3 compatibility
 
 **Changed:** None
 

--- a/news/update_docker_for_circleci.rst
+++ b/news/update_docker_for_circleci.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Add hdf5-tools as dependency for docker images used in CircleCI.
+* Add hdf5-tools and future as dependency for docker images used in CircleCI.
 
 **Changed:** None
 


### PR DESCRIPTION
Update the docker file for circleci:
- add `hdf5-tools` for better nose test
- add 'future' for python2/3 compatibility