### PR TITLE
Add a flag for MCNP/PHITS material cards to write mass fractions instead of mass densities

### DIFF
--- a/news/mat_mcnp_frac.rst
+++ b/news/mat_mcnp_frac.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* A new argument `mult_den` (bool) that makes *Material* class's **get_density_frac** method (hence also **mcnp** and **phits** methods) write mass density if true, otherwise write mass fraction.
+* A new argument `mult_den` (bool) that makes *Material* class's **get_density_frac** method (hence also **mcnp** and **phits** methods) write atom/mass density if true, otherwise write atom/mass fraction.
 * Relevant tests in tests/test_material.py
 
 **Changed:** None

--- a/news/mat_mcnp_frac.rst
+++ b/news/mat_mcnp_frac.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+* A new argument `mult_den` (bool) that makes *Material* class's **get_density_frac** method (hence also **mcnp** and **phits** methods) write mass density if true, otherwise write mass fraction.
+* Relevant tests in tests/test_material.py
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -40,8 +40,10 @@ cdef extern from "material.h" namespace "pyne":
         void norm_comp() except +
         std_string openmc(std_string) except +
         std_string mcnp(std_string) except +
+        std_string mcnp(std_string, bool) except +
         std_string get_uwuw_name() except +
         std_string phits(std_string) except +
+        std_string phits(std_string, bool) except +
         std_string fluka(int, std_string) except +
         bool not_fluka_builtin(std_string) except +
         std_string fluka_material_str(int) except +

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -335,18 +335,18 @@ cdef class _Material:
         c_nucpath = nucpath_bytes
         self.mat_pointer.write_hdf5(c_filename, c_datapath, c_nucpath, row, chunksize)
 
-    def phits(self, frac_type='mass'):
+    def phits(self, frac_type='mass', mult_den=True):
         """phits(frac_type)
         Return an phits card
         Parameters
         ----------
- 	   int 0 means use "mass" as the frac_type
+        int 0 means use "mass" as the frac_type
         """
         cdef std_string card
-        card = self.mat_pointer.phits(frac_type.encode())
+        card = self.mat_pointer.phits(frac_type.encode(), mult_den)
         return card.decode()
 
-    def mcnp(self, frac_type='mass'):
+    def mcnp(self, frac_type='mass', mult_den=True):
         """mcnp(frac_type)
         Return an mcnp card
         Parameters
@@ -354,9 +354,9 @@ cdef class _Material:
         int 0 means use "mass" as the frac_type
         """
         cdef std_string card
-        card = self.mat_pointer.mcnp(frac_type.encode())
+        card = self.mat_pointer.mcnp(frac_type.encode(), mult_den)
         return card.decode()
-    
+
     def get_uwuw_name(self):
         """get_uwuw_name()
         Return a uwuw material name

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -336,22 +336,32 @@ cdef class _Material:
         self.mat_pointer.write_hdf5(c_filename, c_datapath, c_nucpath, row, chunksize)
 
     def phits(self, frac_type='mass', mult_den=True):
-        """phits(frac_type)
+        """phits(frac_type='mass', mult_den=True)
         Return an phits card
         Parameters
         ----------
-        int 0 means use "mass" as the frac_type
+        frac_type : str, optional
+            Either 'mass' or 'atom'. Speficies whether mass or atom fractions
+            are used to describe material composition. (default 'mass')
+        mult_den : bool, optional
+            Flag for whether material cards are written in mass density if True,
+            or mass fraction if False. (default True)
         """
         cdef std_string card
         card = self.mat_pointer.phits(frac_type.encode(), mult_den)
         return card.decode()
 
     def mcnp(self, frac_type='mass', mult_den=True):
-        """mcnp(frac_type)
+        """mcnp(frac_type='mass', mult_den=True)
         Return an mcnp card
         Parameters
         ----------
-        int 0 means use "mass" as the frac_type
+        frac_type : str, optional
+            Either 'mass' or 'atom'. Speficies whether mass or atom fractions
+            are used to describe material composition. (default 'mass')
+        mult_den : bool, optional
+            Flag for whether material cards are written in mass density if True,
+            or mass fraction if False. (default True)
         """
         cdef std_string card
         card = self.mat_pointer.mcnp(frac_type.encode(), mult_den)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1471,7 +1471,7 @@ std::map<int, double> pyne::Material::get_density_frac(std::string frac_type, bo
   std::map<int, double> fracs;
 
   if ("atom" == frac_type) {
-    if (density != -1.0 && !mult_den) {
+    if (density != -1.0 && mult_den) {
       fracs = to_atom_dens();
       for (comp_iter ci = fracs.begin(); ci != fracs.end(); ci++){
         ci->second *= pyne::cm2_per_barn; // unit requirememt is [10^24 atoms/cm3] = [atoms/b.cm]
@@ -1481,7 +1481,7 @@ std::map<int, double> pyne::Material::get_density_frac(std::string frac_type, bo
     }
   } else {
     fracs = comp;
-    if (density != -1.0 && !mult_den) {
+    if (density != -1.0 && mult_den) {
       for (comp_iter ci = fracs.begin(); ci != fracs.end(); ci++){
         ci->second *= density;
       }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1471,7 +1471,7 @@ std::map<int, double> pyne::Material::get_density_frac(std::string frac_type, bo
   std::map<int, double> fracs;
 
   if ("atom" == frac_type) {
-    if (density != -1.0) {
+    if (density != -1.0 && !mult_den) {
       fracs = to_atom_dens();
       for (comp_iter ci = fracs.begin(); ci != fracs.end(); ci++){
         ci->second *= pyne::cm2_per_barn; // unit requirememt is [10^24 atoms/cm3] = [atoms/b.cm]
@@ -1481,11 +1481,9 @@ std::map<int, double> pyne::Material::get_density_frac(std::string frac_type, bo
     }
   } else {
     fracs = comp;
-    if (density != -1.0) {
+    if (density != -1.0 && !mult_den) {
       for (comp_iter ci = fracs.begin(); ci != fracs.end(); ci++){
-        if (mult_den) {
-          ci->second *= density;
-        }
+        ci->second *= density;
       }
     }
   }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -613,7 +613,7 @@ std::string pyne::Material::get_uwuw_name() {
 }
 
 ///---------------------------------------------------------------------------//
-std::string pyne::Material::mcnp(std::string frac_type) {
+std::string pyne::Material::mcnp(std::string frac_type, bool mult_den) {
   //////////////////// Begin card creation ///////////////////////
   std::ostringstream oss;
 
@@ -649,7 +649,7 @@ std::string pyne::Material::mcnp(std::string frac_type) {
   }
 
   // Set up atom or mass frac map
-  std::map<int, double> fracs = get_density_frac(frac_type);
+  std::map<int, double> fracs = get_density_frac(frac_type, mult_den);
   std::string frac_sign = "";
 
   // write the frac map
@@ -660,7 +660,7 @@ std::string pyne::Material::mcnp(std::string frac_type) {
 
 
 ///---------------------------------------------------------------------------//
-std::string pyne::Material::phits(std::string frac_type) {
+std::string pyne::Material::phits(std::string frac_type, bool mult_den) {
   //////////////////// Begin card creation ///////////////////////
   std::ostringstream oss;
 
@@ -699,7 +699,7 @@ std::string pyne::Material::phits(std::string frac_type) {
   }
 
   // Set up atom or mass frac map
-  std::map<int, double> fracs = get_density_frac(frac_type);
+  std::map<int, double> fracs = get_density_frac(frac_type, mult_den);
   std::string frac_sign = "";
 
   // write the frac map
@@ -1467,7 +1467,7 @@ pyne::Material pyne::Material::collapse_elements(int** int_ptr_arry ) {
 
   // Set up atom or mass frac map
 
-std::map<int, double> pyne::Material::get_density_frac(std::string frac_type){
+std::map<int, double> pyne::Material::get_density_frac(std::string frac_type, bool mult_den){
   std::map<int, double> fracs;
 
   if ("atom" == frac_type) {
@@ -1483,7 +1483,9 @@ std::map<int, double> pyne::Material::get_density_frac(std::string frac_type){
     fracs = comp;
     if (density != -1.0) {
       for (comp_iter ci = fracs.begin(); ci != fracs.end(); ci++){
-        ci->second *= density;
+        if (mult_den) {
+          ci->second *= density;
+        }
       }
     }
   }

--- a/src/material.h
+++ b/src/material.h
@@ -169,9 +169,9 @@ namespace pyne
     std::string openmc(std::string fact_type = "mass");
 
     /// Return an mcnp input deck record as a string
-    std::string mcnp(std::string frac_type = "mass");
+    std::string mcnp(std::string frac_type = "mass", bool mult_den = "true");
     /// Return an phits input deck record as a string
-    std::string phits(std::string frac_type = "mass");
+    std::string phits(std::string frac_type = "mass", bool mult_den = "true");
     /// return the compo fraction writen ala "mcnp"
     std::string mcnp_frac(std::map<int, double> fracs, std::string frac_type = "");
     ///
@@ -273,10 +273,10 @@ namespace pyne
     /// atoms per molecule (atoms_per_molecule) in this function using \a apm.
     double mass_density(double num_dens=-1.0, double apm=-1.0);
     // void print_material( pyne::Material test_mat);
-    /// Computes, sets, and returns the mass density when the material density is
-    /// definied otherwise return fraction. Fraction density is returned per atom 
+    /// Computes, sets, and returns the mass density if \a mult_den is true
+    /// otherwise return mass fraction. Fraction density is returned per atom
     /// (default) in atom per barn cm or as a mass density.
-    std::map<int, double> get_density_frac(std::string frac_type="atom");
+    std::map<int, double> get_density_frac(std::string frac_type="atom", bool mult_den);
     /// Computes and returns the number density of the material using the
     /// mass density if \a mass_dens is greater than or equal to zero.  If
     /// \a mass_dens is negative, the denisty member variable is used instead.

--- a/src/material.h
+++ b/src/material.h
@@ -169,9 +169,9 @@ namespace pyne
     std::string openmc(std::string fact_type = "mass");
 
     /// Return an mcnp input deck record as a string
-    std::string mcnp(std::string frac_type = "mass", bool mult_den = "true");
+    std::string mcnp(std::string frac_type = "mass", bool mult_den = true);
     /// Return an phits input deck record as a string
-    std::string phits(std::string frac_type = "mass", bool mult_den = "true");
+    std::string phits(std::string frac_type = "mass", bool mult_den = true);
     /// return the compo fraction writen ala "mcnp"
     std::string mcnp_frac(std::map<int, double> fracs, std::string frac_type = "");
     ///
@@ -276,7 +276,7 @@ namespace pyne
     /// Computes, sets, and returns the mass density if \a mult_den is true
     /// otherwise return mass fraction. Fraction density is returned per atom
     /// (default) in atom per barn cm or as a mass density.
-    std::map<int, double> get_density_frac(std::string frac_type="atom", bool mult_den);
+    std::map<int, double> get_density_frac(std::string frac_type="atom", bool mult_den=true);
     /// Computes and returns the number density of the material using the
     /// mass density if \a mass_dens is greater than or equal to zero.  If
     /// \a mass_dens is negative, the denisty member variable is used instead.

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1274,7 +1274,16 @@ def test_phits():
                 '     92235.15c -7.6400e-01\n'
                 '     92238.25c -1.8336e+01\n')
     assert_equal(mass, mass_exp)
-    
+
+    mass_frac = leu.phits(mult_den=False)
+    mass_frac_exp = ('C name: leu\n'
+                     'C comments: this is a long comment that will definitly go over the 80 character\n'
+                     'C  limit, for science\n'
+                     'M[ 2 ]\n'
+                     '     92235.15c -4.0000e-02\n'
+                     '     92238.25c -9.6000e-01\n')
+    assert_equal(mass_frac, mass_frac_exp)
+
     atom = leu.phits(frac_type='atom')
     atom_exp = ('C name: leu\n'
                 'C comments: this is a long comment that will definitly go over the 80 character\n'
@@ -1305,6 +1314,17 @@ def test_mcnp():
                 '     92235.15c -7.6400e-01\n'
                 '     92238.25c -1.8336e+01\n')
     assert_equal(mass, mass_exp)
+
+    mass_frac = leu.mcnp(mult_den=False)
+    mass_frac_exp = ('C name: leu\n'
+                     'C density = 19.10000\n'
+                     'C source: Some URL\n'
+                     'C comments: this is a long comment that will definitly go over the 80 character\n'
+                     'C  limit, for science\n'
+                     'm2\n'
+                     '     92235.15c -4.0000e-02\n'
+                     '     92238.25c -9.6000e-01\n')
+    assert_equal(mass_frac, mass_frac_exp)
 
     atom = leu.mcnp(frac_type='atom')
     atom_exp = ('C name: leu\n'

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1293,6 +1293,15 @@ def test_phits():
                 '     92238.25c 4.6386e-02\n')
     assert_equal(atom, atom_exp)
 
+    atom_frac = leu.phits(frac_type='atom', mult_den=False)
+    atom_frac_exp = ('C name: leu\n'
+                     'C comments: this is a long comment that will definitly go over the 80 character\n'
+                     'C  limit, for science\n'
+                     'M[ 2 ]\n'
+                     '     92235.15c 4.0491e-02\n'
+                     '     92238.25c 9.5951e-01\n')
+    assert_equal(atom_frac, atom_frac_exp)
+
 def test_mcnp():
 
     leu = Material(nucvec={'U235': 0.04, 'U238': 0.96},
@@ -1336,7 +1345,18 @@ def test_mcnp():
                 '     92235.15c 1.9575e-03\n'
                 '     92238.25c 4.6386e-02\n')
     assert_equal(atom, atom_exp)
-    
+
+    atom_frac = leu.mcnp(frac_type='atom', mult_den=False)
+    atom_frac_exp = ('C name: leu\n'
+                     'C density = 19.10000\n'
+                     'C source: Some URL\n'
+                     'C comments: this is a long comment that will definitly go over the 80 character\n'
+                     'C  limit, for science\n'
+                     'm2\n'
+                     '     92235.15c 4.0491e-02\n'
+                     '     92238.25c 9.5951e-01\n')
+    assert_equal(atom_frac, atom_frac_exp)
+
 def test_mcnp_mat0():
 
     leu = Material(nucvec={'U235': 0.04, 'U236': 0.0, 'U238': 0.96},


### PR DESCRIPTION
This PR adds a boolean argument `mult_den` to methods `get_density_frac` and therefore `mcnp`, `phits`, so that users can choose to write MCNP/PHITS material cards with either (1) mass density (default) or (2) mass fraction.