### PR TITLE
Speed up r2s step2 2

### DIFF
--- a/news/speed_up_r2s_step2_2.rst
+++ b/news/speed_up_r2s_step2_2.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* In R2S step2, add option to write only 'total' to h5 file, reduce the CPU time
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -178,6 +178,8 @@ def photon_source_to_hdf5(filename, nucs='all', chunkshape=(10000,)):
                 j = (row_count-1) % chunksize
                 rows[j] = (idx, ls[0].strip(), ls[1].strip(),
                            np.array(ls[2:], dtype=np.float64))
+        else:
+            raise ValueError(u"Nucs option {0} not support!".format(nucs))
 
         # Save the nuclide in order to keep track of idx
         old = ls[0]

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -179,6 +179,8 @@ def photon_source_to_hdf5(filename, nucs='all', chunkshape=(10000,)):
                 rows[j] = (idx, ls[0].strip(), ls[1].strip(),
                            np.array(ls[2:], dtype=np.float64))
         else:
+            h5f.close()
+            f.close()
             raise ValueError(u"Nucs option {0} not support!".format(nucs))
 
         # Save the nuclide in order to keep track of idx

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -175,10 +175,10 @@ def step2():
         cell_mats = None
     h5_file = 'phtn_src.h5'
     if not isfile(h5_file):
-        photon_source_to_hdf5('phtn_src')
+        photon_source_to_hdf5(filename='phtn_src', nucs='total')
     intensities = "Total photon source intensities (p/s)\n"
     for i, dc in enumerate(decay_times):
-        print('Writing source for decay time: {0}'.format(dc))
+        print('Writing source for decay time: {0} to mesh'.format(dc))
         mesh = Mesh(structured=structured, mesh='blank_mesh.h5m')
         tags = {('TOTAL', dc): tag_name}
         photon_source_hdf5_to_mesh(mesh, h5_file, tags, sub_voxel=sub_voxel,

--- a/tests/test_alara.py
+++ b/tests/test_alara.py
@@ -4,7 +4,7 @@ import nose
 import subprocess
 
 from nose.tools import assert_almost_equal
-from nose.tools import assert_equal, assert_true, with_setup
+from nose.tools import assert_equal, assert_true, with_setup, assert_raises
 from nose.plugins.skip import SkipTest
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -199,6 +199,9 @@ def test_photon_source_to_hdf5():
 
     if os.path.isfile(filename + '.h5'):
         os.remove(filename + '.h5')
+
+    # wrong nuc option raise test
+    assert_raises(ValueError, photon_source_to_hdf5, filename, 'test')
 
 
 def test_photon_source_hdf5_to_mesh():


### PR DESCRIPTION
This PR reduces the CPU time of R2S step2 by about 68% without increasing memory usage (tested with FNG SDR benchmark, mesh case: 9_7_9, sub-voxel mode).

Summary of performance (of test case) before/after this PR:

Resource | before | after | resource reduction
----------- | --------- | ----------- | ----------------
CPU time (s) | 815.463  | 261.266 | 68 %
Memory (MB) | 509.062 | 505.898 |  -

This PR achieves the CPU time reduction by adding an option in `alara.photon_source_to_hdf5()` allowing user to write only photon source of 'TOTAL' into 'phtn_src.h5`. This option will:
- Decrease the CPU time in reading 'phtn_src' and writing `phtn_src.h5`.
- Decrease the CPU time in search matched data of given tags

Major chanegs:
- Add an option in  `alara.photon_source_to_hdf5()` allowing user to write only 'TOTAL' photon source into `phtn_src`