### PR TITLE
Updated documentation links

### DIFF
--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -6,7 +6,7 @@ Conda Package Manager
 The first step is to make sure that you have 
 the conda package manager installed. 
 You can download and install either anaconda or miniconda from 
-`the Continuum downloads page <http://continuum.io/downloads>`_.
+`the downloads page <https://www.anaconda.com/distribution/#download-section>`_.
 Make sure that you follow the full instructions and that the 
 conda command line utility is on your PATH.  This is the default 
 option when installing conda.

--- a/docs/install/linux_source.rst
+++ b/docs/install/linux_source.rst
@@ -46,6 +46,6 @@ do its best to find relevant nuclear data elsewhere on your machine
 or from public sources on the internet.
 
 
-.. _zip: https://github.com/pyne/pyne/zipball/0.4
-.. _tar: https://github.com/pyne/pyne/tarball/0.4
+.. _zip: https://github.com/pyne/pyne/zipball/0.5.1
+.. _tar: https://github.com/pyne/pyne/tarball/0.5.1
 .. _GitHub: http://github.com/pyne/pyne

--- a/readme.rst
+++ b/readme.rst
@@ -114,7 +114,7 @@ PyNE has known issues on the following platforms
 Conda Install Instructions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 After installing anaconda or miniconda from 
-`the Continuum downloads page <http://continuum.io/downloads>`_,
+`the downloads page <https://www.anaconda.com/distribution/#download-section>`_,
 in a new terminal run the following conda install command::
 
     conda install -c conda-forge pyne
@@ -128,7 +128,7 @@ Conda Build Instructions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 On mac and linux PyNE can be installed via the package manager conda. 
 After installing anaconda or miniconda from 
-`the Continuum downloads page <http://continuum.io/downloads>`_ 
+`the downloads page <https://www.anaconda.com/distribution/#download-section>`_ 
 add conda's binary directory to your bash profile by adding::
 
     export PATH=/path/to/anaconda/bin:$PATH
@@ -202,8 +202,8 @@ Once those lines have been added, run the following command before running
     source ~/.bashrc
 
 
-.. _zip: https://github.com/pyne/pyne/zipball/0.4
-.. _tar: https://github.com/pyne/pyne/tarball/0.4
+.. _zip: https://github.com/pyne/pyne/zipball/0.5.1
+.. _tar: https://github.com/pyne/pyne/tarball/0.5.1
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Addresses issue #1142:

Anaconda download links are directed to Anaconda's homepage instead of Continuum.
Download link for PyNE stable release to use in installation updated to PyNE 0.5.11.