### PR TITLE
Bug class Xsdir(object): def read corrected

### DIFF
--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -793,7 +793,7 @@ class Xsdir(object):
             # Handle continuation lines
             while words[-1] == '+':
                 extraWords = self.f.readline().split()
-                words = words + extraWords
+                words = words[:-1] + extraWords  # Correct bug in the XSDIR parsing
             assert len(words) >= 7
 
             # Create XsdirTable object and add to line


### PR DESCRIPTION
The parsing of XSDIR file was uncorrected when the ZAID XS was defined in more than one row. Indeed, the "+" word was not removed from the list having for instance "+" instead of "p-table" value as in the example reported hereinafter.

	18038.80c 37.6366 xdata/endf71x/Ar/18038.710nc 0 1 4 15536 0 0 2.5301E-08 +
          ptable