### PR TITLE
Fix ENDF parsing of TSL files using SCT for non-principal atoms

### DIFF
--- a/news/endf_read_sct.rst
+++ b/news/endf_read_sct.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:**
+  - Fix ENDF parsing of TSL files with short collision time approximation for non-principal atoms.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/endf.pyx
+++ b/pyne/endf.pyx
@@ -2027,7 +2027,7 @@ class Evaluation(object):
         #Read teff curves for non-principal atoms with SCT approximation indicated:
         for i in range(len(B)//6-1):
             if B[6*(i+1)]==0.0:
-                params, teff = _self._get_tab1_record()
+                params, teff = self._get_tab1_record()
                 inel['teff_%i'%(i+1)] = teff#Store as teff_1, teff_2, etc.
 
 

--- a/pyne/endf.pyx
+++ b/pyne/endf.pyx
@@ -2024,6 +2024,13 @@ class Evaluation(object):
         params, teff = self._get_tab1_record()
         inel['teff'] = teff
 
+        #Read teff curves for non-principal atoms with SCT approximation indicated:
+        for i in range(len(B)//6-1):
+            if B[6*(i+1)]==0.0:
+                params, teff = _self._get_tab1_record()
+                inel['teff_%i'%(i+1)] = teff#Store as teff_1, teff_2, etc.
+
+
     def _read_independent_yield(self):
         self._print_info(8, 454)
         iyield = self.fission['yield_independent']


### PR DESCRIPTION
Opening pull request as request on issue #1209 .
