### PR TITLE
R2s allow turn off void rejection

### DIFF
--- a/docs/usersguide/source_sampling.rst
+++ b/docs/usersguide/source_sampling.rst
@@ -226,11 +226,14 @@ groups used in the activation calculations. An "idum" card must be used
 in the MCNP5 input file. This card should have three arguments. The first is the
 sampling mode (0: DEFAULT_ANALOG, 1: DEFAULT_UNIFORM, 2: DEFAULT_USER,
 3: SUBVOXEL_ANALOG, 4: SUBVOXEL_UNIFORM, 5: SUBVOXEL_USER). The second is the
-resample limit for void and cell rejections. For a given particle, if a source
-position is selected in void (MCNP material 0) or in a cell that disagrees with the
-cell number, the source position is resampled within the selected mesh volume
-element until either a correct position is found, or this user-specified limit
-is researched. The third argument should specify the particle type: 1 for
+resample limit for void and cell rejections. If the second argument is set to
+be a postive integer, the void rejection will be applied, i.e., for a given
+particle, if a source position is selected in void (MCNP material 0) or in a
+cell that disagrees with the cell number, the source position is resampled
+within the selected mesh volume element until either a correct position is
+found, or this user-specified limit is researched. If the second argument is
+set to be a negtive integer (-1 is recommended), then the void rejection will
+be disabled. The third argument should specify the particle type: 1 for
 neutrons, 2 for photons.
 
 For example, this "idum" card specifies uniform sampling with a resample limit

--- a/docs/usersguide/source_sampling.rst
+++ b/docs/usersguide/source_sampling.rst
@@ -232,9 +232,8 @@ particle, if a source position is selected in void (MCNP material 0) or in a
 cell that disagrees with the cell number, the source position is resampled
 within the selected mesh volume element until either a correct position is
 found, or this user-specified limit is researched. If the second argument is
-set to be a negtive integer (-1 is recommended), then the void rejection will
-be disabled. The third argument should specify the particle type: 1 for
-neutrons, 2 for photons.
+set to be 0, then the void rejection will be disabled. The third argument
+should specify the particle type: 1 for neutrons, 2 for photons.
 
 For example, this "idum" card specifies uniform sampling with a resample limit
 of 100 with source particles specified as photons:

--- a/news/r2s_allow_turn_off_void_rejection.rst
+++ b/news/r2s_allow_turn_off_void_rejection.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Add the ability to allow user turn off the void rejection in source sampling.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/share/source.F90
+++ b/share/source.F90
@@ -165,7 +165,7 @@ subroutine source
   ! check whether the material of sampled cell is void
   ! idum > 0, enable void rejection
   ! idum < 0, disable void rejection
-  if (mat(icl_tmp).eq.0) .and. idum(2) > 0 then
+  if ((mat(icl_tmp).eq.0) .and. (idum(2) > 0)) then
     goto 300
   else
     goto 400

--- a/share/source.F90
+++ b/share/source.F90
@@ -163,7 +163,9 @@ subroutine source
   endif
 
   ! check whether the material of sampled cell is void
-  if (mat(icl_tmp).eq.0) then
+  ! idum > 0, enable void rejection
+  ! idum < 0, disable void rejection
+  if (mat(icl_tmp).eq.0) .and. idum(2) > 0 then
     goto 300
   else
     goto 400

--- a/share/source.F90
+++ b/share/source.F90
@@ -164,7 +164,7 @@ subroutine source
 
   ! check whether the material of sampled cell is void
   ! idum > 0, enable void rejection
-  ! idum < 0, disable void rejection
+  ! idum = 0, disable void rejection
   if ((mat(icl_tmp).eq.0) .and. (idum(2) > 0)) then
     goto 300
   else

--- a/share/source_mcnp6.F90
+++ b/share/source_mcnp6.F90
@@ -159,7 +159,7 @@ subroutine source
 
   ! check whether the material of sampled cell is void
   ! idum > 0, enable void rejection
-  ! idum < 0, disable void rejection
+  ! idum = 0, disable void rejection
   if ((mat(icl_tmp).eq.0) .and. (idum(2) > 0)) then
     goto 300
   else

--- a/share/source_mcnp6.F90
+++ b/share/source_mcnp6.F90
@@ -158,7 +158,9 @@ subroutine source
   endif
 
   ! check whether the material of sampled cell is void
-  if (mat(icl_tmp).eq.0) then
+  ! idum > 0, enable void rejection
+  ! idum < 0, disable void rejection
+  if ((mat(icl_tmp).eq.0) .and. (idum(2) > 0)) then
     goto 300
   else
     goto 400


### PR DESCRIPTION
As suggested in #1111 , this PR makes the changes to allow user turn off the void rejection.

Using the variable `idum(2)`:
- If it is a positive integer, the void rejection is turned on
- If it is a negtive integer, the void rejection is turned off