### PR TITLE
add news checker in the CI-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
       - run: cd ../ && nuc_data_make ;
       - save_container:
           build: << parameters.build >>
-
+  
   # Run PyNE test
   run_test:
     description: "Run tests"
@@ -108,6 +108,17 @@ commands:
 # Define the different job that will be ran this separate building form
 # testing for each configuration allowing to get more information out of the CI
 jobs:
+# news file checker
+  news_update:
+    executor: 
+      name: py3
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Checking News Update
+          command: news/news_test.sh news
+ 
 # Python 3 jobs
   py3_build:
     executor:
@@ -224,6 +235,8 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - news_update
+        
       - py3_build
       - py3_test:
           requires:

--- a/news/news_test.rst
+++ b/news/news_test.rst
@@ -1,0 +1,12 @@
+**Added:** None
+* script and CI implementation ensuring at least 1 news file have been recreated
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# folder to look for addition
+folder=$1
+
+# default main repo setup
+master_repo="https://github.com/pyne/pyne.git"
+default_branch="develop"
+
+
+# setup temp remote 
+git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
+echo $git_remote_name
+git remote add ${git_remote_name} ${master_repo}
+git fetch ${git_remote_name}
+
+# diff against temp remote
+added_news_file=$((`git diff ${git_remote_name}/${default_branch} --name-only $folder |wc -l`))
+
+# cleaning temp remote
+git remote remove ${git_remote_name}
+
+
+# analysing the diff and returning accordingly
+if [ $added_news_file -eq 0 ]; then
+    exit 1
+fi

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -9,7 +9,6 @@ default_branch="develop"
 
 # setup temp remote 
 git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
-echo $git_remote_name
 git remote add ${git_remote_name} ${master_repo}
 git fetch ${git_remote_name}
 


### PR DESCRIPTION
This add a new CI-test to check if a news file have been created in the news folder.

I guessed as we rely on them, we might as well enforce them!
