### PR TITLE
Update decay half_life data 

### DIFF
--- a/news/update_decay_half_life_data.rst
+++ b/news/update_decay_half_life_data.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+* Missing elements name_to_zz dictionary
+
+**Changed:**
+
+* ENSDF database link to 2019 Oct 4th database
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/pyne/dbgen/decay.py
+++ b/pyne/dbgen/decay.py
@@ -110,12 +110,12 @@ def grab_ensdf_decay(build_dir=""):
         pass
 
     # Grab ENSDF files and unzip them.
-    iaea_base_url = 'http://www.nndc.bnl.gov/ensarchivals/distributions/dist17/'
+    iaea_base_url = 'http://www.nndc.bnl.gov/ensarchivals/distributions/dist19/'
 
     cf_base_url = 'http://data.pyne.io/'
-    ensdf_zip = ['ensdf_170501.099.zip',
-                 'ensdf_170501_199.zip',
-                 'ensdf_170501_299.zip', ]
+    ensdf_zip = ['ensdf_191004_099.zip',
+                 'ensdf_191004_199.zip',
+                 'ensdf_191004_300.zip', ]
 
     for f in ensdf_zip:
         fpath = os.path.join(build_dir, f)

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -127,6 +127,10 @@ pyne::nucname::name_zz_t pyne::nucname::get_name_zz() {
   lzd["Cn"] = 112;
   lzd["Fl"] = 114;
   lzd["Lv"] = 116;
+  lzd["Nh"] = 113;
+  lzd["Mc"] = 115;
+  lzd["Ts"] = 117;
+  lzd["Og"] = 118;
 
   return lzd;
 }


### PR DESCRIPTION
Updates decay half-life data to 2019 Oct 4th database. (Fixes issue #1206 )
 - Added missing element to name_zz dictionary
 - Updated database link

I've tested the change using: `nuc_data_make --fetch-prebuilt n`
The decay table is created without issues.