### PR TITLE
Change the news test to a changelog test

### DIFF
--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-# folder to look for addition
-folder=$1
 
 # default main repo setup
 master_repo="https://github.com/pyne/pyne.git"
@@ -8,18 +6,18 @@ default_branch="develop"
 
 
 # setup temp remote 
-git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
+git_remote_name=ci_changelog_`git log --pretty=format:'%h' -n 1`
 git remote add ${git_remote_name} ${master_repo}
 git fetch ${git_remote_name}
 
 # diff against temp remote
-added_news_file=$((`git diff ${git_remote_name}/${default_branch} --name-only $folder |wc -l`))
+added_changelog_entry=$((`git diff ${git_remote_name}/${default_branch} -- CHANGELOG.rst |wc -l`))
 
 # cleaning temp remote
 git remote remove ${git_remote_name}
 
 
 # analysing the diff and returning accordingly
-if [ $added_news_file -eq 0 ]; then
+if [ $added_changelog_entry -eq 0 ]; then
     exit 1
 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,15 +138,15 @@ commands:
 # Define the different job that will be ran this separate building form
 # testing for each configuration allowing to get more information out of the CI
 jobs:
-# news file checker
-  news_update:
+# CHANGELOG file checker
+  changelog_update:
     executor: 
       name: py3
     working_directory: ~/repo
     steps:
       - checkout
       - run:
-          name: Checking News Update
+          name: Checking CHANGELOG Update
           command: circleci/changelog_test.sh
  
 # Python 3 jobs
@@ -317,7 +317,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - news_update:
+      - changelog_update:
           filters:
             branches:
               ignore: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - checkout
       - run:
           name: Checking News Update
-          command: news/news_test.sh news
+          command: circleci/changelog_test.sh
  
 # Python 3 jobs
   py3_build:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -179,7 +179,7 @@ v0.7.0 RC2
     instead of "C++ & Fortran API Documentation"
     
 * Improvements in building and testing
-  * require contributor to provide news file
+  * require contributor to change CHANGELOG 
   * Expand testing matrix to include:
      * python 2 vs 2
      * with vs without PyMOAB


### PR DESCRIPTION
This changes the strategy for news updates to requires developers to make a change to the CHANGELOG file.

These changes should be reviewed as part of the PR.