### PR TITLE
Fix decay_heat() in material.cpp

### DIFF
--- a/news/material_fix_uses_state_id.rst
+++ b/news/material_fix_uses_state_id.rst
@@ -1,4 +1,6 @@
-**Added:** None
+**Added:**
+
+* Adds tests to tests/test:materials.py:test_decay_heat(self) to check more isotopes
 
 **Changed:**
 

--- a/news/material_fix_uses_state_id.rst
+++ b/news/material_fix_uses_state_id.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* decay_heat() in material.cpp now calls metastable_id to convert zas_id to state_id
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1221,8 +1221,8 @@ pyne::comp_map pyne::Material::decay_heat() {
   double masspermole = mass * pyne::N_A;
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); ++i) {
     dh[i->first] = masspermole * (i->second) * \
-                   decay_const(i->first) * q_val(i->first) / \
-                   atomic_mass(i->first) / pyne::MeV_per_MJ;
+                   decay_const(metastable_id(i->first,i->first % 10000)) * \
+                   q_val(i->first) / atomic_mass(i->first) / pyne::MeV_per_MJ;
   }
   return dh;
 }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1221,7 +1221,7 @@ pyne::comp_map pyne::Material::decay_heat() {
   double masspermole = mass * pyne::N_A;
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); ++i) {
     dh[i->first] = masspermole * (i->second) * \
-                   decay_const(metastable_id(i->first,i->first % 10000)) * \
+                   decay_const(metastable_id(i->first,nucname::snum(i->first))) * \
                    q_val(i->first) / atomic_mass(i->first) / pyne::MeV_per_MJ;
   }
   return dh;

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -222,10 +222,19 @@ class TestMaterialMethods(TestCase):
         assert_equal(set(obs.values()), set(exp.values()))
 
 
-    def test_decay_heat(self):
+    def test_decay_heat1(self):
         mat = Material({922350000: 0.05, 922380000: 0.95}, 15)
         obs = mat.decay_heat()
         exp = {922350000: 4.48963565256e-14, 922380000: 1.2123912039e-13}
+        assert_equal(set(obs), set(exp))
+        for key in exp:
+            assert_almost_equal(obs[key], exp[key])
+    
+
+    def test_decay_heat2(self):
+        mat = Material({471080001: 0.5, 551340001: 0.5}, 2)
+        obs = mat.decay_heat()
+        exp = {471080001: 7.33578506845e-8, 551340001: 6.241109861949e-3}
         assert_equal(set(obs), set(exp))
         for key in exp:
             assert_almost_equal(obs[key], exp[key])

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -234,6 +234,8 @@ class TestMaterialMethods(TestCase):
     def test_decay_heat_metastable(self):
         mat = Material({471080001: 0.5, 551340001: 0.5}, 2)
         obs = mat.decay_heat()
+        # decay heat values from external calculation using half-life: BNL
+        # q-values: ORNL, atomic mass: AMDC
         exp = {471080001: 7.33578506845e-8, 551340001: 6.241109861949e-3}
         assert_equal(set(obs), set(exp))
         for key in exp:

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -222,7 +222,7 @@ class TestMaterialMethods(TestCase):
         assert_equal(set(obs.values()), set(exp.values()))
 
 
-    def test_decay_heat1(self):
+    def test_decay_heat_stable(self):
         mat = Material({922350000: 0.05, 922380000: 0.95}, 15)
         obs = mat.decay_heat()
         exp = {922350000: 4.48963565256e-14, 922380000: 1.2123912039e-13}
@@ -231,7 +231,7 @@ class TestMaterialMethods(TestCase):
             assert_almost_equal(obs[key], exp[key])
     
 
-    def test_decay_heat2(self):
+    def test_decay_heat_metastable(self):
         mat = Material({471080001: 0.5, 551340001: 0.5}, 2)
         obs = mat.decay_heat()
         exp = {471080001: 7.33578506845e-8, 551340001: 6.241109861949e-3}


### PR DESCRIPTION
This PR addresses #1145:

- `decay_heat()` in material.cpp now calls `metastable_id()` before calling `decay_const()`

`decay_const()` searches for the the half-life using state_id notation, but `decay_heat()` formerly called it without first using `metastable_id()` to convert from zas_id to state_id.
I updated the previous test file [found here ](https://gist.github.com/aruzzo/28cbe1e861436f677d574092c06ad116) with a new one [found here](https://gist.github.com/aruzzo/3e87e6381702b6572b13d31e43429c26) to show that `decay_heat()` still works for two previously normal isotopes and now works for two previously problematic isotopes.