### PR TITLE
Form UWUW material name

### DIFF
--- a/news/uwuw_name.rst
+++ b/news/uwuw_name.rst
@@ -1,0 +1,11 @@
+**Added:** None
+- capability to form a uwuw material name
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -40,6 +40,7 @@ cdef extern from "material.h" namespace "pyne":
         void norm_comp() except +
         std_string openmc(std_string) except +
         std_string mcnp(std_string) except +
+        std_string uwuw() except +
         std_string fluka(int, std_string) except +
         bool not_fluka_builtin(std_string) except +
         std_string fluka_material_str(int) except +

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -40,7 +40,7 @@ cdef extern from "material.h" namespace "pyne":
         void norm_comp() except +
         std_string openmc(std_string) except +
         std_string mcnp(std_string) except +
-        std_string uwuw() except +
+        std_string get_uwuw_name() except +
         std_string fluka(int, std_string) except +
         bool not_fluka_builtin(std_string) except +
         std_string fluka_material_str(int) except +

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -346,12 +346,12 @@ cdef class _Material:
         card = self.mat_pointer.mcnp(frac_type.encode())
         return card.decode()
     
-    def uwuw(self):
-        """uwuw()
+    def get_uwuw_name(self):
+        """get_uwuw_name()
         Return a uwuw material name
         """
         cdef std_string uwuw_name
-        uwuw_name = self.mat_pointer.uwuw()
+        uwuw_name = self.mat_pointer.get_uwuw_name()
         return uwuw_name.decode()
 
     def openmc(self, frac_type='mass'):

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -346,7 +346,7 @@ cdef class _Material:
         card = self.mat_pointer.mcnp(frac_type.encode())
         return card.decode()
     
-    def mcnp(self):
+    def uwuw(self):
         """mcnp(frac_type)
         Return a uwuw material name
         """

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -347,7 +347,7 @@ cdef class _Material:
         return card.decode()
     
     def uwuw(self):
-        """mcnp(frac_type)
+        """uwuw()
         Return a uwuw material name
         """
         cdef std_string uwuw_name

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -345,6 +345,14 @@ cdef class _Material:
         cdef std_string card
         card = self.mat_pointer.mcnp(frac_type.encode())
         return card.decode()
+    
+    def mcnp(self):
+        """mcnp(frac_type)
+        Return a uwuw material name
+        """
+        cdef std_string uwuw_name
+        uwuw_name = self.mat_pointer.uwuw()
+        return uwuw_name.decode()
 
     def openmc(self, frac_type='mass'):
         """openmc(frac_type)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -594,6 +594,26 @@ std::string pyne::Material::openmc(std::string frac_type) {
   return oss.str();
 }
 
+///---------------------------------------------------------------------------//
+std::string pyne::Material::uwuw() {
+  // standard uwuw material name is : "mat:<Name of Material>/rho:<density>" 
+  if (! metadata.isMember("name")) {
+    pyne::warning("The material has no name!!");
+    return "";
+  }
+  std::string uwuw_name = "mat:<";
+  uwuw_name += metadata["name"].asString();
+  if (density > 0) {
+    uwuw_name += "/rho:" +std::to_string(density);
+  } else {
+    pyne::warning("No Density defined for this Material");
+  }
+
+  uwuw_name += ">";
+  return uwuw_name;
+}
+
+///---------------------------------------------------------------------------//
 std::string pyne::Material::mcnp(std::string frac_type) {
   //////////////////// Begin card creation ///////////////////////
   std::ostringstream oss;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -595,21 +595,22 @@ std::string pyne::Material::openmc(std::string frac_type) {
 }
 
 ///---------------------------------------------------------------------------//
-std::string pyne::Material::uwuw() {
+std::string pyne::Material::get_uwuw_name() {
   // standard uwuw material name is : "mat:<Name of Material>/rho:<density>" 
   if (! metadata.isMember("name")) {
     pyne::warning("The material has no name");
     return "";
   }
-  std::string uwuw_name = "mat:";
-  uwuw_name += metadata["name"].asString();
+  std::ostringstream uwuw_name;
+  uwuw_name << "mat:";
+  uwuw_name << metadata["name"].asString();
   if (density > 0) {
-    uwuw_name += "/rho:" +std::to_string(density);
+    uwuw_name << "/rho:" << std::setprecision(5) << density;
   } else {
     pyne::warning("No Density defined for this Material");
   }
 
-  return uwuw_name;
+  return uwuw_name.str();
 }
 
 ///---------------------------------------------------------------------------//

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -598,10 +598,10 @@ std::string pyne::Material::openmc(std::string frac_type) {
 std::string pyne::Material::uwuw() {
   // standard uwuw material name is : "mat:<Name of Material>/rho:<density>" 
   if (! metadata.isMember("name")) {
-    pyne::warning("The material has no name!!");
+    pyne::warning("The material has no name");
     return "";
   }
-  std::string uwuw_name = "mat:<";
+  std::string uwuw_name = "mat:";
   uwuw_name += metadata["name"].asString();
   if (density > 0) {
     uwuw_name += "/rho:" +std::to_string(density);
@@ -609,7 +609,6 @@ std::string pyne::Material::uwuw() {
     pyne::warning("No Density defined for this Material");
   }
 
-  uwuw_name += ">";
   return uwuw_name;
 }
 

--- a/src/material.h
+++ b/src/material.h
@@ -172,7 +172,7 @@ namespace pyne
     std::string mcnp(std::string frac_type = "mass");
     ///
     /// Return an uwuw name
-    std::string uwuw();
+    std::string get_uwuw_name();
     ///
     /// Return a fluka input deck MATERIAL card as a string
     std::string fluka(int id, std::string frac_type = "mass");

--- a/src/material.h
+++ b/src/material.h
@@ -171,6 +171,9 @@ namespace pyne
     /// Return an mcnp input deck record as a string
     std::string mcnp(std::string frac_type = "mass");
     ///
+    /// Return an uwuw name
+    std::string uwuw();
+    ///
     /// Return a fluka input deck MATERIAL card as a string
     std::string fluka(int id, std::string frac_type = "mass");
     /// Convenience function to tell whether a given name needs a material card

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1294,7 +1294,6 @@ def test_uwuw():
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
@@ -1308,7 +1307,6 @@ def test_uwuw():
     leu2 = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
@@ -1321,7 +1319,6 @@ def test_uwuw():
     no_name = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1290,7 +1290,47 @@ def test_mcnp_mat0():
     assert_equal(mass, mass_exp)
 
 
+def uwuw():
+    leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
+                   metadata={'mat_number': 2,
+                          'table_ids': {'92235':'15c', '92238':'25c'},
+                          'mat_name':'LEU',
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          'name':'leu'},
+                   density=19.1)
+
+    uwuw_name = leu.uwuw()
+    name_exp = ('<mat:leu/rho:19.1>')
+    assert_equal(uwuw_name, name_exp)
+
+    leu2 = Material(nucvec={'U235': 0.04, 'U238': 0.96},
+                   metadata={'mat_number': 2,
+                          'table_ids': {'92235':'15c', '92238':'25c'},
+                          'mat_name':'LEU',
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          'name':'leu'})
+    uwuw_name = leu2.uwuw()
+    name_exp = ('<mat:leu>')
+    assert_equal(uwuw_name, name_exp)
+
     
+    no_name = Material(nucvec={'U235': 0.04, 'U238': 0.96},
+                   metadata={'mat_number': 2,
+                          'table_ids': {'92235':'15c', '92238':'25c'},
+                          'mat_name':'LEU',
+                          'source':'Some URL',
+                          'comments': ('this is a long comment that will definitly '
+                                       'go over the 80 character limit, for science'),
+                          },
+                   density=19.1)
+    uwuw_name = no_name.uwuw()
+    name_exp = ('')
+    assert_equal(uwuw_name, name_exp)
+
 
 def test_alara():
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1301,7 +1301,7 @@ def test_uwuw():
                           'name':'leu'},
                    density=19.1)
 
-    uwuw_name = leu.uwuw()
+    uwuw_name = leu.get_uwuw_name()
     name_exp = ('mat:leu/rho:19.1')
     assert_equal(uwuw_name, name_exp)
 
@@ -1313,7 +1313,7 @@ def test_uwuw():
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
                           'name':'leu'})
-    uwuw_name = leu2.uwuw()
+    uwuw_name = leu2.get_uwuw_name()
     name_exp = ('mat:leu')
     assert_equal(uwuw_name, name_exp)
 
@@ -1327,7 +1327,7 @@ def test_uwuw():
                                        'go over the 80 character limit, for science'),
                           },
                    density=19.1)
-    uwuw_name = no_name.uwuw()
+    uwuw_name = no_name.get_uwuw_name()
     name_exp = ('')
     assert_equal(uwuw_name, name_exp)
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1290,7 +1290,7 @@ def test_mcnp_mat0():
     assert_equal(mass, mass_exp)
 
 
-def uwuw():
+def test_uwuw():
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
@@ -1302,7 +1302,7 @@ def uwuw():
                    density=19.1)
 
     uwuw_name = leu.uwuw()
-    name_exp = ('<mat:leu/rho:19.1>')
+    name_exp = ('mat:leu/rho:19.1')
     assert_equal(uwuw_name, name_exp)
 
     leu2 = Material(nucvec={'U235': 0.04, 'U238': 0.96},
@@ -1314,7 +1314,7 @@ def uwuw():
                                        'go over the 80 character limit, for science'),
                           'name':'leu'})
     uwuw_name = leu2.uwuw()
-    name_exp = ('<mat:leu>')
+    name_exp = ('mat:leu')
     assert_equal(uwuw_name, name_exp)
 
     


### PR DESCRIPTION
I figured that as we are slowly moving on with the MaterialLibrary C++ API at some point we would need something like that...
this allows to form a UWUW material name, including the density if provided.

this solves #1188 