### PR TITLE
fix news check trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ workflows:
       - news_update:
           filters:
             branches:
-              ignore: master
+              ignore: develop
             tags:
               ignore: /.*/   
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,8 +235,13 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - news_update
-        
+      - news_update:
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/   
+      
       - py3_build
       - py3_test:
           requires:

--- a/news/news_check_trigger_fix.rst
+++ b/news/news_check_trigger_fix.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+- new check won't now be triggered after a merge only on PRs
+
+**Security:** None


### PR DESCRIPTION
News check also ran after a merge on `develop` and fails because `develop` branch and `develop`  branch have the same number of news files...
this should prevent the news check test to be triggered after a merge.

News check should still be triggered on all the PRs