### PR TITLE
Resolved compatibility issue with HDF5 version 1.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,15 @@ set(LIBS ${LIBS} ${HDF5_C_LIBRARIES})
 MESSAGE("--    HDF5 Include directory: ${HDF5_INCLUDE_DIRS}")
 MESSAGE("--    HDF5 Library directories: ${HDF5_LIBRARY_DIRS}")
 MESSAGE("--    HDF5 Libraries: ${HDF5_C_LIBRARIES}")
+MESSAGE("--    HDF5 library version: ${HDF5_VERSION}")
 
+# Version 1.12 of HDF5 deprecates the H5Oget_info_by_idx(), 
+# H5O_info_t() and H5Oget_info_by_name() interfaces.
+# Thus, we give these flags to allow usage of the old interface in newer
+# versions of HDF5.
+if(NOT (${HDF5_VERSION} VERSION_LESS 1.12.0))
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DH5Oget_info_by_idx_vers=1 -DH5O_info_t_vers=1 -DH5Oget_info_by_name_vers=1")
+endif()
 
 # Look for MOAB if requested
 if(WITH_MOAB)

--- a/news/support_hdf5_new_interface.rst
+++ b/news/support_hdf5_new_interface.rst
@@ -1,0 +1,15 @@
+**Added:**
+
+* Add support for new function interfaces in HDF5 version 1.12.0
+
+**Changed:** 
+
+* CMakeLists.txt: added compiler macros acting as HDF5 internal compatibility flags
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
The latest HDF5 release (version 1.12.0) changed interfaces for several functions, including but not limited to: H5Oget_info_by_name(), H5Oget_info_by_idx(), and H5O_info_t(). The purpose of this fix is to maintain compatibility with legacy HDF5, by making use of HDF5 internal compatibility flags defined as compiler macros in the CMakelists.txt.