### PR TITLE
Turn off BLAS/LAPACK and FORTRAN in MOAB build

### DIFF
--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -122,7 +122,9 @@ RUN if [ "$build_dagmc" = "YES" ]; then \
         && cmake .. -DMOAB_DIR=$HOME/opt/moab \
                  -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
         && make \
-        && make install ; \
+        && make install \
+        && cd ../.. \
+        && rm -rf DAGMC;
     fi
 
 ARG build_pyne=YES

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -26,7 +26,6 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             python${PY_SUFIX}-tables \
             python${PY_SUFIX}-scipy \
             python${PY_SUFIX}-jinja2 \
-            gfortran \
             git \
             cmake \
             gfortran \

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -32,6 +32,7 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             vim emacs \
             libblas-dev \
             liblapack-dev \
+            libeigen3-dev \
             libhdf5-dev \
             libhdf5-serial-dev \
             autoconf \
@@ -85,6 +86,8 @@ RUN if [ "$build_moab" = "YES" ] || [ "$enable_pymoab" = "YES" ] ; then \
               -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
               -DENABLE_HDF5=ON \
               -DBUILD_SHARED_LIBS=OFF \
+              -DENABLE_BLASLAPACK=OFF \
+              -DENABLE_FORTRAN=OFF \
         && make -j 3 \
         && make install \
       # build/install shared lib
@@ -93,6 +96,8 @@ RUN if [ "$build_moab" = "YES" ] || [ "$enable_pymoab" = "YES" ] ; then \
               -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
               -DENABLE_HDF5=ON \
               -DBUILD_SHARED_LIBS=ON \
+              -DENABLE_BLASLAPACK=OFF \
+              -DENABLE_FORTRAN=OFF \
         && make -j 3 \
         && make install \
         && cd .. \

--- a/news/moab_no_blas.rst
+++ b/news/moab_no_blas.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** 
+* turn off BLAS/LAPACK & FORTRAN in MOAB build
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Turns off blas/lapack and FORTRAN from MOAB build.

Adds Eigen3 in apt-get to enable this.

Leaves BLAS/LAPACK in apt-get for DAGMC build.