### PR TITLE
allowing Material almagamation without decay

### DIFF
--- a/news/no_decay_mat_amalgamate.rst
+++ b/news/no_decay_mat_amalgamate.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:**
+- added DEFINE variable to allow material.cpp amalgamation without decay.cpp
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/decaygen.py
+++ b/src/decaygen.py
@@ -43,6 +43,7 @@ HEADER = ENV.from_string("""
 #{{ dummy_ifdef }} PYNE_DECAY_IS_DUMMY
 #ifndef PYNE_GEUP5PGEJBFGNHGI36TRBB4WGM
 #define PYNE_GEUP5PGEJBFGNHGI36TRBB4WGM
+#define PYNE_DECAY
 
 {{ autogenwarn }}
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -2089,3 +2089,4 @@ bool pyne::detect_nuclidelist(hid_t data_set, std::string& nucpath){
   H5Tclose(nuc_attr);
   return true;
 }
+

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -175,7 +175,8 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath,
   //
   std::string attrpath = datapath + "_metadata";
   bool attrpath_exists = h5wrap::path_exists(db, attrpath);
-  if (!attrpath_exists) return;
+  if (!attrpath_exists)
+    return;
 
   hid_t metadatapace, attrtype, metadataet, metadatalab, attrmemspace;
   int attrrank;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -45,9 +45,6 @@ void pyne::Material::norm_comp() {
 
 
 void pyne::Material::_load_comp_protocol0(hid_t db, std::string datapath, int row) {
-  // Clear current content
-  comp.clear();
-  
   hid_t matgroup = H5Gopen2(db, datapath.c_str(), H5P_DEFAULT);
   hid_t nucset;
   double nucvalue;
@@ -102,9 +99,6 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath,
 
 void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath,
                                           std::string nucpath, int row) {
-  // Clear current content
-  comp.clear();
-  
   if (!h5wrap::path_exists(db, nucpath))
     throw std::runtime_error("No path found at the location: " + nucpath);
 
@@ -1889,7 +1883,7 @@ std::map<int, double> pyne::Material::to_atom_dens() {
   return atom_dens;
 }
 
-#ifdef PYNE_DECAY
+
 std::vector<std::pair<double, double> > pyne::Material::gammas() {
   std::vector<std::pair<double, double> > result;
   std::map<int, double> atom_fracs = this->to_atom_frac();
@@ -1956,13 +1950,7 @@ std::vector<std::pair<double, double> > pyne::Material::normalize_radioactivity(
   }
   return normed;
 }
-pyne::Material pyne::Material::decay(double t) {
-  Material rtn;
-  comp_map out = pyne::decayers::decay(to_atom_frac(), t);
-  rtn.from_atom_frac(out);
-  rtn.mass = mass * rtn.molecular_mass() / molecular_mass();
-  return rtn;
-}
+
 
 pyne::Material pyne::Material::cram(std::vector<double> A,
                                     const int order) {
@@ -2029,6 +2017,15 @@ pyne::comp_map pyne::Material::dose_per_g(std::string dose_type, int source) {
   return dose;
 }
 
+
+#ifdef PYNE_DECAY
+pyne::Material pyne::Material::decay(double t) {
+  Material rtn;
+  comp_map out = pyne::decayers::decay(to_atom_frac(), t);
+  rtn.from_atom_frac(out);
+  rtn.mass = mass * rtn.molecular_mass() / molecular_mass();
+  return rtn;
+}
 #endif
 
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -90,7 +90,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath,
   hid_t data_set = H5Dopen2(db, datapath.c_str(), H5P_DEFAULT);
 
   // Grab the nucpath
-  If (detect_nuclidelist(data_set, nucpath)){
+  if (detect_nuclidelist(data_set, nucpath)){
     H5Dclose(data_set);
     _load_comp_protocol1(db, datapath, nucpath, row);
   } else {
@@ -2029,7 +2029,7 @@ pyne::comp_map pyne::Material::dose_per_g(std::string dose_type, int source) {
   return dose;
 }
 
-#endif
+#endif  PYNE_DECAY
 
 
 pyne::Material pyne::Material::operator+ (double y) {
@@ -2092,4 +2092,3 @@ bool pyne::detect_nuclidelist(hid_t data_set, std::string& nucpath){
   H5Tclose(nuc_attr);
   return true;
 }
-

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -2009,15 +2009,6 @@ std::vector<std::pair<double, double> > pyne::Material::normalize_radioactivity(
 }
 
 
-pyne::Material pyne::Material::cram(std::vector<double> A,
-                                    const int order) {
-  Material rtn;
-  rtn.from_atom_frac(pyne::transmuters::cram(A, to_atom_frac(), order));
-  rtn.mass = mass * rtn.molecular_mass() / molecular_mass();
-  return rtn;
-}
-
-
 #ifdef PYNE_DECAY
 pyne::Material pyne::Material::decay(double t) {
   Material rtn;
@@ -2027,6 +2018,15 @@ pyne::Material pyne::Material::decay(double t) {
   return rtn;
 }
 #endif //  PYNE_DECAY
+
+
+pyne::Material pyne::Material::cram(std::vector<double> A,
+                                    const int order) {
+  Material rtn;
+  rtn.from_atom_frac(pyne::transmuters::cram(A, to_atom_frac(), order));
+  rtn.mass = mass * rtn.molecular_mass() / molecular_mass();
+  return rtn;
+}
 
 
 pyne::Material pyne::Material::operator+ (double y) {

--- a/src/material.h
+++ b/src/material.h
@@ -322,6 +322,9 @@ namespace pyne
     /// If \a apm and atoms_per_molecule on this instance are both negative, then the best
     /// guess value calculated from the normailized composition is used here.
     double molecular_mass(double apm=-1.0);
+    /// Calculates the activity of a material based on the composition and each
+    /// nuclide's mass, decay_const, and atmoic_mass.
+    comp_map activity();
     /// Calculates the decay heat of a material based on the composition and
     /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
     /// input mass of grams. Return values is in megawatts.
@@ -420,9 +423,6 @@ namespace pyne
     /// Returns a mapping of the nuclides in this material to their atom densities.
     /// This calculation is based off of the material's density.
     std::map<int, double> to_atom_dens();
-    /// Calculates the activity of a material based on the composition and each
-    /// nuclide's mass, decay_const, and atmoic_mass.
-    comp_map activity();
     // Radioactive Material functions
     /// Returns a list of gamma-rays energies in keV and intensities in
     /// decays/s/atom material unnormalized

--- a/src/material.h
+++ b/src/material.h
@@ -321,23 +321,6 @@ namespace pyne
     /// If \a apm and atoms_per_molecule on this instance are both negative, then the best
     /// guess value calculated from the normailized composition is used here.
     double molecular_mass(double apm=-1.0);
-    /// Calculates the activity of a material based on the composition and each
-    /// nuclide's mass, decay_const, and atmoic_mass.
-    comp_map activity();
-    /// Calculates the decay heat of a material based on the composition and
-    /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
-    /// input mass of grams. Return values is in megawatts.
-    comp_map decay_heat();
-    /// Caclulates the dose per gram using the composition of the the
-    /// material, the dose type desired, and the source for dose factors
-    ///   dose_type is one of:
-    ///     ext_air -- returns mrem/h per g per m^3
-    ///     ext_soil -- returns mrem/h per g per m^2
-    ///     ingest -- returns mrem per g
-    ///     inhale -- returns mrem per g
-    ///   source is:
-    ///     {EPA=0, DOE=1, GENII=2}, default is EPA
-    comp_map dose_per_g(std::string dose_type, int source=0);
     /// Returns a copy of the current material where all natural elements in the
     /// composition are expanded to their natural isotopic abundances.
     Material expand_elements(std::set<int> exception_ids);
@@ -422,7 +405,24 @@ namespace pyne
     /// Returns a mapping of the nuclides in this material to their atom densities.
     /// This calculation is based off of the material's density.
     std::map<int, double> to_atom_dens();
-
+#ifdef PYNE_DECAY
+    /// Calculates the activity of a material based on the composition and each
+    /// nuclide's mass, decay_const, and atmoic_mass.
+    comp_map activity();
+    /// Calculates the decay heat of a material based on the composition and
+    /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
+    /// input mass of grams. Return values is in megawatts.
+    comp_map decay_heat();
+    /// Caclulates the dose per gram using the composition of the the
+    /// material, the dose type desired, and the source for dose factors
+    ///   dose_type is one of:
+    ///     ext_air -- returns mrem/h per g per m^3
+    ///     ext_soil -- returns mrem/h per g per m^2
+    ///     ingest -- returns mrem per g
+    ///     inhale -- returns mrem per g
+    ///   source is:
+    ///     {EPA=0, DOE=1, GENII=2}, default is EPA
+    comp_map dose_per_g(std::string dose_type, int source=0);
     // Radioactive Material functions
     /// Returns a list of gamma-rays energies in keV and intensities in
     /// decays/s/atom material unnormalized
@@ -440,7 +440,7 @@ namespace pyne
 
     /// Decays this material for a given amount of time in seconds
     Material decay(double t);
-
+#endif
     /// Transmutes the material via the CRAM method.
     /// \param A The transmutation matrix [unitless]
     /// \param order The CRAM approximation order (default 14).

--- a/src/material.h
+++ b/src/material.h
@@ -22,6 +22,7 @@
 #endif
 
 #ifndef PYNE_IS_AMALGAMATED
+  #define PYNE_DECAY
 #include "json-forwards.h"
 #include "json.h"
 #include "h5wrap.h"

--- a/src/material.h
+++ b/src/material.h
@@ -322,6 +322,20 @@ namespace pyne
     /// If \a apm and atoms_per_molecule on this instance are both negative, then the best
     /// guess value calculated from the normailized composition is used here.
     double molecular_mass(double apm=-1.0);
+    /// Calculates the decay heat of a material based on the composition and
+    /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
+    /// input mass of grams. Return values is in megawatts.
+    comp_map decay_heat();
+    /// Caclulates the dose per gram using the composition of the the
+    /// material, the dose type desired, and the source for dose factors
+    ///   dose_type is one of:
+    ///     ext_air -- returns mrem/h per g per m^3
+    ///     ext_soil -- returns mrem/h per g per m^2
+    ///     ingest -- returns mrem per g
+    ///     inhale -- returns mrem per g
+    ///   source is:
+    ///     {EPA=0, DOE=1, GENII=2}, default is EPA
+    comp_map dose_per_g(std::string dose_type, int source=0);
     /// Returns a copy of the current material where all natural elements in the
     /// composition are expanded to their natural isotopic abundances.
     Material expand_elements(std::set<int> exception_ids);
@@ -409,20 +423,6 @@ namespace pyne
     /// Calculates the activity of a material based on the composition and each
     /// nuclide's mass, decay_const, and atmoic_mass.
     comp_map activity();
-    /// Calculates the decay heat of a material based on the composition and
-    /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
-    /// input mass of grams. Return values is in megawatts.
-    comp_map decay_heat();
-    /// Caclulates the dose per gram using the composition of the the
-    /// material, the dose type desired, and the source for dose factors
-    ///   dose_type is one of:
-    ///     ext_air -- returns mrem/h per g per m^3
-    ///     ext_soil -- returns mrem/h per g per m^2
-    ///     ingest -- returns mrem per g
-    ///     inhale -- returns mrem per g
-    ///   source is:
-    ///     {EPA=0, DOE=1, GENII=2}, default is EPA
-    comp_map dose_per_g(std::string dose_type, int source=0);
     // Radioactive Material functions
     /// Returns a list of gamma-rays energies in keV and intensities in
     /// decays/s/atom material unnormalized

--- a/src/material.h
+++ b/src/material.h
@@ -423,7 +423,7 @@ namespace pyne
     /// Returns a mapping of the nuclides in this material to their atom densities.
     /// This calculation is based off of the material's density.
     std::map<int, double> to_atom_dens();
- 
+
     // Radioactive Material functions
     /// Returns a list of gamma-rays energies in keV and intensities in
     /// decays/s/atom material unnormalized
@@ -443,7 +443,7 @@ namespace pyne
     /// Decays this material for a given amount of time in seconds
     Material decay(double t);
 #endif // PYNE_DECAY
-    
+
     /// Transmutes the material via the CRAM method.
     /// \param A The transmutation matrix [unitless]
     /// \param order The CRAM approximation order (default 14).

--- a/src/material.h
+++ b/src/material.h
@@ -406,7 +406,6 @@ namespace pyne
     /// Returns a mapping of the nuclides in this material to their atom densities.
     /// This calculation is based off of the material's density.
     std::map<int, double> to_atom_dens();
-#ifdef PYNE_DECAY
     /// Calculates the activity of a material based on the composition and each
     /// nuclide's mass, decay_const, and atmoic_mass.
     comp_map activity();
@@ -439,6 +438,7 @@ namespace pyne
     std::vector<std::pair<double, double> > normalize_radioactivity(
       std::vector<std::pair<double, double> > unnormed);
 
+#ifdef PYNE_DECAY
     /// Decays this material for a given amount of time in seconds
     Material decay(double t);
 #endif

--- a/src/material.h
+++ b/src/material.h
@@ -423,7 +423,7 @@ namespace pyne
     /// Returns a mapping of the nuclides in this material to their atom densities.
     /// This calculation is based off of the material's density.
     std::map<int, double> to_atom_dens();
-    
+ 
     // Radioactive Material functions
     /// Returns a list of gamma-rays energies in keV and intensities in
     /// decays/s/atom material unnormalized

--- a/src/material.h
+++ b/src/material.h
@@ -423,6 +423,7 @@ namespace pyne
     /// Returns a mapping of the nuclides in this material to their atom densities.
     /// This calculation is based off of the material's density.
     std::map<int, double> to_atom_dens();
+    
     // Radioactive Material functions
     /// Returns a list of gamma-rays energies in keV and intensities in
     /// decays/s/atom material unnormalized


### PR DESCRIPTION
- Defines a PYNE_DECAY variable to detect if `decay.ccp` is part of amalgamation

- Regroups Material methods in `materials.cpp` & `material.h` to "disable" them is decay.h is not part of the amalgamated `PyNE`

- additional clean fix (clearing the comp when loading a new composition) -- I can do a separate PR for this, if you'd like