### PR TITLE
Fix variable issue for mcnp6 source file

### DIFF
--- a/news/fix_variable_issue_mcnp6_source.rst
+++ b/news/fix_variable_issue_mcnp6_source.rst
@@ -1,0 +1,14 @@
+
+**Added:** None
+
+**Changed:**
+
+* Removed variables ```icl_tmp``` and ```find_cell``` which are not longer needed. 
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/share/source_mcnp6.F90
+++ b/share/source_mcnp6.F90
@@ -132,7 +132,6 @@ subroutine source
   logical, save :: first_run = .true.
   real(dknd), dimension(6) :: rands
   integer :: icl_tmp ! temporary cell index variable
-  integer :: find_cell
   integer :: tries
   integer, save :: cell_list_size = 0
   integer, dimension(:), allocatable, save :: cell_list

--- a/share/source_mcnp6.F90
+++ b/share/source_mcnp6.F90
@@ -54,7 +54,6 @@ subroutine find_cell(cell_list, cell_list_size, icl_tmp, count_1, count_2, count
 
   integer :: i ! iterator variable
   integer :: j ! temporary cell test
-  integer :: icl_tmp ! temporary cell variable
   integer, intent(in) :: cell_list_size
   integer, dimension(cell_list_size), intent(in) :: cell_list
   integer, intent(out) :: icl_tmp ! temporary cell variable


### PR DESCRIPTION
This pull request removes two variables that are not needed with the latest changes. These variables cause errors to come up when building the source. 
1. `icl_tmp`: has two declarations. Kept the one with intent declaration 
2. `find_cell`: has integer declaration, but `find_cell` is a subroutine now