### PR TITLE
Fix ostringstream compiler issue

### DIFF
--- a/news/fix_ostringstream_compiler_issue.rst
+++ b/news/fix_ostringstream_compiler_issue.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* change return type of method to avoid compiler compatibility issue
+
+**Security:** None

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -847,7 +847,7 @@ std::string pyne::Material::mcnp(std::string frac_type, bool mult_den) {
   // Metadata comments
   if (metadata.isMember("comments")) {
     std::string comment_string = "comments: " + metadata["comments"].asString();
-    oss << pyne::comment_line_wrapping(comment_string, comment_prefix, mcnp_line_length).str();
+    oss << pyne::comment_line_wrapping(comment_string, comment_prefix, mcnp_line_length);
   }
 
   // Metadata mat_num
@@ -884,7 +884,7 @@ std::string pyne::Material::phits(std::string frac_type, bool mult_den) {
   // Metadata comments
   if (metadata.isMember("comments")) {
     std::string comment_string = "comments: " + metadata["comments"].asString();
-    oss << pyne::comment_line_wrapping(comment_string, comment_prefix, mcnp_line_length).str();
+    oss << pyne::comment_line_wrapping(comment_string, comment_prefix, mcnp_line_length);
   }
 
   // Metadata mat_num

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -164,7 +164,7 @@ std::string pyne::to_lower(std::string s) {
   return s;
 }
 
-std::ostringstream pyne::comment_line_wrapping(std::string line,
+std::string pyne::comment_line_wrapping(std::string line,
                                                std::string comment_prefix,
                                                int line_length) {
   std::ostringstream oss;
@@ -181,7 +181,7 @@ std::ostringstream pyne::comment_line_wrapping(std::string line,
     oss << comment_prefix << line << std::endl;
   }
 
-  return oss;
+  return oss.str();
 }
 
 std::string pyne::capitalize(std::string s) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -90,7 +90,7 @@ namespace pyne {
   std::string capitalize(std::string s);
 
   /// Forms and returns the wrapped lines with a lenght up to line_lenght.
-  std::ostringstream comment_line_wrapping(std::string line, std::string comment_prefix = "",
+  std::string comment_line_wrapping(std::string line, std::string comment_prefix = "",
                                            int line_length = 79);
 
   /// Finds and returns the first white-space delimited token of a line.


### PR DESCRIPTION
Per guidance from StackOverflow: https://stackoverflow.com/questions/50926506/deleted-function-std-basic-stringstream-in-linux-with-g

With some versions of G++ it is not possible to return stringstreams because the move constructor has not been defined.

The only use cases of this method immediately extracted the string using the `str()` method anyway, so it was changed to just return the string.

Should resolve #1236 