### PR TITLE
update tutorial to remove pytaps references

### DIFF
--- a/news/update-ipynb-pymoab.rst
+++ b/news/update-ipynb-pymoab.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** None
+Updated jupyter notebook intro to use PyMOAB rather than PyTAPS calls.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tutorial/00-intro.ipynb
+++ b/tutorial/00-intro.ipynb
@@ -125,7 +125,7 @@
       "fuel = material.from_atom_frac({'U235': 0.045, 'U238': 0.955, 'O16': 2.0}, mass=1.0, density=10.7)\n",
       "cool = material.from_atom_frac({'H1': 2.0, 'O16': 1.0}, mass=1.0, density=1.0)\n",
       "for i, mat, ve in m:\n",
-      "    coord = m.mesh.getVtxCoords(ve)\n",
+      "    coord = m.mesh.get_coords(ve)\n",
       "    m.mats[i] = fuel if (coord[0]**2 + coord[1]**2) <= 0.5**2 else cool\n",
       "\n",
       "# create a total cross section tag on the mesh\n",


### PR DESCRIPTION
This fixes one line in the intro tutorial to properly call the pyMOAB function rather than the pytaps function.