### PR TITLE
Material write hdf5 refactor

### DIFF
--- a/docs/pyapi/material.rst
+++ b/docs/pyapi/material.rst
@@ -20,7 +20,28 @@ have two main attributes which define them.
 1. **comp**: a normalized composition mapping from nuclides (zzaaam-ints) to mass-weights (floats).
 2. **mass**: the mass of the material.
 
+The :ref:`pyne_material_library` class is available to efficiently manipulate
+collections of materials.
 The material class is presented below.  For more information please refer to :ref:`usersguide_material`.
+
+When using the `write_hdf5` method, the default structure for the `HDF5` file
+is:
+.. verbatim::
+    /material/
+    /material/my_mat/
+    /material/my_mat/composition
+    /material/my_mat/nucid
+    /material/my_mat/composition_metadata
+
+
+Where, `/material` and `/material/my_mat` are HDF5 groups, (`my_mat` value shall provided
+as the datapath by the user).
+
+Older structure are still available to written when providing a `nucpath` to
+the `write_hdf5()` method.
+
+`from_hdf5()` will detect the structure (old or new) of the file (when using `protocol1`).
+
 
 **************
 Material Class

--- a/docs/pyapi/material.rst
+++ b/docs/pyapi/material.rst
@@ -39,9 +39,10 @@ Where, `/material` and `/material/my_mat` are HDF5 groups, (`my_mat` value shall
 be provided as the datapath by the user). IF the `$datapath` or `/material`
 exist as a dataset in the file, then the old writing method will ne used.
 
-Older structure are still available to written when providing a `nucpath` to the
-`write_hdf5()` method.
-Old structure looks like:
+Older data structure are deprecated but still available to written when providing a `nucpath` to the
+`write_hdf5()` method, or when writing a material in a file with the old
+data structure.
+Old data structure looks like:
 .. verbatim::
     /my_mat/
     /------/nucpath

--- a/docs/pyapi/material.rst
+++ b/docs/pyapi/material.rst
@@ -12,17 +12,17 @@ All functionality may be found in the ``material`` package::
 
  from pyne import material
 
-Materials are the primary container for radionuclides. They map nuclides to **mass weights**, 
-though they contain methods for converting to/from atom fractions as well.
-In many ways they take inspiration from numpy arrays and python dictionaries.  Materials
-have two main attributes which define them.
+Materials are the primary container for radionuclides. They map nuclides to
+**mass weights**, though they contain methods for converting to/from atom
+fractions as well.  In many ways they take inspiration from numpy arrays and
+python dictionaries.  Materials have two main attributes which define them.
 
-1. **comp**: a normalized composition mapping from nuclides (zzaaam-ints) to mass-weights (floats).
-2. **mass**: the mass of the material.
+1. **comp**: a normalized composition mapping from nuclides (zzaaam-ints) to
+   mass-weights (floats).  2. **mass**: the mass of the material.
 
 The :ref:`pyne_material_library` class is available to efficiently manipulate
-collections of materials.
-The material class is presented below.  For more information please refer to :ref:`usersguide_material`.
+collections of materials.  The material class is presented below.  For more
+information please refer to :ref:`usersguide_material`.
 
 When using the `write_hdf5` method, the default structure for the `HDF5` file
 is:
@@ -34,13 +34,15 @@ is:
     /material/my_mat/composition_metadata
 
 
-Where, `/material` and `/material/my_mat` are HDF5 groups, (`my_mat` value shall be provided
-as the datapath by the user).
+Where, `/material` and `/material/my_mat` are HDF5 groups, (`my_mat` value shall
+be provided as the datapath by the user). IF the `$datapath` or `/material`
+exist as a dataset in the file, then the old writing method will ne used.
 
-Older structure are still available to written when providing a `nucpath` to
-the `write_hdf5()` method.
+Older structure are still available to written when providing a `nucpath` to the
+`write_hdf5()` method.
 
-`from_hdf5()` will detect the structure (old or new) of the file (when using `protocol1`).
+`from_hdf5()` will detect the structure (old or new) of the file (when using
+`protocol1`).
 
 
 **************

--- a/docs/pyapi/material.rst
+++ b/docs/pyapi/material.rst
@@ -34,7 +34,7 @@ is:
     /material/my_mat/composition_metadata
 
 
-Where, `/material` and `/material/my_mat` are HDF5 groups, (`my_mat` value shall provided
+Where, `/material` and `/material/my_mat` are HDF5 groups, (`my_mat` value shall be provided
 as the datapath by the user).
 
 Older structure are still available to written when providing a `nucpath` to

--- a/docs/pyapi/material.rst
+++ b/docs/pyapi/material.rst
@@ -12,28 +12,28 @@ All functionality may be found in the ``material`` package::
 
  from pyne import material
 
-Materials are the primary container for mixtures of radionuclides. They map nuclides to
-**mass fractions**, though they contain methods for converting to/from atom
-fractions as well.  In many ways they take inspiration from numpy arrays and
-python dictionaries.  Materials have two main attributes which define them.
+Materials are the primary container for mixtures of radionuclides. They map
+nuclides to **mass fractions**, though they contain methods for converting
+to/from atom fractions as well.  In many ways they take inspiration from numpy
+arrays and python dictionaries.  Materials have two main attributes which define
+them.
 
 1. **comp**: a normalized composition mapping from nuclides (zzaaam-ints) to
    mass-fractions (floats).  
-   2. **mass**: the mass of the material.
+2. **mass**: the mass of the material.
 
 The :ref:`pyne_material_library` class is available to efficiently manipulate
 collections of materials.  The material class is presented below.  For more
 information please refer to :ref:`usersguide_material`.
 
-When using the `write_hdf5` method to write a material in a group named `my_mat`, the default structure for the `HDF5` file
-is:
+When using the `write_hdf5` method to write a material in a group named
+`my_mat`, the default structure for the `HDF5` file is:
 .. verbatim::
     /material/
-    /material/my_mat/
-    /material/my_mat/composition
-    /material/my_mat/nucid
-    /material/my_mat/composition_metadata
-
+    /--------/my_mat/
+             /------/composition
+             /------/nuclidelist
+             /------/composition_metadata
 
 Where, `/material` and `/material/my_mat` are HDF5 groups, (`my_mat` value shall
 be provided as the datapath by the user). IF the `$datapath` or `/material`
@@ -41,10 +41,23 @@ exist as a dataset in the file, then the old writing method will ne used.
 
 Older structure are still available to written when providing a `nucpath` to the
 `write_hdf5()` method.
+Old structure looks like:
+.. verbatim::
+    /my_mat/
+    /------/nucpath
+    /my_mat_metadata
+    /nuclidelist
+
+`my_mat` (the `datapath` -- default `material`) is a HDF5 dataset containing the
+material composition, `nucpath` is a attribute containing the path to the
+nuclide list (nested in the `datapath`).
+`my_mat_metadata` is a dataset containing the metatdata of the material.
+`nuclidelist` is a dataset containing the list of nuclides composition the
+material.
+
 
 `from_hdf5()` will detect the structure (old or new) of the file (when using
 `protocol1`).
-
 
 **************
 Material Class
@@ -56,7 +69,8 @@ Material Class
 *****************************
 Material Generation Functions
 *****************************
-The following top-level module functions are used to generate materials from various sources.
+The following top-level module functions are used to generate materials from
+various sources.
 
 .. autofunction:: from_atom_frac
 

--- a/docs/pyapi/material.rst
+++ b/docs/pyapi/material.rst
@@ -12,19 +12,20 @@ All functionality may be found in the ``material`` package::
 
  from pyne import material
 
-Materials are the primary container for radionuclides. They map nuclides to
-**mass weights**, though they contain methods for converting to/from atom
+Materials are the primary container for mixtures of radionuclides. They map nuclides to
+**mass fractions**, though they contain methods for converting to/from atom
 fractions as well.  In many ways they take inspiration from numpy arrays and
 python dictionaries.  Materials have two main attributes which define them.
 
 1. **comp**: a normalized composition mapping from nuclides (zzaaam-ints) to
-   mass-weights (floats).  2. **mass**: the mass of the material.
+   mass-fractions (floats).  
+   2. **mass**: the mass of the material.
 
 The :ref:`pyne_material_library` class is available to efficiently manipulate
 collections of materials.  The material class is presented below.  For more
 information please refer to :ref:`usersguide_material`.
 
-When using the `write_hdf5` method, the default structure for the `HDF5` file
+When using the `write_hdf5` method to write a material in a group named `my_mat`, the default structure for the `HDF5` file
 is:
 .. verbatim::
     /material/
@@ -73,4 +74,3 @@ Material Library
 .. autoclass:: MaterialLibrary(lib=None, datapath="/materials", nucpath="/nucid")
    :members:
    :inherited-members:
-

--- a/news/write_hdf5_structure.rst
+++ b/news/write_hdf5_structure.rst
@@ -6,7 +6,7 @@
     /material/ 
     /material/my_mat/ 
     /material/my_mat/composition
-    /material/my_mat/nucid 
+    /material/my_mat/nuclidelist 
     /material/my_mat/composition_metadata
 where, `/material` and `/material/my_mat` are now HDF% groups
 

--- a/news/write_hdf5_structure.rst
+++ b/news/write_hdf5_structure.rst
@@ -1,0 +1,19 @@
+**Added:** None
+
+**Changed:**
+- change the structure of material when written in a hdf5 file:
+.. verbatim::
+    /material/ 
+    /material/my_mat/ 
+    /material/my_mat/composition
+    /material/my_mat/nucid 
+    /material/my_mat/composition_metadata
+where, `/material` and `/material/my_mat` are now HDF% groups
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -53,7 +53,7 @@ cdef extern from "material.h" namespace "pyne":
         void from_hdf5(char *, char *, int) except +
         void from_hdf5(char *, char *, int, int) except +
 
-        void write_hdf5(char *, char *, char *, float, int) except +
+        void deprecated_write_hdf5(char *, char *, char *, float, int) except +
         void write_hdf5(char *, char *, float, int) except +
 
         void from_text(char *) except +

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -53,9 +53,8 @@ cdef extern from "material.h" namespace "pyne":
         void from_hdf5(char *, char *, int) except +
         void from_hdf5(char *, char *, int, int) except +
 
-        void write_hdf5(char *, char *, char *) except +
-        void write_hdf5(char *, char *, char *, float) except +
         void write_hdf5(char *, char *, char *, float, int) except +
+        void write_hdf5(char *, char *, float, int) except +
 
         void from_text(char *) except +
 

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -335,7 +335,7 @@ cdef class _Material:
         if nucpath != "":
             nucpath_bytes = nucpath.encode('UTF-8')
             c_nucpath = nucpath_bytes
-            self.mat_pointer.write_hdf5(c_filename, c_datapath, c_nucpath, row, chunksize)
+            self.mat_pointer.deprecated_write_hdf5(c_filename, c_datapath, c_nucpath, row, chunksize)
         else:
             self.mat_pointer.write_hdf5(c_filename, c_datapath, row, chunksize)
 

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -198,7 +198,7 @@ cdef class _Material:
             Path to HDF5 file that contains the data to read in.
         datapath : str
             Path to HDF5 table or group that represents the data.
-            In the example below, datapath = "/material".
+            In the example below, datapath = "/mat_name".
         row : int, optional
             The index of the arrays from which to read the data.  This
             ranges from 0 to N-1.  Defaults to the last element of the array.
@@ -277,9 +277,9 @@ cdef class _Material:
         self.mat_pointer.from_hdf5(c_filename, c_datapath, row, protocol)
 
 
-    def write_hdf5(self, filename, datapath="/material", nucpath="",
+    def write_hdf5(self, filename, datapath="/mat_name", nucpath="",
                    row=-0.0, chunksize=100):
-        """write_hdf5(filename, datapath="/material", nucpath="", row=-0.0, chunksize=100)
+        """write_hdf5(filename, datapath="/mat_name", nucpath="", row=-0.0, chunksize=100)
         Writes the material to an HDF5 file, using Protocol 1 (see the
         from_hdf5() method).
 
@@ -2197,7 +2197,7 @@ def mats_latex_table(mats, labels=None, align=None, format=".5g"):
 
 cdef class _MaterialLibrary(object):
 
-    def __init__(self, lib=None, datapath="/materials", nucpath="/nucid"):
+    def __init__(self, lib=None, datapath="/mat_name", nucpath="/nucid"):
         """Parameters
         ----------
         lib : dict-like, str, or None, optional
@@ -2312,7 +2312,7 @@ cdef class _MaterialLibrary(object):
         if opened_here:
             file.close()
 
-    def from_hdf5(self, file, datapath="/materials", nucpath="/nucid"):
+    def from_hdf5(self, file, datapath="/mat_name", nucpath="/nucid"):
         """Loads data from an HDF5 file into this material library.
 
         Parameters
@@ -2355,7 +2355,7 @@ cdef class _MaterialLibrary(object):
                 name = "_" + str(i)
             _lib[name] = mat
 
-    def write_hdf5(self, filename, datapath="/materials", nucpath="/nucid"):
+    def write_hdf5(self, filename, datapath="/mat_name", nucpath="/nucid"):
         """Writes this material library to an HDF5 file.
 
         Parameters

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -277,9 +277,9 @@ cdef class _Material:
         self.mat_pointer.from_hdf5(c_filename, c_datapath, row, protocol)
 
 
-    def write_hdf5(self, filename, datapath="/material", nucpath="/nucid",
+    def write_hdf5(self, filename, datapath="/material", nucpath="",
                    row=-0.0, chunksize=100):
-        """write_hdf5(filename, datapath="/material", nucpath="/nucid", row=-0.0, chunksize=100)
+        """write_hdf5(filename, datapath="/material", nucpath="", row=-0.0, chunksize=100)
         Writes the material to an HDF5 file, using Protocol 1 (see the
         from_hdf5() method).
 
@@ -331,9 +331,14 @@ cdef class _Material:
         datapath_bytes = datapath.encode('UTF-8')
         c_datapath = datapath_bytes
         cdef char * c_nucpath
-        nucpath_bytes = nucpath.encode('UTF-8')
-        c_nucpath = nucpath_bytes
-        self.mat_pointer.write_hdf5(c_filename, c_datapath, c_nucpath, row, chunksize)
+        
+        if nucpath != "":
+            nucpath_bytes = nucpath.encode('UTF-8')
+            c_nucpath = nucpath_bytes
+            self.mat_pointer.write_hdf5(c_filename, c_datapath, c_nucpath, row, chunksize)
+        else:
+            self.mat_pointer.write_hdf5(c_filename, c_datapath, row, chunksize)
+
 
     def phits(self, frac_type='mass'):
         """phits(frac_type)

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -828,7 +828,7 @@ class Mesh(object):
         mats_in_mesh_file = False
         if isinstance(mesh, basestring) and len(mats) == 0:
             with tb.open_file(mesh) as h5f:
-                if '/materials' in h5f:
+                if '/mat_name' in h5f or '/materials' in h5f:
                     mats_in_mesh_file = True
             if mats_in_mesh_file:
                 mats = MaterialLibrary(mesh)

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -828,10 +828,15 @@ class Mesh(object):
         mats_in_mesh_file = False
         if isinstance(mesh, basestring) and len(mats) == 0:
             with tb.open_file(mesh) as h5f:
-                if '/mat_name' in h5f or '/materials' in h5f:
+                if '/mat_name' in h5f:
                     mats_in_mesh_file = True
+                    mat_path = '/mat_name'
+                elif '/materials' in h5f:
+                    mats_in_mesh_file = True
+                    mat_path = '/materials'
+
             if mats_in_mesh_file:
-                mats = MaterialLibrary(mesh)
+                mats = MaterialLibrary(mesh, datapath=mat_path)
 
         if mats is None:
             pass

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -243,14 +243,15 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
     herr_t status= H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     H5O_info_t object_info;
     
+    // Reset status and test if datapath exist as a non-dataset
+    status = H5Oget_info_by_name(db, datapath.c_str(), &object_info, H5P_DEFAULT);
+    bool datapath_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
+    
     // check "/material" path exist as a non-dataset
+    status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     status = H5Oget_info_by_name(db, "/material" , &object_info, H5P_DEFAULT);
     bool material_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
    
-    // Reset status and test if datapath exist as a non-dataset
-    status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
-    status = H5Oget_info_by_name(db, datapath.c_str(), &object_info, H5P_DEFAULT);
-    bool datapath_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
     
     // Group "/material" does not exist as a non-dataset
     if (!material_notdataset_exists || !datapath_notdataset_exists) {

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -169,7 +169,8 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath,
   //
   std::string attrpath = datapath + "_metadata";
   bool attrpath_exists = h5wrap::path_exists(db, attrpath);
-  if (!attrpath_exists) return;
+  if (!attrpath_exists)
+    return;
 
   hid_t metadatapace, attrtype, metadataet, metadatalab, attrmemspace;
   int attrrank;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -516,6 +516,22 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
+  
+  // This complicated algorythm is required to allow backward compatibility with
+  // previous version of write_hdf5 (where data were written in a hdf5 DATASET)
+  // FILE EXIST ?
+  //    NO -> create file with a "/material" group, write the data in it
+  //    YES:
+  //      - DATAPTH exist: 
+  //        - YES && != /material -> Detect NUCPATH + old write_hdf5
+  //        - NO -> CONTINUE
+  //          - "/material" EXIST:
+  //            - NO -> create "/material" group and write everyting in it
+  //            - YES:
+  //              - "/material" is a DATASET -> detect NUCPATH + old write_hdf5
+  //              - "/material" is a GROUP -> add data in it
+  //              - "/material" isn't a GROUP nor a DATASET -> fail and complain
+  
   hid_t db;
   if (!pyne::file_exists(filename)) {
     // Create the file

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -237,7 +237,7 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
     _load_comp_protocol0(db, datapath, row);
   } else if (protocol == 1) {
     
-    // Check is /material type
+    // Check /material type
     herr_t status;
     H5O_info_t object_info;
     status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
@@ -546,6 +546,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
       }
     }
   }
+  
   // Check if /material exist and what type it is
   herr_t status;
   H5O_info_t object_info;
@@ -570,7 +571,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     material_grp_id =
         H5Gcreate2(db, "/material", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   }
-  // Check is /material exist as a Group
+  // Check if /material exist as a Group
   // Group "/material/datapath" does not exist create it
   if (!h5wrap::path_exists(db, "/material" + datapath)) {
     data_id = H5Gcreate2(db, ("/material" + datapath).c_str(), H5P_DEFAULT,
@@ -578,11 +579,14 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   } else {
     data_id = H5Gopen2(material_grp_id, datapath.c_str(), H5P_DEFAULT);
   }
-  // std::string nucpath = "/nuclidelist";
-  std::string full_datapath = "/material" + datapath + "/composition";
+  //write nuclide list
   std::string nucpath = "/material" + datapath + "/nuclidelist";
   std::vector<int> nuclides = write_hdf5_nucpath(data_id, nucpath);
+  // write data 
+  std::string full_datapath = "/material" + datapath + "/composition";
   write_hdf5_datapath(data_id, full_datapath, row, chunksize, nuclides);
+  
+  //close all groups and files
   H5Gclose(data_id);
   H5Gclose(material_grp_id);
   H5Fclose(db);
@@ -612,7 +616,7 @@ void pyne::Material::deprecated_write_hdf5(std::string filename, std::string dat
   //
   std::vector<int> nuclides = write_hdf5_nucpath(db, nucpath);
 
-  // Check is datapath already exist
+  // Check if datapath already exist
   bool datapath_exists = h5wrap::path_exists(db, datapath);
   // write mat composition in datapath
   write_hdf5_datapath(db, datapath, row, chunksize, nuclides);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -517,7 +517,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
   
-  // This complicated algorythm is required to allow backward compatibility with
+  // This complicated algorithm is required to allow backward compatibility with
   // previous version of write_hdf5 (where data were written in a hdf5 DATASET)
   // FILE EXIST ?
   //    NO -> create file with a "/material" group, write the data in it

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -239,7 +239,7 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
   } else if (protocol == 1) {
     
     // Check /material type:
-    // Valid status are: 
+    // Valid options are: 
     //     - old format: "/material" or datapath as a dataset
     //     - new format: "/material" as a groupset
     // Testing for datapath first and "/material" in second so one can check 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -88,9 +88,10 @@ void pyne::Material::_load_comp_protocol0(hid_t db, std::string datapath, int ro
 
 
 void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int row) {
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   std::string nucpath;
   hid_t data_set = H5Dopen2(db, datapath.c_str(), H5P_DEFAULT);
-
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   hsize_t data_offset[1] = {static_cast<hsize_t>(row)};
   if (row < 0) {
     // Handle negative row indices
@@ -99,6 +100,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
     H5Sget_simple_extent_dims(data_space, data_dims, NULL);
     data_offset[0] += data_dims[0];
   }
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
   // Grab the nucpath
   hid_t nuc_attr = H5Aopen(data_set, "nucpath", H5P_DEFAULT);
@@ -112,24 +114,29 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   nucpath = std::string(nucpathbuf, nuc_attr_len);
   delete[] nucpathbuf;
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Grab the nuclides
   std::vector<int> nuclides = h5wrap::h5_array_to_cpp_vector_1d<int>(db, nucpath, H5T_NATIVE_INT);
   int nuc_size = nuclides.size();
   hsize_t nuc_dims[1] = {static_cast<hsize_t>(nuc_size)};
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Get the data hyperslab
   hid_t data_hyperslab = H5Dget_space(data_set);
   hsize_t data_count[1] = {1};
   H5Sselect_hyperslab(data_hyperslab, H5S_SELECT_SET, data_offset, NULL, data_count, NULL);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Get memory space for writing
   hid_t mem_space = H5Screate_simple(1, data_count, NULL);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Get material type
   size_t material_data_size = sizeof(pyne::material_data) + sizeof(double)*(nuc_size-1);
   hid_t desc = H5Tcreate(H5T_COMPOUND, material_data_size);
   hid_t comp_values_array_type = H5Tarray_create2(H5T_NATIVE_DOUBLE, 1, nuc_dims);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // make the data table type
   H5Tinsert(desc, "mass", HOFFSET(pyne::material_data, mass), H5T_NATIVE_DOUBLE);
   H5Tinsert(desc, "density", HOFFSET(pyne::material_data, density),
@@ -138,21 +145,25 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
             H5T_NATIVE_DOUBLE);
   H5Tinsert(desc, "comp", HOFFSET(pyne::material_data, comp), comp_values_array_type);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // make the data array, have to over-allocate
   material_data * mat_data = new material_data [material_data_size];
 
   // Finally, get data and put in on this instance
   H5Dread(data_set, desc, mem_space, data_hyperslab, H5P_DEFAULT, mat_data);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   mass = (*mat_data).mass;
   density = (*mat_data).density;
   atoms_per_molecule = (*mat_data).atoms_per_mol;
   for (int i = 0; i < nuc_size; i++)
     comp[nuclides[i]] = (double) (*mat_data).comp[i];
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
   delete[] mat_data;
   H5Tclose(str_attr);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   //
   // Get metadata from associated dataset, if available
   //
@@ -161,11 +172,13 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   if (!attrpath_exists)
     return;
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   hid_t metadatapace, attrtype, metadataet, metadatalab, attrmemspace;
   int attrrank;
   hvl_t attrdata [1];
 
   attrtype = H5Tvlen_create(H5T_NATIVE_CHAR);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
   // Get the metadata from the file
   metadataet = H5Dopen2(db, attrpath.c_str(), H5P_DEFAULT);
@@ -174,16 +187,19 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   attrmemspace = H5Screate_simple(1, data_count, NULL);
   H5Dread(metadataet, attrtype, attrmemspace, metadatalab, H5P_DEFAULT, attrdata);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // convert to in-memory JSON
   Json::Reader reader;
   reader.parse((char *) attrdata[0].p, (char *) attrdata[0].p+attrdata[0].len, metadata, false);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // close attr data objects
   H5Fflush(db, H5F_SCOPE_GLOBAL);
   H5Dclose(metadataet);
   H5Sclose(metadatapace);
   H5Tclose(attrtype);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Close out the HDF5 file
   H5Fclose(db);
 }
@@ -204,29 +220,35 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
   // Turn off annoying HDF5 errors
   herr_t status;
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
   // Check that the file is there
   if (!pyne::file_exists(filename))
     throw pyne::FileNotFound(filename);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Check to see if the file is in HDF5 format.
   bool ish5 = H5Fis_hdf5(filename.c_str());
   if (!ish5)
     throw h5wrap::FileNotHDF5(filename);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   //Set file access properties so it closes cleanly
   hid_t fapl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl,H5F_CLOSE_STRONG);
   // Open the database
   hid_t db = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
   bool datapath_exists = h5wrap::path_exists(db, datapath);
   if (!datapath_exists)
     throw h5wrap::PathNotFound(filename, datapath);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
   // Clear current content
   comp.clear();
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
   // Load via various protocols
   if (protocol == 0)
@@ -239,8 +261,10 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
   // Close the database
   status = H5Fclose(db);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Renormalize the composition, just to be safe.
   norm_comp();
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 }
 
 
@@ -271,9 +295,10 @@ std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string nucpat
     nuc_dims[0] = nuc_size;
     pyne::comp_iter i = comp.begin();
     bool missing_nucs = false;
-    while (i != comp.end() or missing_nucs) {
+    for ( pyne::comp_iter i = comp.begin(); i != comp.end(); i++ ) {
       missing_nucs |= std::binary_search(nuclides.begin(), nuclides.end(), i->first);
-      i++;
+      if (missing_nucs)
+        break;
     }
     if (missing_nucs)
       std::cout
@@ -283,19 +308,24 @@ std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string nucpat
 
   } else {
     nuclides = std::vector<int>();
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
     for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++)
       nuclides.push_back(i->first);
     nuc_size = nuclides.size();
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
     // Create the data if it doesn't exist
     int nuc_data[nuc_size];
     for (int n = 0; n != nuc_size; n++) nuc_data[n] = nuclides[n];
     nuc_dims[0] = nuc_size;
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
     hid_t nuc_space = H5Screate_simple(1, nuc_dims, NULL);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
     hid_t nuc_set = H5Dcreate2(db, nucpath.c_str(), H5T_NATIVE_INT, nuc_space,
                                H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(nuc_set, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, nuc_data);
     H5Fflush(db, H5F_SCOPE_GLOBAL);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
 
     H5Dclose(nuc_set);
   }
@@ -469,14 +499,17 @@ void pyne::Material::write_hdf5_datapath(hid_t db, std::string datapath, float r
 
 void pyne::Material::write_hdf5(std::string filename, std::string datapath,
                                 float row, int chunksize) {
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Turn off annoying HDF5 errors
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Set file access properties so it closes cleanly
   hid_t fapl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   hid_t db;
   if (pyne::file_exists(filename)) {
     bool ish5 = H5Fis_hdf5(filename.c_str());
@@ -511,6 +544,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     H5Gcreate2(db, "/material", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   }
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   std::string full_datapath = "/material" + datapath;
 
   // Check is /material exist as a Group
@@ -518,9 +552,11 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
   status = H5Gget_objinfo(db, full_datapath.c_str(), 0, NULL);
   // Group "/material/datapath" does not exist create it
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   if (status != 0) {
     H5Gcreate2(db, full_datapath.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   }
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   std::string full_nucpath = full_datapath + "/nucid";
   std::vector<int> nuclides = write_hdf5_nucpath(db, full_nucpath);
   write_hdf5_datapath(db, (full_datapath + "/composition").c_str(), row, chunksize, nuclides);
@@ -536,11 +572,13 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
                                 std::string nucpath, float row, int chunksize) {
   int row_num = (int)row;
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   // Turn off annoying HDF5 errors
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
   // Set file access properties so it closes cleanly
   hid_t fapl;
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
@@ -552,17 +590,20 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   } else
     db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   //
   // Read in nuclist if available, write it out if not
   //
   std::vector<int> nuclides = write_hdf5_nucpath(db, nucpath);
 
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   bool datapath_exists = h5wrap::path_exists(db, datapath);
   write_hdf5_datapath(db, datapath, row, chunksize, nuclides);
 
   // if datapath has been create register location of nucpath
   if (!datapath_exists) {
     hid_t data_set = H5Dopen2(db, datapath.c_str(), H5P_DEFAULT);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
     // Add attribute pointing to nuc path
     hid_t nuc_attr_type = H5Tcopy(H5T_C_S1);
     H5Tset_size(nuc_attr_type, nucpath.length());
@@ -571,9 +612,11 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
                                 nuc_attr_space, H5P_DEFAULT, H5P_DEFAULT);
     H5Awrite(nuc_attr, nuc_attr_type, nucpath.c_str());
     H5Fflush(db, H5F_SCOPE_GLOBAL);
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
     H5Dclose(data_set);
   }
   // Close out the HDF5 file
+  std::cout << __FILE__ << ":" << __LINE__ << std::endl;
   H5Fclose(db);
   // Remember the milk!
   // ...by which I mean to deallocate

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -571,10 +571,11 @@ void pyne::Material::write_hdf5(std::string filename, std::string mat_name,
       case prot1_layout::unknown: {
         throw std::runtime_error(
             mat_name +
-            " is not a dataset and /material entity is not a group.");
+            " is not a dataset and /material entity is neither a group nor a dataset.");
         break;
       }
-
+      
+      // old layout
       case prot1_layout::old_layout: {
         std::string nucpath = "/nucid";
         hid_t data_set = H5Dopen2(db, mat_name.c_str(), H5P_DEFAULT);
@@ -596,11 +597,14 @@ void pyne::Material::write_hdf5(std::string filename, std::string mat_name,
         break;
       }
 
+      // no "/material or matname in the hdf5 file -> build the new layout
       case prot1_layout::path_donotexists: {
         material_grp_id =
             H5Gcreate2(db, "/material", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         break;
       }
+
+      // /material as a group -> new layout: open the "/material" group
       case prot1_layout::new_layout: {
         material_grp_id = H5Gopen2(db, "/material", H5P_DEFAULT);
         break;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -550,11 +550,6 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
 }
 
 
-void pyne::Material::write_hdf5(std::string filename) {
-  write_hdf5(filename, "/material", "/nucid", -0.0, 100);
-}
-
-
 void pyne::Material::write_hdf5(std::string filename, std::string datapath,
                                 std::string nucpath, float row, int chunksize) {
   int row_num = (int)row;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -239,7 +239,7 @@ int pyne::Material::detect_hdf5_layout(hid_t db, std::string path){
 }
 
 
-void pyne::Material::from_hdf5(std::string filename, std::string datapath, int row, int protocol) {
+void pyne::Material::from_hdf5(std::string filename, std::string mat_name, int row, int protocol) {
   // Turn off annoying HDF5 errors
   herr_t status;
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
@@ -264,29 +264,29 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
   comp.clear();
   // Load via various protocols
   if (protocol == 0) {
-    bool datapath_exists = h5wrap::path_exists(db, datapath);
+    bool datapath_exists = h5wrap::path_exists(db, mat_name);
     if (!datapath_exists)
-      throw h5wrap::PathNotFound(filename, datapath);
-    _load_comp_protocol0(db, datapath, row);
+      throw h5wrap::PathNotFound(filename, mat_name);
+    _load_comp_protocol0(db, mat_name, row);
   } else if (protocol == 1) {
     
-    int prot1_hdf5_layout = detect_hdf5_layout(db, datapath);
+    int prot1_hdf5_layout = detect_hdf5_layout(db, mat_name);
     switch(prot1_hdf5_layout) {
       case prot1_layout::path_donotexists:
-        throw std::runtime_error("/material and " +datapath+ " paths do not exist.");
+        throw std::runtime_error("/material and " +mat_name+ " paths do not exist.");
         break;
 
       case prot1_layout::unknown:
-        throw std::runtime_error(datapath + " is not a dataset and /material entity is not a group.");
+        throw std::runtime_error(mat_name + " is not a dataset and /material entity is not a group nor a dataset.");
         break;
 
       case old_layout:
-        _load_comp_protocol1(db, datapath, row);
+        _load_comp_protocol1(db, mat_name, row);
         break;
       
       case prot1_layout::new_layout:
-        std::string full_datapath = "/material" + datapath + "/composition";
-        std::string nucpath = "/material" + datapath + "/nuclidelist";
+        std::string full_datapath = "/material" + mat_name + "/composition";
+        std::string nucpath = "/material" + mat_name + "/nuclidelist";
         _load_comp_protocol1(db, full_datapath, nucpath, row);
         break;
     }
@@ -301,9 +301,9 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
 }
 
 
-void pyne::Material::deprecated_write_hdf5(char * filename, char * datapath, char * nucpath, float row, int chunksize) {
+void pyne::Material::deprecated_write_hdf5(char * filename, char * mat_name, char * nucpath, float row, int chunksize) {
   std::string fname (filename);
-  std::string groupname (datapath);
+  std::string groupname (mat_name);
   std::string nuclist (nucpath);
   deprecated_write_hdf5(fname, groupname, nuclist, row, chunksize);
 }
@@ -360,7 +360,7 @@ std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string nucpat
 }
 
 
-void pyne::Material::write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, std::vector<int> nuclides) {
+void pyne::Material::write_hdf5_datapath(hid_t db, std::string mat_name, float row, int chunksize, std::vector<int> nuclides) {
 
   int row_num = (int)row;
 
@@ -400,9 +400,9 @@ void pyne::Material::write_hdf5_datapath(hid_t db, std::string datapath, float r
   }
 
   // get / make the data set
-  bool datapath_exists = h5wrap::path_exists(db, datapath);
+  bool datapath_exists = h5wrap::path_exists(db, mat_name);
   if (datapath_exists) {
-    data_set = H5Dopen2(db, datapath.c_str(), H5P_DEFAULT);
+    data_set = H5Dopen2(db, mat_name.c_str(), H5P_DEFAULT);
     data_space = H5Dget_space(data_set);
     data_rank = H5Sget_simple_extent_dims(data_space, data_dims, data_max_dims);
 
@@ -429,7 +429,7 @@ void pyne::Material::write_hdf5_datapath(hid_t db, std::string datapath, float r
     H5Pset_deflate(data_set_params, 1);
 
     // Create the data set
-    data_set = H5Dcreate2(db, datapath.c_str(), desc, data_space, H5P_DEFAULT,
+    data_set = H5Dcreate2(db, mat_name.c_str(), desc, data_space, H5P_DEFAULT,
                             data_set_params, H5P_DEFAULT);
     H5Dset_extent(data_set, data_dims);
 
@@ -456,7 +456,7 @@ void pyne::Material::write_hdf5_datapath(hid_t db, std::string datapath, float r
   //
   // Write out the metadata to the file
   //
-  std::string attrpath = datapath + "_metadata";
+  std::string attrpath = mat_name + "_metadata";
   hid_t metadatapace, attrtype, metadataet, metadatalab, attrmemspace;
   int attrrank;
 
@@ -524,9 +524,9 @@ void pyne::Material::write_hdf5_datapath(hid_t db, std::string datapath, float r
 }
 
 
-void pyne::Material::write_hdf5(std::string filename, std::string datapath,
+void pyne::Material::write_hdf5(std::string filename, std::string mat_name,
                                 float row, int chunksize) {
-  if (datapath.front() != '/') datapath = '/' + datapath;
+  if (mat_name.front() != '/') mat_name = '/' + mat_name;
 
   hid_t material_grp_id;  // Holder of HDF5 Id of the "/material" group
   hid_t data_id;  // Holder of HDF5 Id of the data group to write the data
@@ -566,31 +566,31 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     if (!ish5) throw h5wrap::FileNotHDF5(filename);
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
 
-    int prot1_hdf5_layout = detect_hdf5_layout(db, datapath);
+    int prot1_hdf5_layout = detect_hdf5_layout(db, mat_name);
     switch (prot1_hdf5_layout) {
       case prot1_layout::unknown: {
         throw std::runtime_error(
-            datapath +
+            mat_name +
             " is not a dataset and /material entity is not a group.");
         break;
       }
 
       case prot1_layout::old_layout: {
         std::string nucpath = "/nucid";
-        hid_t data_set = H5Dopen2(db, datapath.c_str(), H5P_DEFAULT);
+        hid_t data_set = H5Dopen2(db, mat_name.c_str(), H5P_DEFAULT);
 
-        if (h5wrap::path_exists(db, datapath)) {
+        if (h5wrap::path_exists(db, mat_name)) {
           // if path exists grab the nucpath
           bool nucpath_detetcted = detect_nuclidelist(data_set, nucpath);
           if (!nucpath_detetcted) {  // can't find a valid nuclide list path
-                                     // form datapath... fail
+                                     // from mat_name... fail
             throw std::runtime_error(
-                "Can't find the nuclide list path in the existing datapath. "
+                "Can't find the nuclide list path in the existing mat_name. "
                 "Can't "
-                "add your material to the datapath.");
+                "add your material to the mat_name.");
           }
         }
-        deprecated_write_hdf5(db, datapath, nucpath, row, chunksize);
+        deprecated_write_hdf5(db, mat_name, nucpath, row, chunksize);
         H5Fclose(db);
         return;
         break;
@@ -608,18 +608,18 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     }
   }
 
-  // Group "/material/datapath" does not exist create it
-  if (!h5wrap::path_exists(db, "/material" + datapath)) {
-    data_id = H5Gcreate2(db, ("/material" + datapath).c_str(), H5P_DEFAULT,
+  // Group "/material/mat_name" does not exist create it
+  if (!h5wrap::path_exists(db, "/material" + mat_name)) {
+    data_id = H5Gcreate2(db, ("/material" + mat_name).c_str(), H5P_DEFAULT,
                          H5P_DEFAULT, H5P_DEFAULT);
   } else {
-    data_id = H5Gopen2(material_grp_id, datapath.c_str(), H5P_DEFAULT);
+    data_id = H5Gopen2(material_grp_id, mat_name.c_str(), H5P_DEFAULT);
   }
   // write nuclide list
-  std::string nucpath = "/material" + datapath + "/nuclidelist";
+  std::string nucpath = "/material" + mat_name + "/nuclidelist";
   std::vector<int> nuclides = write_hdf5_nucpath(data_id, nucpath);
   // write data
-  std::string full_datapath = "/material" + datapath + "/composition";
+  std::string full_datapath = "/material" + mat_name + "/composition";
   write_hdf5_datapath(data_id, full_datapath, row, chunksize, nuclides);
 
   // close all groups and files

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -565,65 +565,66 @@ void pyne::Material::write_hdf5(std::string filename, std::string mat_name,
     bool ish5 = H5Fis_hdf5(filename.c_str());
     if (!ish5) throw h5wrap::FileNotHDF5(filename);
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
+  }
+  int prot1_hdf5_layout = detect_hdf5_layout(db, mat_name);
+  switch (prot1_hdf5_layout) {
+    case prot1_layout::unknown: {
+      throw std::runtime_error(
+          mat_name +
+          " is not a dataset and /material entity is neither a group nor a dataset.");
+      break;
+    }
+    
+    // old layout
+    case prot1_layout::old_layout: {
+      std::string nucpath = "/nucid";
+      hid_t data_set = H5Dopen2(db, mat_name.c_str(), H5P_DEFAULT);
 
-    int prot1_hdf5_layout = detect_hdf5_layout(db, mat_name);
-    switch (prot1_hdf5_layout) {
-      case prot1_layout::unknown: {
-        throw std::runtime_error(
-            mat_name +
-            " is not a dataset and /material entity is neither a group nor a dataset.");
-        break;
-      }
-      
-      // old layout
-      case prot1_layout::old_layout: {
-        std::string nucpath = "/nucid";
-        hid_t data_set = H5Dopen2(db, mat_name.c_str(), H5P_DEFAULT);
-
-        if (h5wrap::path_exists(db, mat_name)) {
-          // if path exists grab the nucpath
-          bool nucpath_detetcted = detect_nuclidelist(data_set, nucpath);
-          if (!nucpath_detetcted) {  // can't find a valid nuclide list path
-                                     // from mat_name... fail
-            throw std::runtime_error(
-                "Can't find the nuclide list path in the existing mat_name. "
-                "Can't "
-                "add your material to the mat_name.");
-          }
+      if (h5wrap::path_exists(db, mat_name)) {
+        // if path exists grab the nucpath
+        bool nucpath_detetcted = detect_nuclidelist(data_set, nucpath);
+        if (!nucpath_detetcted) {  // can't find a valid nuclide list path
+                                   // from mat_name... fail
+          throw std::runtime_error(
+              "Can't find the nuclide list path in the existing mat_name. "
+              "Can't "
+              "add your material to the mat_name.");
         }
-        deprecated_write_hdf5(db, mat_name, nucpath, row, chunksize);
-        H5Fclose(db);
-        return;
-        break;
       }
+      deprecated_write_hdf5(db, mat_name, nucpath, row, chunksize);
+      H5Fclose(db);
+      return;
+      break;
+    }
 
-      // no "/material or matname in the hdf5 file -> build the new layout
-      case prot1_layout::path_donotexists: {
-        material_grp_id =
-            H5Gcreate2(db, "/material", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        break;
-      }
+    // no "/material or matname in the hdf5 file -> build the new layout
+    case prot1_layout::path_donotexists: {
+      material_grp_id =
+          H5Gcreate2(db, "/material", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      break;
+    }
 
-      // /material as a group -> new layout: open the "/material" group
-      case prot1_layout::new_layout: {
-        material_grp_id = H5Gopen2(db, "/material", H5P_DEFAULT);
-        break;
-      }
+    // /material as a group -> new layout: open the "/material" group
+    case prot1_layout::new_layout: {
+      material_grp_id = H5Gopen2(db, "/material", H5P_DEFAULT);
+      break;
     }
   }
+  
 
+  //mat_name is proided with a "/" so need to open with fullpath
   // Group "/material/mat_name" does not exist create it
   if (!h5wrap::path_exists(db, "/material" + mat_name)) {
     data_id = H5Gcreate2(db, ("/material" + mat_name).c_str(), H5P_DEFAULT,
                          H5P_DEFAULT, H5P_DEFAULT);
   } else {
-    data_id = H5Gopen2(material_grp_id, mat_name.c_str(), H5P_DEFAULT);
+    data_id = H5Gopen2(db, ("/material"+mat_name).c_str(), H5P_DEFAULT);
   }
   // write nuclide list
-  std::string nucpath = "/material" + mat_name + "/nuclidelist";
+  std::string nucpath = "nuclidelist";
   std::vector<int> nuclides = write_hdf5_nucpath(data_id, nucpath);
   // write data
-  std::string full_datapath = "/material" + mat_name + "/composition";
+  std::string full_datapath = "composition";
   write_hdf5_datapath(data_id, full_datapath, row, chunksize, nuclides);
 
   // close all groups and files

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -244,9 +244,6 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
 }
 
 
-
-
-
 void pyne::Material::write_hdf5(char * filename, char * datapath, char * nucpath, float row, int chunksize) {
   std::string fname (filename);
   std::string groupname (datapath);
@@ -254,25 +251,8 @@ void pyne::Material::write_hdf5(char * filename, char * datapath, char * nucpath
   write_hdf5(fname, groupname, nuclist, row, chunksize);
 }
 
-std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string dsatapath,
-                                        std::string nucpath) {
-  int row_num = (int)row;
 
-  // Turn off annoying HDF5 errors
-  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
-
-  // Set file access properties so it closes cleanly
-  hid_t fapl;
-  fapl = H5Pcreate(H5P_FILE_ACCESS);
-  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
-  // Create new/open datafile.
-  hid_t db;
-  if (pyne::file_exists(filename)) {
-    bool ish5 = H5Fis_hdf5(filename.c_str());
-    if (!ish5) throw h5wrap::FileNotHDF5(filename);
-    db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
-  } else
-    db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string nucpath) {
 
   //
   // Read in nuclist if available, write it out if not
@@ -292,8 +272,7 @@ std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string dsatap
     pyne::comp_iter i = comp.begin();
     bool missing_nucs = false;
     while (i != comp.end() or missing_nucs) {
-      if(std::none_of(nuclides.begin(); nuclides.end(); i->first)
-          missing_nucs = true;
+      missing_nucs |= std::binary_search(nuclides.begin(), nuclides.end(), i->first);
       i++;
     }
     if (missing_nucs)
@@ -324,6 +303,47 @@ std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string dsatap
 }
 
 void pyne::Material::write_hdf5(std::string filename, std::string datapath,
+                                float row, int chunksize) {
+  int row_num = (int)row;
+
+  // Turn off annoying HDF5 errors
+  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+
+  // Set file access properties so it closes cleanly
+  hid_t fapl;
+  fapl = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+  // Create new/open datafile.
+  hid_t db;
+  if (pyne::file_exists(filename)) {
+    bool ish5 = H5Fis_hdf5(filename.c_str());
+    if (!ish5) throw h5wrap::FileNotHDF5(filename);
+    db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
+
+    // Check is /material exist as a Group
+    herr_t status;
+    status = H5Eset_auto(NULL, NULL);
+    status = H5Gget_objinfo(db, "/material", 0, NULL);
+    
+    // Group "/material" does not exist
+    if (status != 0) {
+      // Check if path exists
+      bool datapath_exists = h5wrap::path_exists(db, datapath);
+      // no Group but path fallback on old method using default
+      if (datapath_exists) {
+        H5Fclose(db);
+        write_hdf5(filename, datapath, "/nucid", row, chunksize);
+        return;
+      }
+    }
+  } else
+    db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+}
+
+
+
+
+void pyne::Material::write_hdf5(std::string filename, std::string datapath,
                                 std::string nucpath, float row, int chunksize) {
   int row_num = (int) row;
 
@@ -348,34 +368,11 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   //
   // Read in nuclist if available, write it out if not
   //
-  bool nucpath_exists = h5wrap::path_exists(db, nucpath);
-  std::vector<int> nuclides;
-  int nuc_size;
+  std::vector<int> nuclides = write_hdf5_nucpath(db, nucpath);
+  
   hsize_t nuc_dims[1];
-
-  if (nucpath_exists) {
-    nuclides = h5wrap::h5_array_to_cpp_vector_1d<int>(db, nucpath, H5T_NATIVE_INT);
-    nuc_size = nuclides.size();
-    nuc_dims[0] = nuc_size;
-  } else {
-    nuclides = std::vector<int>();
-    for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++)
-      nuclides.push_back(i->first);
-    nuc_size = nuclides.size();
-
-    // Create the data if it doesn't exist
-    int nuc_data [nuc_size];
-    for (int n = 0; n != nuc_size; n++)
-      nuc_data[n] = nuclides[n];
-    nuc_dims[0] = nuc_size;
-    hid_t nuc_space = H5Screate_simple(1, nuc_dims, NULL);
-    hid_t nuc_set = H5Dcreate2(db, nucpath.c_str(), H5T_NATIVE_INT, nuc_space,
-                               H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Dwrite(nuc_set, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, nuc_data);
-    H5Fflush(db, H5F_SCOPE_GLOBAL);
-  }
-
-
+  int nuc_size = nuc_dims[0] = nuclides.size();
+  
   //
   // Write out the data itself to the file
   //

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -530,7 +530,12 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     if (!ish5) throw h5wrap::FileNotHDF5(filename);
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
 
-    // if datapath != /material and exist -> old format
+    // there are a few things that may be true here:
+    // datapath does not exist - there are many possible reasons for this, including
+    //         datapath = "non_default_path" without a leading slash (/) --> assume this is a modifier for a new format
+    // datapath does exist:
+    //         datapath = "/non_default_path" --> old format
+    //         datapath = "/material"   --> new format
     if (h5wrap::path_exists(db, datapath) && datapath != "/material") {
       std::string nucpath;
       hid_t data_set = H5Dopen2(db, datapath.c_str(), H5P_DEFAULT);
@@ -2081,4 +2086,3 @@ bool pyne::detect_nuclidelist(hid_t data_set, std::string& nucpath){
   H5Tclose(nuc_attr);
   return true;
 }
-

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -291,7 +291,7 @@ std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string nucpat
       missing_nucs |= !std::binary_search(nuclides.begin(), nuclides.end(), i->first);
       if (missing_nucs) {
         break;
-    }
+      }
     }
     if (missing_nucs)
       std::cout

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -594,7 +594,6 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     material_grp_id =
         H5Gcreate2(db, "/material", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   }
-  // Check if /material exist as a Group
   // Group "/material/datapath" does not exist create it
   if (!h5wrap::path_exists(db, "/material" + datapath)) {
     data_id = H5Gcreate2(db, ("/material" + datapath).c_str(), H5P_DEFAULT,

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -239,18 +239,21 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
   } else if (protocol == 1) {
     
     // Check /material type
-    herr_t status;
+    // set test variables
+    herr_t status= H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     H5O_info_t object_info;
-    status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    
+    // check "/matierial" path exist as a non-dataset
     status = H5Oget_info_by_name(db, "/material" , &object_info, H5P_DEFAULT);
-    bool material_path_exists = (status ==0 && object_info.type != H5O_TYPE_DATASET)
-    herr_t status2;
-    H5O_info_t object_info2;
-    status2 = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
-    status2 = H5Oget_info_by_name(db, datapath.c_str(), &object_info, H5P_DEFAULT);
-    // Group "/material" does not exist
-    if (status != 0 || object_info.type == H5O_TYPE_DATASET ||
-        status2 != 0 || object_info2.type == H5O_TYPE_DATASET) {
+    bool material_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
+   
+    // Reset status and test for datapath
+    status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    status = H5Oget_info_by_name(db, datapath.c_str(), &object_info, H5P_DEFAULT);
+    bool datapath_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
+    
+    // Group "/material" does not exist as a non-dataset
+    if (!material_notdataset_exists || !datapath_notdataset_exists) {
       bool datapath_exists = h5wrap::path_exists(db, datapath);
       if (!datapath_exists)
         throw h5wrap::PathNotFound(filename, datapath);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -243,11 +243,11 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
     herr_t status= H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     H5O_info_t object_info;
     
-    // check "/matierial" path exist as a non-dataset
+    // check "/material" path exist as a non-dataset
     status = H5Oget_info_by_name(db, "/material" , &object_info, H5P_DEFAULT);
     bool material_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
    
-    // Reset status and test for datapath
+    // Reset status and test if datapath exist as a non-dataset
     status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     status = H5Oget_info_by_name(db, datapath.c_str(), &object_info, H5P_DEFAULT);
     bool datapath_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -516,13 +516,13 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   fapl = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
-  
+
   // This complicated algorithm is required to allow backward compatibility with
   // previous version of write_hdf5 (where data were written in a hdf5 DATASET)
   // FILE EXIST ?
   //    NO -> create file with a "/material" group, write the data in it
   //    YES:
-  //      - DATAPTH exist: 
+  //      - DATAPTH exist:
   //        - YES && != /material -> Detect NUCPATH + old write_hdf5
   //        - NO -> CONTINUE
   //          - "/material" EXIST:
@@ -531,7 +531,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   //              - "/material" is a DATASET -> detect NUCPATH + old write_hdf5
   //              - "/material" is a GROUP -> add data in it
   //              - "/material" isn't a GROUP nor a DATASET -> fail and complain
-  
+
   hid_t db;
   if (!pyne::file_exists(filename)) {
     // Create the file
@@ -541,7 +541,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     bool ish5 = H5Fis_hdf5(filename.c_str());
     if (!ish5) throw h5wrap::FileNotHDF5(filename);
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
-    
+
     // if datapath != /material and exist -> old format
     if (h5wrap::path_exists(db, datapath) && datapath != "/material") {
       std::string nucpath;
@@ -554,9 +554,9 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
         return;
       } else {  // can't find a valid nuclide list path form datapath... fail
         std::cout
-            << "Can't find the nuclide list path in the existing datapath." << std::endl 
-            << "Can't add your material to the datapath."
-            << std::endl;
+            << "Can't find the nuclide list path in the existing datapath."
+            << std::endl
+            << "Can't add your material to the datapath." << std::endl;
         exit(1);
       }
     }
@@ -575,7 +575,8 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
       deprecated_write_hdf5(filename, datapath, "/nucid", row, chunksize);
       return;
 
-    } else if (object_info.type != H5O_TYPE_GROUP) {  // "/material" either a dataset or a group:
+    } else if (object_info.type !=
+               H5O_TYPE_GROUP) {  // "/material" either a dataset or a group:
                                   // fail!
       std::cout << "Non-group/non-dataset object /material already exists "
                    "in the file. Can't write the Material"
@@ -591,12 +592,12 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   // Check is /material exist as a Group
   // Group "/material/datapath" does not exist create it
   if (!h5wrap::path_exists(db, "/material" + datapath)) {
-    data_id = H5Gcreate2(db, ("/material"+datapath).c_str(), H5P_DEFAULT,
+    data_id = H5Gcreate2(db, ("/material" + datapath).c_str(), H5P_DEFAULT,
                          H5P_DEFAULT, H5P_DEFAULT);
   } else {
     data_id = H5Gopen2(material_grp_id, datapath.c_str(), H5P_DEFAULT);
   }
-  //std::string nucpath = "/nuclidelist";
+  // std::string nucpath = "/nuclidelist";
   std::string full_datapath = "/material" + datapath + "/composition";
   std::string nucpath = "/material" + datapath + "/nuclidelist";
   std::vector<int> nuclides = write_hdf5_nucpath(data_id, nucpath);
@@ -605,8 +606,6 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   H5Gclose(material_grp_id);
   H5Fclose(db);
 }
-
-
 void pyne::Material::deprecated_write_hdf5(std::string filename, std::string datapath,
                                 std::string nucpath, float row, int chunksize) {
   int row_num = (int)row;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -521,7 +521,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
         // create Group
         H5Gcreate2(db, "/material", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
       } else if (object_info.type != H5O_TYPE_GROUP) {
-        std::cout << "Non-group/non-dataset object /Material already exists "
+        std::cout << "Non-group/non-dataset object /material already exists "
                      "in the file. Can't write the Material" << std::endl;
         exit(1);
       }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -541,7 +541,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string mat_name,
   H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
 
-  // This complicated algorythm is required to allow backward compatibility with
+  // This complicated algorithm is required to allow backward compatibility with
   // previous version of write_hdf5 (where data were written in a hdf5 DATASET)
   // FILE EXIST ?
   //    NO -> create file with a "/material" group, write the data in it
@@ -550,7 +550,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string mat_name,
   //        - YES && != /material -> Detect NUCPATH + old write_hdf5
   //        - NO -> CONTINUE
   //          - "/material" EXIST:
-  //            - NO -> create "/material" group and write everyting in it
+  //            - NO -> create "/material" group and write everything in it
   //            - YES:
   //              - "/material" is a DATASET -> detect NUCPATH + old write_hdf5
   //              - "/material" is a GROUP -> add data in it

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -243,6 +243,7 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
     H5O_info_t object_info;
     status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     status = H5Oget_info_by_name(db, "/material" , &object_info, H5P_DEFAULT);
+    bool material_path_exists = (status ==0 && object_info.type != H5O_TYPE_DATASET)
     herr_t status2;
     H5O_info_t object_info2;
     status2 = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -254,7 +254,74 @@ void pyne::Material::write_hdf5(char * filename, char * datapath, char * nucpath
   write_hdf5(fname, groupname, nuclist, row, chunksize);
 }
 
+std::vector<int> pyne::Material::write_hdf5_nucpath(hid_t db, std::string dsatapath,
+                                        std::string nucpath) {
+  int row_num = (int)row;
 
+  // Turn off annoying HDF5 errors
+  H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+
+  // Set file access properties so it closes cleanly
+  hid_t fapl;
+  fapl = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+  // Create new/open datafile.
+  hid_t db;
+  if (pyne::file_exists(filename)) {
+    bool ish5 = H5Fis_hdf5(filename.c_str());
+    if (!ish5) throw h5wrap::FileNotHDF5(filename);
+    db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
+  } else
+    db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+
+  //
+  // Read in nuclist if available, write it out if not
+  //
+  bool nucpath_exists = h5wrap::path_exists(db, nucpath);
+
+  std::vector<int> nuclides;
+  int nuc_size;
+  hsize_t nuc_dims[1];
+
+  // if nucpath exist: get it and check against the one we have!
+  if (nucpath_exists) {
+    nuclides =
+        h5wrap::h5_array_to_cpp_vector_1d<int>(db, nucpath, H5T_NATIVE_INT);
+    nuc_size = nuclides.size();
+    nuc_dims[0] = nuc_size;
+    pyne::comp_iter i = comp.begin();
+    bool missing_nucs = false;
+    while (i != comp.end() or missing_nucs) {
+      if(std::none_of(nuclides.begin(); nuclides.end(); i->first)
+          missing_nucs = true;
+      i++;
+    }
+    if (missing_nucs)
+      std::cout
+          << "One or more nuclides are missing from the existing nuclides "
+             "list, material will likely not be written correctly."
+          << std::endl;
+
+  } else {
+    nuclides = std::vector<int>();
+    for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++)
+      nuclides.push_back(i->first);
+    nuc_size = nuclides.size();
+
+    // Create the data if it doesn't exist
+    int nuc_data[nuc_size];
+    for (int n = 0; n != nuc_size; n++) nuc_data[n] = nuclides[n];
+    nuc_dims[0] = nuc_size;
+    hid_t nuc_space = H5Screate_simple(1, nuc_dims, NULL);
+    hid_t nuc_set = H5Dcreate2(db, nucpath.c_str(), H5T_NATIVE_INT, nuc_space,
+                               H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5Dwrite(nuc_set, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, nuc_data);
+    H5Fflush(db, H5F_SCOPE_GLOBAL);
+
+    H5Dclose(nuc_set);
+  }
+  return nuclides;
+}
 
 void pyne::Material::write_hdf5(std::string filename, std::string datapath,
                                 std::string nucpath, float row, int chunksize) {

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -492,6 +492,9 @@ void pyne::Material::write_hdf5_datapath(hid_t db, std::string datapath, float r
 
 void pyne::Material::write_hdf5(std::string filename, std::string datapath,
                                 float row, int chunksize) {
+  if (datapath.front() != '/')
+    datapath = '/' + datapath;
+  
   hid_t material_grp_id;  // Holder of HDF5 Id of the "/material" group
   hid_t data_id;  // Holder of HDF5 Id of the data group to write the data
                   // (located in "/material/datapath")

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -537,8 +537,8 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
 
       // Grab the nucpath
       if (detect_nuclidelist(data_set, nucpath)) {
-        H5Fclose(db);
-        deprecated_write_hdf5(filename, datapath, nucpath, row, chunksize);
+      deprecated_write_hdf5(db, datapath, "/nucid", row, chunksize);
+      H5Fclose(db);
         return;
       } else {  // can't find a valid nuclide list path form datapath... fail
         throw std::runtime_error(
@@ -558,8 +558,8 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     if (object_info.type ==
         H5O_TYPE_DATASET) {  // "/material" is a dataset -> old format use
                              // deprecated write_hdf5
+      deprecated_write_hdf5(db, datapath, "/nucid", row, chunksize);
       H5Fclose(db);
-      deprecated_write_hdf5(filename, datapath, "/nucid", row, chunksize);
       return;
 
     } else if (object_info.type != H5O_TYPE_GROUP) {
@@ -593,9 +593,9 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   H5Fclose(db);
 }
 
+
 void pyne::Material::deprecated_write_hdf5(std::string filename, std::string datapath,
                                 std::string nucpath, float row, int chunksize) {
-  int row_num = (int)row;
   // Turn off annoying HDF5 errors
   H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
@@ -611,6 +611,15 @@ void pyne::Material::deprecated_write_hdf5(std::string filename, std::string dat
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
   } else
     db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+
+  deprecated_write_hdf5(db, datapath, nucpath, row, chunksize);
+
+  H5Fclose(db);
+}
+
+void pyne::Material::deprecated_write_hdf5(hid_t db, std::string datapath,
+                                std::string nucpath, float row, int chunksize) {
+  int row_num = (int)row;
 
   //
   // Read in nuclist if available, write it out if not
@@ -635,10 +644,6 @@ void pyne::Material::deprecated_write_hdf5(std::string filename, std::string dat
     H5Fflush(db, H5F_SCOPE_GLOBAL);
     H5Dclose(data_set);
   }
-  // Close out the HDF5 file
-  H5Fclose(db);
-  // Remember the milk!
-  // ...by which I mean to deallocate
 }
 
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -243,8 +243,13 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
     H5O_info_t object_info;
     status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     status = H5Oget_info_by_name(db, "/material" , &object_info, H5P_DEFAULT);
+    herr_t status2;
+    H5O_info_t object_info2;
+    status2 = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    status2 = H5Oget_info_by_name(db, datapath.c_str(), &object_info, H5P_DEFAULT);
     // Group "/material" does not exist
-    if (status !=0 || object_info.type == H5O_TYPE_DATASET) {
+    if (status != 0 || object_info.type == H5O_TYPE_DATASET ||
+        status2 != 0 || object_info2.type == H5O_TYPE_DATASET) {
       bool datapath_exists = h5wrap::path_exists(db, datapath);
       if (!datapath_exists)
         throw h5wrap::PathNotFound(filename, datapath);

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -275,7 +275,7 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
     int prot1_hdf5_layout = detect_hdf5_layout(db, datapath);
     switch(prot1_hdf5_layout) {
       case path_donotexists:
-        throw std::runtime_error("/material and " +datapath+ " path do not exist.");
+        throw std::runtime_error("/material and " +datapath+ " paths do not exist.");
         break;
 
       case unknown:

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -238,22 +238,26 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
     _load_comp_protocol0(db, datapath, row);
   } else if (protocol == 1) {
     
-    // Check /material type
-    // set test variables
+    // Check /material type:
+    // Valid status are: 
+    //     - old format: "/material" or datapath as a dataset
+    //     - new format: "/material" as a groupset
+    // Testing for datapath first and "/material" in second so one can check 
+    // in the "else if" statement if "/material" exist otherwise as a group
+    // Initialize test variables
     herr_t status= H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     H5O_info_t object_info;
     
-    // Reset status and test if datapath exist as a non-dataset
+    // Test if datapath exist as a non-dataset
     status = H5Oget_info_by_name(db, datapath.c_str(), &object_info, H5P_DEFAULT);
     bool datapath_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
     
-    // check "/material" path exist as a non-dataset
+    // Reset status and test "/material" path exist as a non-dataset
     status = H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     status = H5Oget_info_by_name(db, "/material" , &object_info, H5P_DEFAULT);
     bool material_notdataset_exists = (status == 0 && object_info.type != H5O_TYPE_DATASET);
-   
     
-    // Group "/material" does not exist as a non-dataset
+    // Group "/material" & datapath do not exist as a non-dataset
     if (!material_notdataset_exists || !datapath_notdataset_exists) {
       bool datapath_exists = h5wrap::path_exists(db, datapath);
       if (!datapath_exists)

--- a/src/material.h
+++ b/src/material.h
@@ -154,7 +154,7 @@ namespace pyne
     /// \param mat_name Path to the the material in the file.
     /// \param row The index to read out, may be negative.
     /// \param protocol Flag for layout of material on disk.
-    void from_hdf5(std::string filename, std::string mat_name="/material",
+    void from_hdf5(std::string filename, std::string mat_name="/mat_name",
                                                           int row=-1, int protocol=1);
    
   private:
@@ -182,7 +182,7 @@ namespace pyne
     ///            appended to the end of the dataset.
     /// \param chunksize The chunksize for all material data on disk.
     /// New write_hdf5 which fallback on the old one when required
-    void write_hdf5(std::string filename, std::string mat_name="/material", 
+    void write_hdf5(std::string filename, std::string mat_name="/mat_name", 
         float row=-0.0, int chunksize= 100);
 
     /// Writes this nucpath to an HDF5 file.

--- a/src/material.h
+++ b/src/material.h
@@ -156,7 +156,11 @@ namespace pyne
     /// \param protocol Flag for layout of material on disk.
     void from_hdf5(std::string filename, std::string datapath="/material",
                                                           int row=-1, int protocol=1);
-    /// Writes this material out to an HDF5 file.
+    /// Writes this material out to an HDF5 file in the old data structure
+    /// format.
+    /// Now deprecated, as material data structure in HDF5 format has been
+    /// refactored. Will only be used when adding material in a file containing
+    /// old material data structure
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.
     /// \param datapath Path to the the material in the file.

--- a/src/material.h
+++ b/src/material.h
@@ -149,7 +149,6 @@ namespace pyne
     /// \param protocol Flag for layout of material on disk.
     void from_hdf5(std::string filename, std::string datapath="/material",
                                                           int row=-1, int protocol=1);
-
     /// Writes this material out to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.
@@ -172,11 +171,9 @@ namespace pyne
     /// \param chunksize The chunksize for all material data on disk.
     void write_hdf5(std::string filename, std::string datapath,
                     std::string nucpath, float row=-0.0, int chunksize=100);
-    /// Readd the missing default write_hdf5
-    void write_hdf5(std::string filename);
     
     /// New write_hdf5 which fallback on the old one when required
-    void write_hdf5(std::string filename, std::string datapath, float row=-0.0, int chunksize= 100);
+    void write_hdf5(std::string filename, std::string datapath="/material", float row=-0.0, int chunksize= 100);
 
     /// write nucpath method
     std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);

--- a/src/material.h
+++ b/src/material.h
@@ -164,11 +164,17 @@ namespace pyne
     /// \param chunksize The chunksize for all material data on disk.
     void write_hdf5(std::string filename, std::string datapath,
                     std::string nucpath, float row=-0.0, int chunksize=100);
+    /// Readd the missing default write_hdf5
     void write_hdf5(std::string filename);
+    
+    /// New write_hdf5 which fallback on the old one when required
+    void write_hdf5(std::string filename, std::string datapath, float row=-0.0, int chunksize= 100);
+
+    /// write nucpath method
     std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
+    // write datapath method
     void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, std::vector<int> nuclides);
 
-    void write_hdf5(std::string filename, std::string datapath, float row=-0.0, int chunksize= 100);
 
     /// Return an openmc xml material element as a string
     std::string openmc(std::string fact_type = "mass");

--- a/src/material.h
+++ b/src/material.h
@@ -130,44 +130,44 @@ namespace pyne
     /// Loads the matrial composition from an HDF5 file according to the layout
     /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param datapath Path to the base node for the material in \a db.
+    /// \param mat_name Path to the base node for the material in \a db.
     /// \param row The index to read out, may be negative.
-    void _load_comp_protocol1(hid_t db, std::string datapath, int row);
+    void _load_comp_protocol1(hid_t db, std::string mat_name, int row);
     
     /// Loads the matrial composition from an HDF5 file according to the layout
     /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param datapath Path to the base node for the material in a db.
+    /// \param mat_name Path to the base node for the material in a db.
     /// \param nucpath Path to the base node for nuclide list in a db.
     /// \param row The index to read out, may be negative.
-    void _load_comp_protocol1(hid_t db, std::string datapath, std::string nucpath, int row);
+    void _load_comp_protocol1(hid_t db, std::string mat_name, std::string nucpath, int row);
     
     /// Loads a material from an HDF5 file into this object.
     /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
+    /// \param mat_name Path to the the material in the file.
     /// \param row The index to read out, may be negative.
     /// \param protocol Flag for layout of material on disk.
-    void from_hdf5(char * filename, char * datapath, int row=-1, int protocol=1);
+    void from_hdf5(char * filename, char * mat_name, int row=-1, int protocol=1);
 
     /// Loads a material from an HDF5 file into this object.
     /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
+    /// \param mat_name Path to the the material in the file.
     /// \param row The index to read out, may be negative.
     /// \param protocol Flag for layout of material on disk.
-    void from_hdf5(std::string filename, std::string datapath="/material",
+    void from_hdf5(std::string filename, std::string mat_name="/material",
                                                           int row=-1, int protocol=1);
    
   private:
 
     /// Detect the HDF5 file assuming protocol1.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param datapath Path to look for the material in the file.
+    /// \param mat_name Path to look for the material in the file.
     /// Return options are: 
-    ///     -"-1": datapath and "/material" do not exist
-    ///     - "0": datapath and/or "/material" exist but either as a group or a dataset
-    ///     - "1": datapath exists as a dataset -> old layout
+    ///     -"-1": mat_name and "/material" do not exist
+    ///     - "0": mat_name and/or "/material" exist but either as a group or a dataset
+    ///     - "1": mat_name exists as a dataset -> old layout
     ///     - "2": "/material" exists as a group-> new layout
-    int detect_hdf5_layout(hid_t db, std::string path);
+    int detect_hdf5_layout(hid_t db, std::string mat_name);
   
     enum prot1_layout {path_donotexists=-1, unknown, old_layout, new_layout};
   
@@ -176,13 +176,13 @@ namespace pyne
     /// Writes this material out to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
+    /// \param mat_name Path to the the material in the file.
     /// \param row The index to read out, may be negative. Also note that this is a
     ///            float.  A value of -0.0 indicates that the material should be
     ///            appended to the end of the dataset.
     /// \param chunksize The chunksize for all material data on disk.
     /// New write_hdf5 which fallback on the old one when required
-    void write_hdf5(std::string filename, std::string datapath="/material", 
+    void write_hdf5(std::string filename, std::string mat_name="/material", 
         float row=-0.0, int chunksize= 100);
 
     /// Writes this nucpath to an HDF5 file.
@@ -196,7 +196,7 @@ namespace pyne
     /// Writes this datapath to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param datapath Path to the the material in the file.
+    /// \param mat_name Path to the the material in the file.
     /// \param nucpath Path to the nuclides list in the file.
     /// \param row The index to read out, may be negative. Also note that this is a
     ///            float.  A value of -0.0 indicates that the material should be
@@ -204,7 +204,7 @@ namespace pyne
     /// \param chunksize The chunksize for all material data on disk.
     /// Only the nuclides present in the nuclides list can be part of the composition 
     /// of the material, additional nuclides will be ignored, and a warning will be thrown
-    void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, 
+    void write_hdf5_datapath(hid_t db, std::string mat_name, float row, int chunksize, 
         std::vector<int> nuclides);
     /// Writes this material out to an HDF5 file in the old data structure
     /// format.

--- a/src/material.h
+++ b/src/material.h
@@ -165,6 +165,8 @@ namespace pyne
     void write_hdf5(std::string filename, std::string datapath="/material",
                     std::string nucpath="/nucid", float row=-0.0, int chunksize=100);
 
+    std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
+
     /// Return an openmc xml material element as a string
     std::string openmc(std::string fact_type = "mass");
 

--- a/src/material.h
+++ b/src/material.h
@@ -158,7 +158,7 @@ namespace pyne
     ///            float.  A value of -0.0 indicates that the material should be
     ///            appended to the end of the dataset.
     /// \param chunksize The chunksize for all material data on disk.
-    void write_hdf5(char * filename, char * datapath, char * nucpath, float row=-0.0,
+    void deprecated_write_hdf5(char * filename, char * datapath, char * nucpath, float row=-0.0,
                                                                     int chunksize=100);
     /// Writes this material out to an HDF5 file.
     /// This happens according to protocol 1.
@@ -169,7 +169,7 @@ namespace pyne
     ///            float.  A value of -0.0 indicates that the material should be
     ///            appended to the end of the dataset.
     /// \param chunksize The chunksize for all material data on disk.
-    void write_hdf5(std::string filename, std::string datapath,
+    void deprecated_write_hdf5(std::string filename, std::string datapath,
                     std::string nucpath, float row=-0.0, int chunksize=100);
     
     /// Writes this material out to an HDF5 file.
@@ -191,7 +191,17 @@ namespace pyne
     /// \return list of nuclide writen in the file (or the existing list if the nuclides 
     /// list was already in the file 
     std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
-    
+   
+    /// Looking for the nuclide list path in the nucpath attribute of the dataset.
+    /// This happens according to protocol 1.
+    /// \param dataset hid of the dataset.
+    /// \param nucpath address of the path to the nuclides list in the file 
+    /// (update when nucpath is found).
+    /// \return true if the nucpath attribure is present in the dataset
+    bool detect_nuclidelist(hid_t dataset, std::string& nucpath);
+
+
+
     /// Writes this datapath to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param db HDF5 id for the open HDF5 file.

--- a/src/material.h
+++ b/src/material.h
@@ -43,6 +43,13 @@ namespace pyne
   }  // namespace decayers
   #endif
 
+  /// Looking for the nuclide list path in the nucpath attribute of the dataset.
+  /// This happens according to protocol 1.
+  /// \param dataset hid of the dataset.
+  /// \param nucpath address of the path to the nuclides list in the file 
+  /// (update when nucpath is found).
+  /// \return true if the nucpath attribure is present in the dataset
+  bool detect_nuclidelist(hid_t dataset, std::string& nucpath);
 
   // These 37 strings are predefined FLUKA materials.
   // Materials not on this list requires a MATERIAL card.
@@ -191,16 +198,6 @@ namespace pyne
     /// \return list of nuclide writen in the file (or the existing list if the nuclides 
     /// list was already in the file 
     std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
-   
-    /// Looking for the nuclide list path in the nucpath attribute of the dataset.
-    /// This happens according to protocol 1.
-    /// \param dataset hid of the dataset.
-    /// \param nucpath address of the path to the nuclides list in the file 
-    /// (update when nucpath is found).
-    /// \return true if the nucpath attribure is present in the dataset
-    bool detect_nuclidelist(hid_t dataset, std::string& nucpath);
-
-
 
     /// Writes this datapath to an HDF5 file.
     /// This happens according to protocol 1.

--- a/src/material.h
+++ b/src/material.h
@@ -171,6 +171,21 @@ namespace pyne
     /// \param chunksize The chunksize for all material data on disk.
     void deprecated_write_hdf5(char * filename, char * datapath, char * nucpath, float row=-0.0,
                                                                     int chunksize=100);
+    /// Writes this material out to an HDF5 file in the old data structure
+    /// format.
+    /// Now deprecated, as material data structure in HDF5 format has been
+    /// refactored. Only used when adding material in a file containing
+    /// old material data structure.
+    /// This happens according to protocol 1.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param nucpath Path to the nuclides set in the file.
+    /// \param row The index to read out, may be negative. Also note that this is a
+    ///            float.  A value of -0.0 indicates that the material should be
+    ///            appended to the end of the dataset.
+    /// \param chunksize The chunksize for all material data on disk.
+    void deprecated_write_hdf5(hid_t db, std::string datapath, std::string nucpath, float row=-0.0,
+                                                                    int chunksize=100);
     /// Writes this material out to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.

--- a/src/material.h
+++ b/src/material.h
@@ -156,6 +156,39 @@ namespace pyne
     /// \param protocol Flag for layout of material on disk.
     void from_hdf5(std::string filename, std::string datapath="/material",
                                                           int row=-1, int protocol=1);
+    /// Writes this material out to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param filename Path on disk to the HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param row The index to read out, may be negative. Also note that this is a
+    ///            float.  A value of -0.0 indicates that the material should be
+    ///            appended to the end of the dataset.
+    /// \param chunksize The chunksize for all material data on disk.
+    /// New write_hdf5 which fallback on the old one when required
+    void write_hdf5(std::string filename, std::string datapath="/material", 
+        float row=-0.0, int chunksize= 100);
+
+    /// Writes this nucpath to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param nucpath Path to the nuclides list in the file.
+    /// \return list of nuclide writen in the file (or the existing list if the nuclides 
+    /// list was already in the file 
+    std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
+
+    /// Writes this datapath to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param nucpath Path to the nuclides list in the file.
+    /// \param row The index to read out, may be negative. Also note that this is a
+    ///            float.  A value of -0.0 indicates that the material should be
+    ///            appended to the end of the dataset.
+    /// \param chunksize The chunksize for all material data on disk.
+    /// Only the nuclides present in the nuclides list can be part of the composition 
+    /// of the material, additional nuclides will be ignored, and a warning will be thrown
+    void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, 
+        std::vector<int> nuclides);
     /// Writes this material out to an HDF5 file in the old data structure
     /// format.
     /// Now deprecated, as material data structure in HDF5 format has been
@@ -197,41 +230,6 @@ namespace pyne
     /// \param chunksize The chunksize for all material data on disk.
     void deprecated_write_hdf5(std::string filename, std::string datapath,
                     std::string nucpath, float row=-0.0, int chunksize=100);
-    
-    /// Writes this material out to an HDF5 file.
-    /// This happens according to protocol 1.
-    /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
-    /// \param row The index to read out, may be negative. Also note that this is a
-    ///            float.  A value of -0.0 indicates that the material should be
-    ///            appended to the end of the dataset.
-    /// \param chunksize The chunksize for all material data on disk.
-    /// New write_hdf5 which fallback on the old one when required
-    void write_hdf5(std::string filename, std::string datapath="/material", 
-        float row=-0.0, int chunksize= 100);
-
-    /// Writes this nucpath to an HDF5 file.
-    /// This happens according to protocol 1.
-    /// \param db HDF5 id for the open HDF5 file.
-    /// \param nucpath Path to the nuclides list in the file.
-    /// \return list of nuclide writen in the file (or the existing list if the nuclides 
-    /// list was already in the file 
-    std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
-
-    /// Writes this datapath to an HDF5 file.
-    /// This happens according to protocol 1.
-    /// \param db HDF5 id for the open HDF5 file.
-    /// \param datapath Path to the the material in the file.
-    /// \param nucpath Path to the nuclides list in the file.
-    /// \param row The index to read out, may be negative. Also note that this is a
-    ///            float.  A value of -0.0 indicates that the material should be
-    ///            appended to the end of the dataset.
-    /// \param chunksize The chunksize for all material data on disk.
-    /// Only the nuclides present in the nuclides list can be part of the composition 
-    /// of the material, additional nuclides will be ignored, and a warning will be thrown
-    void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, 
-        std::vector<int> nuclides);
-
     /// Return an openmc xml material element as a string
     std::string openmc(std::string fact_type = "mass");
 

--- a/src/material.h
+++ b/src/material.h
@@ -126,7 +126,15 @@ namespace pyne
     /// \param datapath Path to the base node for the material in \a db.
     /// \param row The index to read out, may be negative.
     void _load_comp_protocol1(hid_t db, std::string datapath, int row);
-
+    
+    /// Loads the matrial composition from an HDF5 file according to the layout
+    /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param datapath Path to the base node for the material in a db.
+    /// \param nucpath Path to the base node for nuclide list in a db.
+    /// \param row The index to read out, may be negative.
+    void _load_comp_protocol1(hid_t db, std::string datapath, std::string nucpath, int row);
+    
     /// Loads a material from an HDF5 file into this object.
     /// \param filename Path on disk to the HDF5 file.
     /// \param datapath Path to the the material in the file.

--- a/src/material.h
+++ b/src/material.h
@@ -159,8 +159,8 @@ namespace pyne
     /// Writes this material out to an HDF5 file in the old data structure
     /// format.
     /// Now deprecated, as material data structure in HDF5 format has been
-    /// refactored. Will only be used when adding material in a file containing
-    /// old material data structure
+    /// refactored. Only used when adding material in a file containing
+    /// old material data structure.
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.
     /// \param datapath Path to the the material in the file.

--- a/src/material.h
+++ b/src/material.h
@@ -162,10 +162,13 @@ namespace pyne
     ///            float.  A value of -0.0 indicates that the material should be
     ///            appended to the end of the dataset.
     /// \param chunksize The chunksize for all material data on disk.
-    void write_hdf5(std::string filename, std::string datapath="/material",
-                    std::string nucpath="/nucid", float row=-0.0, int chunksize=100);
-
+    void write_hdf5(std::string filename, std::string datapath,
+                    std::string nucpath, float row=-0.0, int chunksize=100);
+    void write_hdf5(std::string filename);
     std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
+    void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, std::vector<int> nuclides);
+
+    void write_hdf5(std::string filename, std::string datapath, float row=-0.0, int chunksize= 100);
 
     /// Return an openmc xml material element as a string
     std::string openmc(std::string fact_type = "mass");

--- a/src/material.h
+++ b/src/material.h
@@ -130,44 +130,44 @@ namespace pyne
     /// Loads the matrial composition from an HDF5 file according to the layout
     /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param mat_name Path to the base node for the material in \a db.
+    /// \param datapath Path to the base node for the material in \a db.
     /// \param row The index to read out, may be negative.
-    void _load_comp_protocol1(hid_t db, std::string mat_name, int row);
+    void _load_comp_protocol1(hid_t db, std::string datapath, int row);
     
     /// Loads the matrial composition from an HDF5 file according to the layout
     /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param mat_name Path to the base node for the material in a db.
+    /// \param datapath Path to the base node for the material in a db.
     /// \param nucpath Path to the base node for nuclide list in a db.
     /// \param row The index to read out, may be negative.
-    void _load_comp_protocol1(hid_t db, std::string mat_name, std::string nucpath, int row);
+    void _load_comp_protocol1(hid_t db, std::string datapath, std::string nucpath, int row);
     
     /// Loads a material from an HDF5 file into this object.
     /// \param filename Path on disk to the HDF5 file.
-    /// \param mat_name Path to the the material in the file.
+    /// \param datapath Path to the the material in the file.
     /// \param row The index to read out, may be negative.
     /// \param protocol Flag for layout of material on disk.
-    void from_hdf5(char * filename, char * mat_name, int row=-1, int protocol=1);
+    void from_hdf5(char * filename, char * datapath, int row=-1, int protocol=1);
 
     /// Loads a material from an HDF5 file into this object.
     /// \param filename Path on disk to the HDF5 file.
-    /// \param mat_name Path to the the material in the file.
+    /// \param datapath Path to the the material in the file.
     /// \param row The index to read out, may be negative.
     /// \param protocol Flag for layout of material on disk.
-    void from_hdf5(std::string filename, std::string mat_name="/mat_name",
+    void from_hdf5(std::string filename, std::string datapath="/mat_name",
                                                           int row=-1, int protocol=1);
    
   private:
 
     /// Detect the HDF5 file assuming protocol1.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param mat_name Path to look for the material in the file.
+    /// \param datapath Path to look for the material in the file.
     /// Return options are: 
-    ///     -"-1": mat_name and "/material" do not exist
-    ///     - "0": mat_name and/or "/material" exist but either as a group or a dataset
-    ///     - "1": mat_name exists as a dataset -> old layout
+    ///     -"-1": datapath and "/material" do not exist
+    ///     - "0": datapath and/or "/material" exist but either as a group or a dataset
+    ///     - "1": datapath exists as a dataset -> old layout
     ///     - "2": "/material" exists as a group-> new layout
-    int detect_hdf5_layout(hid_t db, std::string mat_name);
+    int detect_hdf5_layout(hid_t db, std::string datapath);
   
     enum prot1_layout {path_donotexists=-1, unknown, old_layout, new_layout};
   
@@ -176,13 +176,13 @@ namespace pyne
     /// Writes this material out to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.
-    /// \param mat_name Path to the the material in the file.
+    /// \param datapath Path to the the material in the file.
     /// \param row The index to read out, may be negative. Also note that this is a
     ///            float.  A value of -0.0 indicates that the material should be
     ///            appended to the end of the dataset.
     /// \param chunksize The chunksize for all material data on disk.
     /// New write_hdf5 which fallback on the old one when required
-    void write_hdf5(std::string filename, std::string mat_name="/mat_name", 
+    void write_hdf5(std::string filename, std::string datapath="/mat_name", 
         float row=-0.0, int chunksize= 100);
 
     /// Writes this nucpath to an HDF5 file.
@@ -196,7 +196,7 @@ namespace pyne
     /// Writes this datapath to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param db HDF5 id for the open HDF5 file.
-    /// \param mat_name Path to the the material in the file.
+    /// \param datapath Path to the the material in the file.
     /// \param nucpath Path to the nuclides list in the file.
     /// \param row The index to read out, may be negative. Also note that this is a
     ///            float.  A value of -0.0 indicates that the material should be
@@ -204,7 +204,7 @@ namespace pyne
     /// \param chunksize The chunksize for all material data on disk.
     /// Only the nuclides present in the nuclides list can be part of the composition 
     /// of the material, additional nuclides will be ignored, and a warning will be thrown
-    void write_hdf5_datapath(hid_t db, std::string mat_name, float row, int chunksize, 
+    void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, 
         std::vector<int> nuclides);
     /// Writes this material out to an HDF5 file in the old data structure
     /// format.

--- a/src/material.h
+++ b/src/material.h
@@ -164,7 +164,7 @@ namespace pyne
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.
     /// \param datapath Path to the the material in the file.
-    /// \param nucpath Path to the nuclides set in the file.
+    /// \param nucpath Path to the nuclides list in the file.
     /// \param row The index to read out, may be negative. Also note that this is a
     ///            float.  A value of -0.0 indicates that the material should be
     ///            appended to the end of the dataset.
@@ -172,14 +172,39 @@ namespace pyne
     void write_hdf5(std::string filename, std::string datapath,
                     std::string nucpath, float row=-0.0, int chunksize=100);
     
+    /// Writes this material out to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param filename Path on disk to the HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param row The index to read out, may be negative. Also note that this is a
+    ///            float.  A value of -0.0 indicates that the material should be
+    ///            appended to the end of the dataset.
+    /// \param chunksize The chunksize for all material data on disk.
     /// New write_hdf5 which fallback on the old one when required
-    void write_hdf5(std::string filename, std::string datapath="/material", float row=-0.0, int chunksize= 100);
+    void write_hdf5(std::string filename, std::string datapath="/material", 
+        float row=-0.0, int chunksize= 100);
 
-    /// write nucpath method
+    /// Writes this nucpath to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param nucpath Path to the nuclides list in the file.
+    /// \return list of nuclide writen in the file (or the existing list if the nuclides 
+    /// list was already in the file 
     std::vector<int> write_hdf5_nucpath(hid_t db, std::string nucpath);
-    // write datapath method
-    void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, std::vector<int> nuclides);
-
+    
+    /// Writes this datapath to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param nucpath Path to the nuclides list in the file.
+    /// \param row The index to read out, may be negative. Also note that this is a
+    ///            float.  A value of -0.0 indicates that the material should be
+    ///            appended to the end of the dataset.
+    /// \param chunksize The chunksize for all material data on disk.
+    /// Only the nuclides present in the nuclides list can be part of the composition 
+    /// of the material, additional nuclides will be ignored, and a warning will be thrown
+    void write_hdf5_datapath(hid_t db, std::string datapath, float row, int chunksize, 
+        std::vector<int> nuclides);
 
     /// Return an openmc xml material element as a string
     std::string openmc(std::string fact_type = "mass");

--- a/src/material.h
+++ b/src/material.h
@@ -156,7 +156,9 @@ namespace pyne
     /// \param protocol Flag for layout of material on disk.
     void from_hdf5(std::string filename, std::string datapath="/material",
                                                           int row=-1, int protocol=1);
-    
+   
+  private:
+
     /// Detect the HDF5 file assuming protocol1.
     /// \param db HDF5 id for the open HDF5 file.
     /// \param datapath Path to look for the material in the file.
@@ -166,7 +168,11 @@ namespace pyne
     ///     - "1": datapath exists as a dataset -> old layout
     ///     - "2": "/material" exists as a group-> new layout
     int detect_hdf5_layout(hid_t db, std::string path);
-    
+  
+    enum prot1_layout {path_donotexists=-1, unknown, old_layout, new_layout};
+  
+  public:
+
     /// Writes this material out to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.

--- a/src/material.h
+++ b/src/material.h
@@ -156,6 +156,17 @@ namespace pyne
     /// \param protocol Flag for layout of material on disk.
     void from_hdf5(std::string filename, std::string datapath="/material",
                                                           int row=-1, int protocol=1);
+    
+    /// Detect the HDF5 file assuming protocol1.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param datapath Path to look for the material in the file.
+    /// Return options are: 
+    ///     -"-1": datapath and "/material" do not exist
+    ///     - "0": datapath and/or "/material" exist but either as a group or a dataset
+    ///     - "1": datapath exists as a dataset -> old layout
+    ///     - "2": "/material" exists as a group-> new layout
+    int detect_hdf5_layout(hid_t db, std::string path);
+    
     /// Writes this material out to an HDF5 file.
     /// This happens according to protocol 1.
     /// \param filename Path on disk to the HDF5 file.

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -49,7 +49,7 @@ def setup():
         urlretrieve(o2benchurl, H5NAME)
         sys.stderr.write("done.\n")
         sys.stderr.flush()
-    MATS = MaterialLibrary(H5NAME)
+    MATS = MaterialLibrary(H5NAME, "/materials")
     with open('o2hls.json', 'r') as f:
         O2HLS = json.load(f)
     O2HLS = {int(nuc): v for nuc, v in O2HLS.items()}

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -245,28 +245,36 @@ def test_hdf5_protocol_1():
     # Test material writing
     leu = Material({'U235': 0.04, 'U238': 0.96}, 4.2, 2.72, 1.0)
     leu.metadata['comment'] = 'first light'
-    leu.write_hdf5('proto1.h5', chunksize=10)
-
+    leu.write_hdf5('proto1.h5')
+    
     for i in range(2, 11):
         leu = Material({'U235': 0.04, 'U238': 0.96}, i*4.2, 2.72, 1.0*i)
         leu.metadata['comment'] = 'fire in the disco - {0}'.format(i)
         leu.write_hdf5('proto1.h5')
 
     # Loads with protocol 1 now.
-    m = Material()
-    m.from_hdf5('proto1.h5', '/material', -3, 1)
+    for i in range(2, 11):
+        m = Material()
+        m.from_hdf5('proto1.h5', '/material', i-1, 1)
+        assert_equal(m.density, 2.72)
+        assert_equal(m.atoms_per_molecule, 1.0*i)
+        assert_equal(m.mass, i*4.2)
+        assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
+        assert_equal(m.metadata['comment'], 'fire in the disco - {0}'.format(i))
+    
+    m = from_hdf5('proto1.h5', '/material', -1, 1)
     assert_equal(m.density, 2.72)
-    assert_equal(m.atoms_per_molecule, 8.0)
-    assert_equal(m.mass, 33.6)
+    assert_equal(m.atoms_per_molecule, 10.0)
+    assert_equal(m.mass, 42.0)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
-    assert_equal(m.metadata['comment'], 'fire in the disco - 8')
+    assert_equal(m.metadata['comment'], 'fire in the disco - 10')
 
-    m = from_hdf5('proto1.h5', '/material', 3, 1)
+    m = from_hdf5('proto1.h5', '/material', 0, 1)
     assert_equal(m.density, 2.72)
-    assert_equal(m.atoms_per_molecule, 5.0)
-    assert_equal(m.mass, 21.0)
+    assert_equal(m.atoms_per_molecule, 1.0)
+    assert_equal(m.mass, 4.2) 
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
-    assert_equal(m.metadata['comment'], 'fire in the disco - 5')
+    assert_equal(m.metadata['comment'], 'first light')
     os.remove('proto1.h5')
 
 class TestMaterialMethods(TestCase):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -182,14 +182,14 @@ def test_hdf5_protocol_1_old():
 
     # Loads with protocol 1 now.
     m = Material()
-    m.from_hdf5('proto1.h5', '/material',  -3, 1)
+    m.from_hdf5('proto1.h5', '/mat_name',  -3, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 8.0)
     assert_equal(m.mass, 33.6)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'fire in the disco - 8')
 
-    m = from_hdf5('proto1.h5', '/material', 3, 1)
+    m = from_hdf5('proto1.h5', '/mat_name', 3, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 4.0)
     assert_equal(m.mass, 16.8)
@@ -255,21 +255,21 @@ def test_hdf5_protocol_1():
     # Loads with protocol 1 now.
     for i in range(2, 11):
         m = Material()
-        m.from_hdf5('proto1.h5', '/material', i-1, 1)
+        m.from_hdf5('proto1.h5', '/mat_name', i-1, 1)
         assert_equal(m.density, 2.72)
         assert_equal(m.atoms_per_molecule, 1.0*i)
         assert_equal(m.mass, i*4.2)
         assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
         assert_equal(m.metadata['comment'], 'fire in the disco - {0}'.format(i))
     
-    m = from_hdf5('proto1.h5', '/material', -1, 1)
+    m = from_hdf5('proto1.h5', '/mat_name', -1, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 10.0)
     assert_equal(m.mass, 42.0)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'fire in the disco - 10')
 
-    m = from_hdf5('proto1.h5', '/material', 0, 1)
+    m = from_hdf5('proto1.h5', '/mat_name', 0, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 1.0)
     assert_equal(m.mass, 4.2) 
@@ -1241,7 +1241,7 @@ def test_openmc():
     leu.write_hdf5('leu.h5')
 
     leu_read = Material()
-    leu_read.from_hdf5('leu.h5', '/material')
+    leu_read.from_hdf5('leu.h5', '/mat_name')
 
     mass = leu.openmc()
     assert_equal(mass, mass_exp)

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -202,7 +202,6 @@ def test_hdf5_protocol_1():
     if 'proto1.h5' in os.listdir('.'):
         os.remove('proto1.h5')
 
-    print("done")
     # Test material writing
     leu = Material({'U235': 0.04, 'U238': 0.96}, 4.2, 2.72, 1.0)
     leu.metadata['comment'] = 'first light'
@@ -212,10 +211,8 @@ def test_hdf5_protocol_1():
         leu = Material({'U235': 0.04, 'U238': 0.96}, i*4.2, 2.72, 1.0*i)
         leu.metadata['comment'] = 'fire in the disco - {0}'.format(i)
         leu.write_hdf5('proto1.h5')
-    print("done2")
 
     # Loads with protocol 1 now.
-    print("done3")
     m = Material()
     m.from_hdf5('proto1.h5', '/material', -3, 1)
     assert_equal(m.density, 2.72)
@@ -224,16 +221,13 @@ def test_hdf5_protocol_1():
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'fire in the disco - 8')
 
-    print("done4")
     m = from_hdf5('proto1.h5', '/material', 3, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 4.0)
     assert_equal(m.mass, 16.8)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'fire in the disco - 4')
-    print("done5")
-    #os.remove('proto1.h5')
-    print("kill")
+    os.remove('proto1.h5')
 
 class TestMaterialMethods(TestCase):
     "Tests that the Material member functions work."

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -263,10 +263,10 @@ def test_hdf5_protocol_1():
 
     m = from_hdf5('proto1.h5', '/material', 3, 1)
     assert_equal(m.density, 2.72)
-    assert_equal(m.atoms_per_molecule, 4.0)
-    assert_equal(m.mass, 16.8)
+    assert_equal(m.atoms_per_molecule, 5.0)
+    assert_equal(m.mass, 21.0)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
-    assert_equal(m.metadata['comment'], 'fire in the disco - 4')
+    assert_equal(m.metadata['comment'], 'fire in the disco - 5')
     os.remove('proto1.h5')
 
 class TestMaterialMethods(TestCase):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -196,8 +196,48 @@ def test_hdf5_protocol_1_old():
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'fire in the disco - 4')
 
-    os.remove('proto1.h5')
+    # Test mateiral old format detection
+    leu = Material({'U235': 0.02, 'U238': 0.98}, 6.34, 2.72, 1.0)
+    leu.metadata['comment'] = 'hitting the dancefloor'
+    leu.write_hdf5('proto1.h5', datapath="/new_mat", chunksize=10)
 
+    # Loads with protocol 1 now.
+    m = Material()
+    m.from_hdf5('proto1.h5', '/new_mat',  -0, 1)
+    assert_equal(m.density, 2.72)
+    assert_equal(m.atoms_per_molecule, 1.0)
+    assert_equal(m.mass, 6.34)
+    assert_equal(m.comp, {922350000: 0.02, 922380000: 0.98})
+    assert_equal(m.metadata['comment'], 'hitting the dancefloor')
+
+    os.remove('proto1.h5')
+    
+    leu = Material({'U235': 0.02, 'U238': 0.98}, 6.34, 2.72, 1.0)
+    leu.metadata['comment'] = 'hitting the dancefloor'
+    leu.write_hdf5('proto1.h5', datapath="/new_mat", nucpath="/nucid", chunksize=10)
+    # Test material writing
+    leu = Material({'U235': 0.04, 'U238': 0.96}, 4.2, 2.72, 1.0)
+    leu.metadata['comment'] = 'first light'
+    leu.write_hdf5('proto1.h5', datapath="/new_mat", chunksize=10)
+    # Loads with protocol 1 now.
+    m = Material()
+    m.from_hdf5('proto1.h5', '/new_mat',  -0, 1)
+    assert_equal(m.density, 2.72)
+    assert_equal(m.atoms_per_molecule, 1.0)
+    assert_equal(m.mass, 6.34)
+    assert_equal(m.comp, {922350000: 0.02, 922380000: 0.98})
+    assert_equal(m.metadata['comment'], 'hitting the dancefloor')
+    # Loads with protocol 1 now.
+    m = Material()
+    m.from_hdf5('proto1.h5', '/new_mat', -1, 1)
+    assert_equal(m.density, 2.72)
+    assert_equal(m.atoms_per_molecule, 1.0)
+    assert_equal(m.mass, 4.2)
+    assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
+    assert_equal(m.metadata['comment'], 'first light')
+    
+    os.remove('proto1.h5')
+    
 def test_hdf5_protocol_1():
     if 'proto1.h5' in os.listdir('.'):
         os.remove('proto1.h5')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -166,6 +166,38 @@ def test_from_hdf5_protocol_0():
     assert_equal(mat.comp, {922350000: 1.0, 942390000: 0.0})
 
 
+def test_hdf5_protocol_1_old():
+    if 'proto1.h5' in os.listdir('.'):
+        os.remove('proto1.h5')
+
+    # Test material writing
+    leu = Material({'U235': 0.04, 'U238': 0.96}, 4.2, 2.72, 1.0)
+    leu.metadata['comment'] = 'first light'
+    leu.write_hdf5('proto1.h5', nucpath="/nucid", chunksize=10)
+
+    for i in range(2, 11):
+        leu = Material({'U235': 0.04, 'U238': 0.96}, i*4.2, 2.72, 1.0*i)
+        leu.metadata['comment'] = 'fire in the disco - {0}'.format(i)
+        leu.write_hdf5('proto1.h5')
+
+    # Loads with protocol 1 now.
+    m = Material()
+    m.from_hdf5('proto1.h5', '/material',  -3, 1)
+    assert_equal(m.density, 2.72)
+    assert_equal(m.atoms_per_molecule, 8.0)
+    assert_equal(m.mass, 33.6)
+    assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
+    assert_equal(m.metadata['comment'], 'fire in the disco - 8')
+
+    m = from_hdf5('proto1.h5', '/material', 3, 1)
+    assert_equal(m.density, 2.72)
+    assert_equal(m.atoms_per_molecule, 4.0)
+    assert_equal(m.mass, 16.8)
+    assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
+    assert_equal(m.metadata['comment'], 'fire in the disco - 4')
+
+    os.remove('proto1.h5')
+
 def test_hdf5_protocol_1():
     if 'proto1.h5' in os.listdir('.'):
         os.remove('proto1.h5')

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -202,6 +202,7 @@ def test_hdf5_protocol_1():
     if 'proto1.h5' in os.listdir('.'):
         os.remove('proto1.h5')
 
+    print("done")
     # Test material writing
     leu = Material({'U235': 0.04, 'U238': 0.96}, 4.2, 2.72, 1.0)
     leu.metadata['comment'] = 'first light'
@@ -211,8 +212,10 @@ def test_hdf5_protocol_1():
         leu = Material({'U235': 0.04, 'U238': 0.96}, i*4.2, 2.72, 1.0*i)
         leu.metadata['comment'] = 'fire in the disco - {0}'.format(i)
         leu.write_hdf5('proto1.h5')
+    print("done2")
 
     # Loads with protocol 1 now.
+    print("done3")
     m = Material()
     m.from_hdf5('proto1.h5', '/material', -3, 1)
     assert_equal(m.density, 2.72)
@@ -221,15 +224,16 @@ def test_hdf5_protocol_1():
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'fire in the disco - 8')
 
+    print("done4")
     m = from_hdf5('proto1.h5', '/material', 3, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 4.0)
     assert_equal(m.mass, 16.8)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'fire in the disco - 4')
-
-    os.remove('proto1.h5')
-
+    print("done5")
+    #os.remove('proto1.h5')
+    print("kill")
 
 class TestMaterialMethods(TestCase):
     "Tests that the Material member functions work."

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -567,7 +567,6 @@ def test_matlib():
 
     m.write_hdf5('test_matlib.h5m')
     shutil.copy('test_matlib.h5m', 'test_matlib2.h5m')
-    shutil.copy('test_matlib.h5m', 'test_matlib2_.h5m')
     m2 = Mesh(mesh='test_matlib2.h5m')  # MOAB fails to flush
     for i, mat, ve in m2:
         assert_equal(len(mat.comp), len(mats[i].comp))

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -567,6 +567,7 @@ def test_matlib():
 
     m.write_hdf5('test_matlib.h5m')
     shutil.copy('test_matlib.h5m', 'test_matlib2.h5m')
+    shutil.copy('test_matlib.h5m', 'test_matlib2_.h5m')
     m2 = Mesh(mesh='test_matlib2.h5m')  # MOAB fails to flush
     for i, mat, ve in m2:
         assert_equal(len(mat.comp), len(mats[i].comp))


### PR DESCRIPTION
this updates the write_hdf5 method to refactor the structure of material in an hdf5 file as such:

```
/material/
/material/mat_1/
/material/mat_1/nucid
/material/mat_1/composition
/material/mat_1/composition_metadata
```

`/material` and `/datapath` being HDF5 groups
 `/nucid`, `composition` and `composition_metadata` being HDF5 dataset

the value of `datapath` is string variable can/should be user provided.

this will allows a future MaterialLibrary (see #1104) to coexist with simple material inside the same hdf5 file

this is not done yet, still need some cleaning ad missing docstring.
I also need to tweak the `from_hdf5` method to be able to read the new structure


but for some reason `nosetests` are not finishing on my computer for this (or `master`....)