### PR TITLE
Use implicit none in source.F90 and add MCNP6 version

### DIFF
--- a/docs/usersguide/source_sampling.rst
+++ b/docs/usersguide/source_sampling.rst
@@ -202,18 +202,19 @@ source sampling within MCNP5. This file is found in pyne/share/source.F90.
 The simplest way to compile MCNP5 with the source subroutine is as follows:
 
   #. Obtain a copy of the MCNP5 source code.
-  #. Navigate to the folder MCNP5/Source/src.
-  #. Soft-link the following files into this folder:
+  #. Navigate to the folder MCNP5/Source/src: ``cd MCNP5/Source/src``
+  #. Symlink the following files into this folder:
 
-     a. pyne/src/source_sampling.cpp
-     b. pyne/src/source_sampling.h
-     c. pyne/src/measure.cpp
-     d. pyne/src/measure.h
+     a. ``ln -s /path/to/pyne/src/source_sampling.cpp .``
+     b. ``ln -s /path/to/pyne/src/source_sampling.h .``
+     c. ``ln -s /path/to/pyne/src/measure.cpp .``
+     d. ``ln -s /path/to/pyne/src/measure.h .``
 
   #. Remove the pre-existing empty source.F90 file.
-  #. Soft-link pyne/share/source.F90.
-  #. Open the file MCNP/Source/src/FILE.list.
-  #. Edit line 78 to include the additional source files. It should look like "CXX_SRC := measure.cpp source_sampling.cpp".
+  #. Symlink source.F90: ``ln -s /path/to/pyne/share/source.F90 .``
+  #. Open the file MCNP/Source/src/FILE.list and edit line 78 to include the
+     additional source files. It should look like
+     ``CXX_SRC := measure.cpp source_sampling.cpp``.
   #. Compile MCNP5 using the standard build method.
 
 Once MCNP5 is compiled, MCNP5 can be run normally. The file "source.h5m" and
@@ -239,3 +240,17 @@ of 100 with source particles specified as photons:
 
   idum 1 100 2
 
+************************
+Source Sampling in MCNP6
+************************
+
+Another version of the source.F90 file was produced for use with MCNP6. The
+instructions for how to use it are identical to those for the MCNP5 version
+except for one difference: the file that should be symlinked is called
+``pyne/share/source_mcnp6.F90`` instead. It should still be called
+``source.F90`` inside the MCNP source directory. For example:
+
+.. code-block:: bash
+
+  cd MCNP6/Source/src
+  ln -s /path/to/pyne/share/source_mcnp6.F90 source.F90

--- a/news/source_f90_implicit_none.rst
+++ b/news/source_f90_implicit_none.rst
@@ -1,0 +1,15 @@
+**Added:**
+
+* MCNP6 version of source.F90
+
+**Changed:**
+
+* Changed source.F90 to use "implicit none" instead of "implicit real"
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/share/source.F90
+++ b/share/source.F90
@@ -9,7 +9,7 @@
 ! (e.g. most Cartesean meshes). This version of find_cell does not work for
 ! repeated geometries or universes.
 !
-! Full instructions on compiling and using MCNP6 with this subroutine are found
+! Full instructions on compiling and using MCNP5 with this subroutine are found
 ! in the PyNE user manual.
 
 function find_cell(cell_list, cell_list_size) result(icl_tmp)

--- a/share/source_mcnp6.F90
+++ b/share/source_mcnp6.F90
@@ -1,0 +1,182 @@
+! This is Fortran90 code that can be compiled directly into MCNP5 in order
+! to use the mesh-based sampling capabilities provided by the Sampler class
+! within source_sampling.cpp. The subroutine "source" calls the MCNP5 interface
+! C++ functions within source_sampling.cpp. The function "find_cell"
+! determines what geomety cell a sampled x, y, z are in, which allows for
+! void rejection within the source subroutine. Void rejection ensures that
+! particles are never born in void (which is non-physical) which may arise in
+! the case of source density meshes that are non-conformal to the geometry
+! (e.g. most Cartesean meshes). This version of find_cell does not work for
+! repeated geometries or universes.
+!
+! Full instructions on compiling and using MCNP6 with this subroutine are found
+! in the PyNE user manual.
+
+function find_cell(cell_list, cell_list_size) result(icl_tmp)
+! This function determines the current MCNP cell index location.
+! Return a positive integer if a valid cell is found, otherwise it returns -1.
+! This only works if there are no repeated geometries or universes present in
+! the model.
+! Parameters:
+!     cell_list: array of integers. Contains cell numbers that the source
+!                particle possiblely located.
+!     cell_list_size: integer. Size of the cell_list.
+!
+! There are 3 types of not found icl_tmp (icl_tmp == -1):
+! - Type 1: Sorce particle is located in a cell that exist in neutron transport
+!             but removed in photon transport. Therefore, the cell number does
+!             not exist in the ncl list.
+!           This is not an error, happens with small frequency.
+!           Skip it and resample next particle without warning message.
+! - Type 2: Source particle is not located in the given cell_list for HEX
+!             mesh cases (both voxel and sub-voxel). Because cell_list from
+!             discretize_geom() missed some cells with very small volume
+!             fractions.
+!           This is caused by random error, happens with small frequency.
+!           Skip it andd resample next particle with warning message.
+! - Type 3: Source partilce with a specific coordinates can't be found in any
+!             cell from ncl(1) to ncl(mxa).
+!           This is an error. When this error happens, it means that there is
+!             something wrong in either the source.F90 file or the DAGMC
+!             geometry representation. It happens with low frenquency for some
+!             complex geometry. The results is suspicious under this condition.
+!           Skip it and resample next particle with error message.
+
+  use fixcom, only: mxa
+  use mcnp_global, only: ncl
+  use mcnp_interfaces_mod, only: namchg
+  use mcnp_params, only: dknd
+  use pblcom, only: pbl
+  use varcom, only: nps
+  use mcnp_debug
+
+  implicit none
+
+  integer :: i ! iterator variable
+  integer :: j ! temporary cell test
+  integer :: icl_tmp ! temporary cell variable
+  integer, intent(in) :: cell_list_size
+  integer, dimension(cell_list_size), intent(in) :: cell_list
+  integer :: cidx ! cell index
+
+  icl_tmp = -1
+  ! If the cell_list is given (for HEX mesh),
+  ! use it to find cell first
+  if (cell_list_size > 0) then
+    ! HEX mesh. VOXEL/SUBVOXEL
+    do i = 1, cell_list_size
+      if (cell_list(i) .le. 0) then
+        ! not a valid cell number (-1)
+        exit
+      endif
+      cidx = namchg(1, cell_list(i))
+      if (cidx .eq. 0) then
+        ! Type 1: cell index not found, skip and resampling
+        exit
+      endif
+      call chkcel(cidx, 0, j)
+      if (j .eq. 0) then
+        ! valid cell found
+        icl_tmp = cidx
+        exit
+      endif
+    enddo
+  endif
+
+  ! If the icl_tmp is not found yet (for HEX mesh), type 2 or type 3 happens,
+  ! or the cell_list is not given (for TET mesh),
+  ! find it in the entire list of cells
+  if ((icl_tmp == -1) .or. (cell_list_size .eq. 0)) then
+    do i = 1, mxa
+      call chkcel(i, 0, j)
+      if (j .eq. 0) then
+        ! valid cell found
+        icl_tmp = i
+        if (cell_list_size > 0) then
+          ! this is a type 2 problem, skip
+          ! reset the icl_tmp to -1 because of the type 2 not found
+          icl_tmp = -1
+        endif
+        exit
+      endif
+    enddo
+    ! icl now is -1, it is a type 3 error.
+    ! Skip and print error message
+    if(icl_tmp .le. 0) then
+      write(*,*) 'ERROR: history ', nps, 'at position ', &
+      &          pbl%r%x, pbl%r%y, pbl%r%z, ' not in any cell'
+      write(*,*) 'Skipping and resampling the source particle'
+    endif
+  endif
+end function find_cell
+
+subroutine source
+  ! This subroutine is called directly by MCNP to select particle birth
+  ! parameters
+
+  use mcnp_global, only: mat
+  use mcnp_params, only: dknd
+  use mcnp_random, only: rang
+  use pblcom, only: pbl
+  use mcnp_debug
+
+  implicit none
+
+  logical, save :: first_run = .true.
+  real(dknd), dimension(6) :: rands
+  integer :: icl_tmp ! temporary cell index variable
+  integer :: find_cell
+  integer :: tries
+  integer, save :: cell_list_size = 0
+  integer, dimension(:), allocatable, save :: cell_list
+
+  if (first_run .eqv. .true.) then
+    ! set up, and return cell_list_size to create a cell_list
+    call sampling_setup(idum(1), cell_list_size)
+    allocate(cell_list(cell_list_size))
+    first_run = .false.
+  endif
+
+100 continue
+  tries = 0
+  rands(1) = rang() ! sample alias table
+  rands(2) = rang() ! sample alias table
+  rands(6) = rang() ! sample energy
+200 continue
+  rands(3) = rang() ! sample x
+  rands(4) = rang() ! sample y
+  rands(5) = rang() ! sample z
+
+  call particle_birth(rands, pbl%r%x, pbl%r%y, pbl%r%z, pbl%r%erg, pbl%r%wgt, &
+  &                   cell_list)
+  ! Loop over cell_list to find icl_tmp
+  icl_tmp = find_cell(cell_list, cell_list_size)
+
+  ! check whether this is a valid cell
+  if (icl_tmp .le. 0) then
+    goto 300
+  endif
+
+  ! check whether the material of sampled cell is void
+  if (mat(icl_tmp).eq.0) then
+    goto 300
+  else
+    goto 400
+  endif
+
+300 continue
+  tries = tries + 1
+  if(tries < idum(2)) then
+    goto 200
+  else
+    goto 100
+  endif
+
+400 continue
+  pbl%i%icl = icl_tmp
+  pbl%r%tme = 0.0
+  pbl%i%ipt = idum(3)
+  pbl%i%jsu = 0
+
+  return
+end subroutine source

--- a/share/source_mcnp6.F90
+++ b/share/source_mcnp6.F90
@@ -1,6 +1,6 @@
-! This is Fortran90 code that can be compiled directly into MCNP5 in order
+! This is Fortran90 code that can be compiled directly into MCNP6 in order
 ! to use the mesh-based sampling capabilities provided by the Sampler class
-! within source_sampling.cpp. The subroutine "source" calls the MCNP5 interface
+! within source_sampling.cpp. The subroutine "source" calls the MCNP6 interface
 ! C++ functions within source_sampling.cpp. The function "find_cell"
 ! determines what geomety cell a sampled x, y, z are in, which allows for
 ! void rejection within the source subroutine. Void rejection ensures that


### PR DESCRIPTION
This PR:

* changes source.F90 to use `implicit none` instead of `implicit real` for the reasons described in #1138 
* tidies the formatting of source.F90 (consistent indentation, removal of trailing spaces, etc.)
* adds an MCNP6 version, called source_mcnp6.F90

This PR should not change the functionality of source.F90 at all. I tested this version with the JET shutdown photon source and it works the same as before.