### PR TITLE
Fix r2s example doc typo

### DIFF
--- a/news/fix_r2s_example_doc_typo.rst
+++ b/news/fix_r2s_example_doc_typo.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Fix typos in the R2S example files.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -83,7 +83,7 @@ flux  my_flux     alara_fluxin  1e10     0      default
 
 # Specify the irradiation schedule below.
 # Syntax is found in the ALARA user manual
-# This example is for a single 3.5 h pulse
+# This example is for a single 3.5 d pulse
 schedule    my_schedule
     3.5 d my_flux my_pulse_history 0  s
 end

--- a/tests/files_test_r2s/r2s_examples/r2s_run/alara_params.txt
+++ b/tests/files_test_r2s/r2s_examples/r2s_run/alara_params.txt
@@ -20,7 +20,7 @@ flux  my_flux     alara_fluxin  1e10     0      default
 
 # Specify the irradiation schedule below.
 # Syntax is found in the ALARA user manual
-# This example is for a single 3.5 h pulse
+# This example is for a single 3.5 d pulse
 schedule    my_schedule
     3.5 d my_flux my_pulse_history 0  s
 end

--- a/tests/files_test_r2s/r2s_examples/r2s_run/exp_alara_inp
+++ b/tests/files_test_r2s/r2s_examples/r2s_run/exp_alara_inp
@@ -53,7 +53,7 @@ flux  my_flux     alara_fluxin  1e10     0      default
 
 # Specify the irradiation schedule below.
 # Syntax is found in the ALARA user manual
-# This example is for a single 3.5 h pulse
+# This example is for a single 3.5 d pulse
 schedule    my_schedule
     3.5 d my_flux my_pulse_history 0  s
 end

--- a/tests/files_test_r2s/r2s_examples/subvoxel_r2s_run/alara_params.txt
+++ b/tests/files_test_r2s/r2s_examples/subvoxel_r2s_run/alara_params.txt
@@ -20,7 +20,7 @@ flux  my_flux     alara_fluxin  1e10     0      default
 
 # Specify the irradiation schedule below.
 # Syntax is found in the ALARA user manual
-# This example is for a single 3.5 h pulse
+# This example is for a single 3.5 d pulse
 schedule    my_schedule
     3.5 d my_flux my_pulse_history 0  s
 end

--- a/tests/files_test_r2s/r2s_examples/subvoxel_r2s_run/exp_alara_inp
+++ b/tests/files_test_r2s/r2s_examples/subvoxel_r2s_run/exp_alara_inp
@@ -50,7 +50,7 @@ flux  my_flux     alara_fluxin  1e10     0      default
 
 # Specify the irradiation schedule below.
 # Syntax is found in the ALARA user manual
-# This example is for a single 3.5 h pulse
+# This example is for a single 3.5 d pulse
 schedule    my_schedule
     3.5 d my_flux my_pulse_history 0  s
 end

--- a/tests/files_test_r2s/r2s_examples/unstructured_r2s_run/alara_params.txt
+++ b/tests/files_test_r2s/r2s_examples/unstructured_r2s_run/alara_params.txt
@@ -20,7 +20,7 @@ flux  my_flux     alara_fluxin  1e10     0      default
 
 # Specify the irradiation schedule below.
 # Syntax is found in the ALARA user manual
-# This example is for a single 3.5 h pulse
+# This example is for a single 3.5 d pulse
 schedule    my_schedule
     3.5 d my_flux my_pulse_history 0  s
 end

--- a/tests/files_test_r2s/r2s_examples/unstructured_r2s_run/exp_alara_inp
+++ b/tests/files_test_r2s/r2s_examples/unstructured_r2s_run/exp_alara_inp
@@ -272,7 +272,7 @@ flux  my_flux     alara_fluxin  1e10     0      default
 
 # Specify the irradiation schedule below.
 # Syntax is found in the ALARA user manual
-# This example is for a single 3.5 h pulse
+# This example is for a single 3.5 d pulse
 schedule    my_schedule
     3.5 d my_flux my_pulse_history 0  s
 end


### PR DESCRIPTION
This PR fixes some typos in the R2S example files. Found by @moatazharb here: https://github.com/pyne/pyne/pull/1123#discussion_r310361640.