### PR TITLE
Attempt to add try/catch/skip to endf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,17 +214,6 @@ jobs:
         - run_test:
             flags: "python3"
             build: "python3_dagmc_pymoab_openmc"
-  # Test endf separately
-  endf_test:
-    executor:
-      name: py3_dagmc_pymoab_openmc
-    working_directory: ~/repo
-    steps:
-      - pull_container:
-          build: "python3_dagmc_pymoab_openmc"
-      - run: |
-          cd ~/repo/tests
-          nosetest test_endf.py --no-skip 
 
 # Python 2 jobs
 # without optional depedencies
@@ -338,9 +327,6 @@ workflows:
           requires:
             - py3_dagmc_pymoab_build
       - py3_dagmc_pymoab_openmc_test:
-          requires:
-            - py3_dagmc_pymoab_openmc_build
-      - endf_test:
           requires:
             - py3_dagmc_pymoab_openmc_build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
           build: "python3_dagmc_pymoab_openmc"
       - run: |
           cd ~/repo/tests
-          nosetests test_endf.py --no-skip 
+          nosetest test_endf.py --no-skip 
 
 # Python 2 jobs
 # without optional depedencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - pull_container:
-          build: "python3_dagmc_pymoab"
+          build: "python3_dagmc_pymoab_openmc"
       - run: |
           cd ~/repo/tests
           nosetests test_endf.py --no-skip 
@@ -339,6 +339,9 @@ workflows:
           requires:
             - py3_dagmc_pymoab_build
       - py3_dagmc_pymoab_openmc_test:
+          requires:
+            - py3_dagmc_pymoab_openmc_build
+      - endf_test:
           requires:
             - py3_dagmc_pymoab_openmc_build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ commands:
           cd ~/repo/tests
           ./travis-run-tests.sh << parameters.flags >>
 
+
   # Build and push PyNE website
   website_build_push:
     description: "build PyNE website and push it either on the test branch (default) or on the deployed branch"
@@ -214,6 +215,17 @@ jobs:
         - run_test:
             flags: "python3"
             build: "python3_dagmc_pymoab_openmc"
+  # Test endf separately
+  endf_test:
+    executor:
+      name: py3_dagmc_pymoab_openmc
+    working_directory: ~/repo
+    steps:
+      - pull_container:
+          build: "python3_dagmc_pymoab"
+      - run: |
+          cd ~/repo/tests
+          nosetests test_endf.py --no-skip 
 
 # Python 2 jobs
 # without optional depedencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,6 @@ commands:
           cd ~/repo/tests
           ./travis-run-tests.sh << parameters.flags >>
 
-
   # Build and push PyNE website
   website_build_push:
     description: "build PyNE website and push it either on the test branch (default) or on the deployed branch"

--- a/news/skip_endf.rst
+++ b/news/skip_endf.rst
@@ -1,6 +1,4 @@
-**Added:** 
-- added a test to cehck if endf test are skipped because website is not
-  reachable
+**Added:** None 
 
 **Changed:** 
 - now skips endf test when website is not reachable to allow completeness of

--- a/news/skip_endf.rst
+++ b/news/skip_endf.rst
@@ -1,0 +1,15 @@
+**Added:** 
+- added a test to cehck if endf test are skipped because website is not
+  reachable
+
+**Changed:** 
+- now skips endf test when website is not reachable to allow completeness of
+  the other tests.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Add try/catch/skip to endf tests that require some file from remote location.

Also force the endf test to run without skip to inform if those test have been skipped.