### PR TITLE
openMC material name 

### DIFF
--- a/news/mat_name.rst
+++ b/news/mat_name.rst
@@ -1,0 +1,11 @@
+**Added:** None
+
+**Changed:** None
+- change openmc mat name reference from "mat_name" to "name"
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -502,15 +502,10 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   // add name if specified
-  if (temp_mat.metadata.isMember("mat_name")) {
-    std::cout << "Usage of mat_name ad a Metadata is deprecated, please use \"name\" instead." <<std::endl;
-    temp_mat.metadata["name"] = temp_mat.metadata["mat_name"].asString();
-  }
 
   if (temp_mat.metadata.isMember("name")) {
     oss << "name=" << new_quote << temp_mat.metadata["name"].asString() << end_quote;
-  }
-
+  } 
   // close the material tag
   oss << ">";
   // new line

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -503,7 +503,12 @@ std::string pyne::Material::openmc(std::string frac_type) {
 
   // add name if specified
   if (temp_mat.metadata.isMember("mat_name")) {
-    oss << "name=" << new_quote << temp_mat.metadata["mat_name"].asString() << end_quote;
+    std::cout << "Usage of mat_name ad a Metadata is deprecated, please use \"name\" instead." <<std::endl;
+    temp_mat.metadata["name"] = temp_mat.metadata["mat_name"].asString();
+  }
+
+  if (temp_mat.metadata.isMember("name")) {
+    oss << "name=" << new_quote << temp_mat.metadata["name"].asString() << end_quote;
   }
 
   // close the material tag

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1137,11 +1137,10 @@ def test_openmc():
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
-                          'name':'leu'},
+                          'name':'LEU'},
                    density=19.1)
 
     mass = leu.openmc()
@@ -1177,11 +1176,10 @@ def test_openmc_mat0():
     leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238M': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92236':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
-                          'name':'leu'},
+                          'name':'LEU'},
                    density=19.1)
 
     mass = leu.openmc()
@@ -1197,11 +1195,10 @@ def test_openmc_sab():
     leu = Material(nucvec={'H1': 0.66, 'O16': 0.33},
                    metadata={'mat_number': 2,
                              'sab': 'c_H_in_H2O',
-                             'mat_name':'Water',
                              'source':'Some URL',
                              'comments': ('this is a long comment that will definitly '
                                           'go over the 80 character limit, for science'),
-                          'name':'leu'},
+                          'name':'Water'},
                    density=1.001)
 
     mass = leu.openmc()
@@ -1218,8 +1215,7 @@ def test_openmc_c():
     csi = Material()
     csi.from_atom_frac({'C': 0.5, 'Si': 0.5})
     csi.metadata= {'mat_number': 2,
-                   'mat_name':'silicon carbide',
-                   'name':'leu'}
+                   'name':'silicon carbide'}
     csi.density = 3.16
 
     atom = csi.openmc(frac_type='atom')
@@ -1237,7 +1233,6 @@ def test_mcnp():
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
@@ -1271,7 +1266,6 @@ def test_mcnp_mat0():
     leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92236':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
@@ -1332,11 +1326,10 @@ def test_write_openmc():
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),
-                          'name':'leu'},
+                          'name':'LEU'},
                    density=19.1)
 
     leu.write_openmc('openmc_mass_fracs.txt')
@@ -1366,7 +1359,6 @@ def test_write_mcnp():
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
-                          'mat_name':'LEU',
                           'source':'Some URL',
                           'comments': ('this is a long comment that will definitly '
                                        'go over the 80 character limit, for science'),


### PR DESCRIPTION
openmc() method in material.cc was looking for the "mat_name" for the name of the material.

this enforce the metadata convention: `name` for the material name.

I added some method to still catch `mat_name` if present in order to allow backward compatibility.

this should partially fix #1189 