### PR TITLE
Change default initializer of Mesh()

### DIFF
--- a/news/fix_mesh_default_initialization.rst
+++ b/news/fix_mesh_default_initialization.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* Default initializer pyne.mesh.Mesh() now raises an exception with info on how to properly make a mesh
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -704,8 +704,8 @@ class Mesh(object):
             stored in self.dims.
 
         """
-	# if Mesh is made and no parameters passed, raise MeshError
-	if mesh is None and not structured and structured_coords is None and \
+        # if Mesh is made and no parameters passed, raise MeshError
+        if mesh is None and not structured and structured_coords is None and \
             structured_set is None and structured_ordering=='xyz' and mats==():
             raise MeshError("Trivial mesh instantiation "
                             "For structured mesh instantiation, need to "
@@ -714,7 +714,7 @@ class Mesh(object):
                                 "B. Mesh file\n"
                                 "C. Mesh coordinates\n"
                                 "D. Structured entity set AND PyMOAB instance")
-	    return 
+            return 
         if mesh is None:
             self.mesh = mb_core.Core()
         elif isinstance(mesh, basestring):

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -706,10 +706,9 @@ class Mesh(object):
         """
 	# if Mesh is made and no parameters passed, raise MeshError
 	if mesh is None and not structured and structured_coords is None and \
-	    structured_set is None and structured_ordering=='xyz' and \
-	mats==():
-	    raise MeshError("Trivial mesh instantiation "
-				"For structured mesh instantiation, need to "
+            structured_set is None and structured_ordering=='xyz' and mats==():
+            raise MeshError("Trivial mesh instantiation "
+                            "For structured mesh instantiation, need to "
                                 "supply exactly one of the following:\n"
                                 "A. PyMOAB instance\n"
                                 "B. Mesh file\n"

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -707,7 +707,7 @@ class Mesh(object):
         # if Mesh is made and no parameters passed, raise MeshError
         if mesh is None and not structured and structured_coords is None and \
             structured_set is None and structured_ordering=='xyz' and mats==():
-            raise MeshError("Trivial mesh instantiation "
+            raise MeshError("Trivial mesh instantiation detected. "
                             "For structured mesh instantiation, need to "
                                 "supply exactly one of the following:\n"
                                 "A. PyMOAB instance\n"

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -708,7 +708,7 @@ class Mesh(object):
         if mesh is None and not structured and structured_coords is None and \
             structured_set is None and structured_ordering=='xyz' and mats==():
             raise MeshError("Trivial mesh instantiation detected. "
-                            "For structured mesh instantiation, need to "
+                            "For structured mesh instantiation, "
                                 "supply exactly one of the following:\n"
                                 "A. PyMOAB instance\n"
                                 "B. Mesh file\n"

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -706,7 +706,7 @@ class Mesh(object):
         """
 	# if Mesh is made and no parameters passed, raise MeshError
 	if mesh is None and not structured and structured_coords is None and \
-	structured_set is None and structured_ordering=='xyz' and \
+	    structured_set is None and structured_ordering=='xyz' and \
 	mats==():
 	    raise MeshError("Trivial mesh instantiation "
 				"For structured mesh instantiation, need to "

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -705,8 +705,8 @@ class Mesh(object):
 
         """
         # if Mesh is made and no parameters passed, raise MeshError
-        if mesh is None and not structured and structured_coords is None and \
-            structured_set is None and structured_ordering=='xyz' and mats==():
+        if (mesh is None and not structured and structured_coords is None and \
+            structured_set is None and structured_ordering=='xyz' and mats==()):
             raise MeshError("Trivial mesh instantiation detected. "
                             "For structured mesh instantiation, "
                                 "supply exactly one of the following:\n"

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -705,8 +705,9 @@ class Mesh(object):
 
         """
         # if Mesh is made and no parameters passed, raise MeshError
-        if (mesh is None and not structured and structured_coords is None and \
-            structured_set is None and structured_ordering=='xyz' and mats==()):
+        if (mesh is None) and (not structured) and (structured_coords is None) \
+            and (structured_set is None) and (structured_ordering=='xyz') \ 
+            and (mats==()):
             raise MeshError("Trivial mesh instantiation detected. "
                             "For structured mesh instantiation, "
                                 "supply exactly one of the following:\n"

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -714,7 +714,6 @@ class Mesh(object):
                                 "B. Mesh file\n"
                                 "C. Mesh coordinates\n"
                                 "D. Structured entity set AND PyMOAB instance")
-            return 
         if mesh is None:
             self.mesh = mb_core.Core()
         elif isinstance(mesh, basestring):

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -704,6 +704,18 @@ class Mesh(object):
             stored in self.dims.
 
         """
+	# if Mesh is made and no parameters passed, raise MeshError
+	if mesh is None and not structured and structured_coords is None and \
+	structured_set is None and structured_ordering=='xyz' and \
+	mats==():
+	    raise MeshError("Trivial mesh instantiation "
+				"For structured mesh instantiation, need to "
+                                "supply exactly one of the following:\n"
+                                "A. PyMOAB instance\n"
+                                "B. Mesh file\n"
+                                "C. Mesh coordinates\n"
+                                "D. Structured entity set AND PyMOAB instance")
+	    return 
         if mesh is None:
             self.mesh = mb_core.Core()
         elif isinstance(mesh, basestring):

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -706,8 +706,8 @@ class Mesh(object):
         """
         # if Mesh is made and no parameters passed, raise MeshError
         if (mesh is None) and (not structured) and (structured_coords is None) \
-            and (structured_set is None) and (structured_ordering=='xyz') \ 
-            and (mats==()):
+            and (structured_set is None) and (structured_ordering == 'xyz') \
+            and (mats == ()):
             raise MeshError("Trivial mesh instantiation detected. "
                             "For structured mesh instantiation, "
                                 "supply exactly one of the following:\n"


### PR DESCRIPTION
Hi, I wanted to introduce myself quickly as this is my first PR to PyNE. I'm Anthony Ruzzo, a current undergrad student in Nuclear Engineering at the University of Illinois at Urbana-Champaign. I'm working under @katyhuff to help address different issues with PyNE. 

This PR addresses issue #1095:

- Default initialization of a mesh, `m=pyne.mesh.Mesh()` now raises an exception with information on how to create a PyNE mesh properly