### PR TITLE
Flip QA paradigm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ v0.7.0 RC2
 
 **Enhancements to Previous Capabilities**
 
+* Turn off QA warnings by default and enable with env variable 'PYNE_QA_WARN' (#1268)
 * Enhancements of Material and MaterialLibrary capabilities
    * A C++ API for the MaterialLibrary class has been created for direct
      use in compiled software tools

--- a/docs/devsguide/style_guide.rst
+++ b/docs/devsguide/style_guide.rst
@@ -97,7 +97,7 @@ Expectations
 * The *only* exceptions to not having tests and documentation are when merging in and
   slowly integrating legacy code or code not originally originally written for pyne.
 * Without both tests and documentation, the code must be marked as experimental.
-  It should issue a ``pyne.utils.QAWarning``.
+  It should invoke ``pyne.utils.QA_warn()``.
 * Have *extreme* empathy for your users.
 * Be selfish. Since you will be writing tests you will be your first user.
 * Nothing says "I <3 PyNE" quite like an ASCII art dragon.

--- a/pyne/_argparse.py
+++ b/pyne/_argparse.py
@@ -86,12 +86,11 @@ import os as _os
 import re as _re
 import sys as _sys
 import textwrap as _textwrap
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 from gettext import gettext as _
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 try:
     set

--- a/pyne/ace.pyx
+++ b/pyne/ace.pyx
@@ -20,7 +20,7 @@ from __future__ import division, unicode_literals
 import io
 import struct
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     from collections.abc import OrderedDict
@@ -39,7 +39,7 @@ from pyne.rxname import label
 from pyne._utils import fromstring_split, fromstring_token
 cdef bint NP_LE_V15 = int(np.__version__.split('.')[1]) <= 5 and np.__version__.startswith('1')
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def ascii_to_binary(ascii_file, binary_file):
     """Convert an ACE file in ASCII format (type 1) to binary format (type 2).

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -30,7 +30,7 @@ if HAVE_PYMOAB:
     from pyne.mesh import mesh_iterate
 else:
     warn("The PyMOAB optional dependency could not be imported. "
-         "Some aspects of the mesh module may be incomplete.", QAWarning)
+         "Some aspects of the mesh module may be incomplete.", ImportWarning)
 
 response_strings = {'decay_heat': 'Total Decay Heat',
                     'specific_activity': 'Specific Activity',

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -14,18 +14,17 @@ try:
 except AttributeError:
     collectionsAbc = collections
 from warnings import warn
-from pyne.utils import QAWarning, to_sec, str_to_unicode
+from pyne.utils import QA_warn, to_sec, str_to_unicode
 import numpy as np
 import tables as tb
 from io import open
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 try:
     basestring
 except NameError:
     basestring = str
-
 
 if HAVE_PYMOAB:
     from pyne.mesh import mesh_iterate

--- a/pyne/apigen/enrich_multi_sym.py
+++ b/pyne/apigen/enrich_multi_sym.py
@@ -9,8 +9,7 @@ import os
 import logging
 import multiprocessing
 import time
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 from sympy import Symbol, pprint, latex, diff, count_ops, simplify, cse, Eq, Q, \
     log, logcombine, Abs, exp, sqrt, series, separate, powsimp, collect, expand, Abs
@@ -19,7 +18,7 @@ from sympy.utilities.iterables import numbered_symbols
 
 from utils import cse_to_c
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 NPROCS = 10
 

--- a/pyne/apigen/main.py
+++ b/pyne/apigen/main.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
 import argparse
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def main():
     parser = argparse.ArgumentParser("Generates PyNE API")

--- a/pyne/apigen/utils.py
+++ b/pyne/apigen/utils.py
@@ -1,11 +1,10 @@
 """Utility functions for pyne.apigen"""
 import re
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 from sympy.utilities.codegen import codegen
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def cse_to_c(replacements, reduced_exprs, indent=2, debug=False):
     """Converts the return value sympy.cse() to a single C code snippet.

--- a/pyne/binaryreader.py
+++ b/pyne/binaryreader.py
@@ -5,15 +5,15 @@ Fortran formatted records.
 
 """
 import struct
+
 try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
 
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 class _FortranRecord(object):
     """A single Fortran formatted record.

--- a/pyne/bins.pyx
+++ b/pyne/bins.pyx
@@ -1,5 +1,4 @@
 """Tools to generate and handle various binning structures."""
-from warnings import warn
 
 cimport cython
 
@@ -7,9 +6,9 @@ cimport numpy as np
 import numpy as np
 from numpy import logspace
 
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def ninespace(start, stop, num=50, endpoint=True):
     """Splits the range into one-minus-log-uniform bins defined by num points.

--- a/pyne/cccc.py
+++ b/pyne/cccc.py
@@ -32,10 +32,10 @@ from __future__ import division
 from warnings import warn
 import numpy as np
 
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 from pyne.binaryreader import _BinaryReader, _FortranRecord
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 class Isotxs(_BinaryReader):

--- a/pyne/cccc.py
+++ b/pyne/cccc.py
@@ -673,7 +673,7 @@ class Rtflux(object):
         else:
             warn("The PyMOAB optional dependency could not be imported. "
                  "All aspects of the partisn module are not imported.",
-                 QAWarning)
+                 ImportWarning)
 
         if not m.structured:
             raise ValueError("Only structured mesh is supported.")

--- a/pyne/cli/tape9.py
+++ b/pyne/cli/tape9.py
@@ -5,8 +5,7 @@ import os
 import sys
 import argparse
 from glob import glob
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 
@@ -19,7 +18,7 @@ from pyne.xs.data_source import EAFDataSource, SimpleDataSource, NullDataSource
 from pyne.dbgen.api import build_dir
 from pyne.dbgen.decay import grab_ensdf_decay
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def parse_ensdf(files):
     """Parses a list of ensdf files for origen."""

--- a/pyne/dagmc.pyx
+++ b/pyne/dagmc.pyx
@@ -29,7 +29,7 @@ from pymoab import core as mb_core, types
 if not HAVE_PYMOAB:
     warn("The PyMOAB optional dependency could not be imported. "
          "Some aspects of dagmc module may be incomplete",
-         QAWarning)
+         ImportWarning)
 
 # Globals
 VOL_FRAC_TOLERANCE = 1E-10 # The maximum volume fraction to be considered valid

--- a/pyne/dagmc.pyx
+++ b/pyne/dagmc.pyx
@@ -4,7 +4,7 @@ from __future__ import print_function, division, unicode_literals
 import sys
 from contextlib import contextmanager
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 cimport numpy as np
 import numpy as np
@@ -17,7 +17,7 @@ from pyne.material_library import MaterialLibrary
 
 np.import_array()
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 if sys.version_info[0] >= 3:
     unichr = chr

--- a/pyne/data.pyx
+++ b/pyne/data.pyx
@@ -13,8 +13,7 @@ from libcpp.utility cimport pair as cpp_pair
 #from cython cimport pointer
 
 #Standard lib import
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 cimport numpy as np
 import numpy as np
@@ -34,7 +33,7 @@ cimport cpp_data
 cimport pyne.stlcontainers as conv
 import pyne.stlcontainers as conv
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Mathematical constants
 pi = cpp_data.pi

--- a/pyne/dbgen/atomic_mass.py
+++ b/pyne/dbgen/atomic_mass.py
@@ -3,8 +3,7 @@ from __future__ import print_function
 import os
 import re
 import pkgutil
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 import tables as tb
@@ -13,7 +12,7 @@ from pyne import nucname
 from pyne.dbgen.api import BASIC_FILTERS
 from pyne.dbgen.isotopic_abundance import get_isotopic_abundances
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Note that since ground state and meta-stable isotopes are of the same atomic mass,
 # the meta-stables have been discluded from the following data sets.

--- a/pyne/dbgen/cinder.py
+++ b/pyne/dbgen/cinder.py
@@ -7,8 +7,7 @@ import re
 import sys
 import shutil
 from glob import glob
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 import tables as tb
@@ -20,7 +19,7 @@ from .api import BASIC_FILTERS
 if sys.version_info[0] > 2:
     basestring = str
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 def grab_cinder_dat(build_dir="", datapath=''):

--- a/pyne/dbgen/decay.py
+++ b/pyne/dbgen/decay.py
@@ -4,6 +4,8 @@ import os
 import glob
 import shutil
 from zipfile import ZipFile
+from pyne.utils import QA_warn
+
 try:
     import urllib.request as urllib
 except ImportError:
@@ -15,6 +17,8 @@ import tables as tb
 
 from pyne import ensdf
 from pyne.dbgen.api import BASIC_FILTERS
+
+QA_warn(__name__)
 
 
 def _readpoint(line, dstart, dlen):

--- a/pyne/dbgen/eaf.py
+++ b/pyne/dbgen/eaf.py
@@ -5,8 +5,7 @@ the IAEA.
 from __future__ import print_function
 import re
 import os
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib
@@ -20,7 +19,7 @@ import tables as tb
 from .. import nucname
 from .api import BASIC_FILTERS
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def grab_eaf_data(build_dir=""):
     """Grabs the EAF activation data files

--- a/pyne/dbgen/hashtools.py
+++ b/pyne/dbgen/hashtools.py
@@ -2,15 +2,14 @@
 Tools to generate, set and check the hashes of datasets in pyne.
 """
 import hashlib
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy
 import tables
 
 from .. import data
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # list of nodes from distinct data sets
 nodelist = ['/atomic_mass', '/material_library',

--- a/pyne/dbgen/isotopic_abundance.py
+++ b/pyne/dbgen/isotopic_abundance.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 from __future__ import print_function
 import pkgutil
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 def get_isotopic_abundances():

--- a/pyne/dbgen/kaeri.py
+++ b/pyne/dbgen/kaeri.py
@@ -2,8 +2,7 @@ from __future__ import print_function
 import os
 import re
 import sys
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib2
@@ -14,7 +13,7 @@ except ImportError:
 
 from pyne import nucname
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 if sys.version_info[0] > 2:
   basestring = str

--- a/pyne/dbgen/materials_library.py
+++ b/pyne/dbgen/materials_library.py
@@ -11,8 +11,7 @@ import os
 import csv
 import sys
 from itertools import takewhile, groupby
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import tables as tb
 
@@ -21,7 +20,7 @@ from pyne.data import natural_abund, natural_abund_map
 from pyne.material import Material
 from pyne.material_library import MaterialLibrary
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 def make_elements():

--- a/pyne/dbgen/ndsfpy.py
+++ b/pyne/dbgen/ndsfpy.py
@@ -20,8 +20,7 @@ subsequent fee for these data.
 from __future__ import print_function, division
 import os
 import shutil
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib2
@@ -35,7 +34,7 @@ import tables as tb
 from pyne import nucname
 from pyne.dbgen.api import BASIC_FILTERS
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def readtable(i, spdat):
     """

--- a/pyne/dbgen/nuc_data_make.py
+++ b/pyne/dbgen/nuc_data_make.py
@@ -1,8 +1,7 @@
 from __future__ import print_function
 import os
 import argparse
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib2
@@ -27,7 +26,7 @@ from pyne.dbgen import wimsdfpy
 from pyne.dbgen import ndsfpy
 from pyne.dbgen.hashtools import check_hashes
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Thanks to http://patorjk.com/software/taag/
 # and http://www.chris.com/ascii/index.php?art=creatures/dragons (Jeff Ferris)

--- a/pyne/dbgen/q_val.py
+++ b/pyne/dbgen/q_val.py
@@ -8,8 +8,7 @@ q_value, and the percent of q coming from gammas. This data is from
 from __future__ import print_function
 import csv
 import os
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 import tables as tb
@@ -18,7 +17,7 @@ from pyne import nucname
 from pyne.api import nuc_data
 from pyne.dbgen.api import BASIC_FILTERS
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Parses data from .csv
 def grab_q_values(fname):

--- a/pyne/dbgen/scattering_lengths.py
+++ b/pyne/dbgen/scattering_lengths.py
@@ -6,8 +6,7 @@ from __future__ import print_function
 import os
 import re
 import shutil
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib2
@@ -20,7 +19,7 @@ import tables as tb
 from .. import nucname
 from .api import BASIC_FILTERS
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def grab_scattering_lengths(build_dir="", file_out='scattering_lengths.html'):
     """Grabs the scattering cross-section lengths for neutrons from the NIST website

--- a/pyne/dbgen/simple_xs.py
+++ b/pyne/dbgen/simple_xs.py
@@ -1,8 +1,7 @@
 """This module provides a way to grab and store simple cross sections from KAERI."""
 from __future__ import print_function
 import os
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib
@@ -18,7 +17,7 @@ from ..utils import to_barns
 from .api import BASIC_FILTERS
 from .kaeri import grab_kaeri_nuclide, parse_for_all_isotopes
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def grab_kaeri_simple_xs(build_dir=""):
     """Grabs the KAERI files needed for the simple cross sections table, 

--- a/pyne/dbgen/wimsdfpy.py
+++ b/pyne/dbgen/wimsdfpy.py
@@ -22,8 +22,7 @@ import os
 import re
 import sys
 import shutil
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib2
@@ -40,7 +39,7 @@ import tables as tb
 from pyne import nucname
 from pyne.dbgen.api import BASIC_FILTERS
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def grab_fpy(build_dir="", file_out='wimsd-fpyield.html'):
     """Grabs the WIMS fission product yields from the IAEA website

--- a/pyne/endf.pyx
+++ b/pyne/endf.pyx
@@ -20,7 +20,7 @@ try:
 except ImportError:
     from collections import OrderedDict, Iterable
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 cimport numpy as np
 import numpy as np
@@ -37,7 +37,7 @@ from pyne.utils import fromendf_tok, endftod
 
 np.import_array()
 
-warn(__name__ + ' is not yet QA compliant.', QAWarning)
+QA_warn(__name__)
 
 libraries = {0: 'ENDF/B', 1: 'ENDF/A', 2: 'JEFF', 3: 'EFF',
              4: 'ENDF/B High Energy', 5: 'CENDL', 6: 'JENDL',

--- a/pyne/endl.py
+++ b/pyne/endl.py
@@ -17,7 +17,6 @@ from __future__ import print_function, division, unicode_literals
 
 import re
 import sys
-from warnings import warn
 try:
     from collections.abc import namedtuple, defaultdict
 except ImportError:
@@ -25,12 +24,12 @@ except ImportError:
 
 import numpy as np
 
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 from pyne import rxdata
 import pyne.utils as utils
 from pyne import nucname
 
-warn(__name__ + ' is not yet QA compliant.', QAWarning)
+QA_warn(__name__)
 
 if sys.version_info[0] > 2:
     basestring = str

--- a/pyne/enrichment.pyx
+++ b/pyne/enrichment.pyx
@@ -16,7 +16,7 @@ from libc.stdlib cimport free
 from libcpp.string cimport string as std_string
 
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 from pyne cimport nucname
 from pyne import nucname
@@ -27,7 +27,7 @@ import pyne.material
 from pyne cimport cpp_enrichment
 
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 #####################

--- a/pyne/ensdf.py
+++ b/pyne/ensdf.py
@@ -7,8 +7,7 @@ try:
 except ImportError:
     from collections import defaultdict
 from warnings import warn
-from pyne.utils import QAWarning
-from pyne.utils import time_conv_dict
+from pyne.utils import QA_warn, time_conv_dict
 
 import numpy as np
 
@@ -17,7 +16,7 @@ from pyne import nucname, rxname, data
 if sys.version_info[0] > 2:
     basestring = str
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 _valexp = re.compile('([0-9.]*)([Ee][+-]?\d*)')
 _val = re.compile('(\d*)[.](\d*)')

--- a/pyne/ensdf_processing.py
+++ b/pyne/ensdf_processing.py
@@ -2,7 +2,7 @@
 
 import sys, os, shutil, subprocess, tarfile
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     import urllib.request as urllib
@@ -12,7 +12,7 @@ except ImportError:
 if sys.version_info[0] > 2:
     basestring = str
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 class SetupIncompleteError(Exception):
     def __init__(self, value):

--- a/pyne/fluka.py
+++ b/pyne/fluka.py
@@ -26,7 +26,7 @@ if HAVE_PYMOAB:
 else:
     warn("The PyMOAB optional dependency could not be imported. "
          "Some aspects of the fluka module may be incomplete.",
-         QAWarning)
+         ImportWarning)
 
 
 class Usrbin(object):

--- a/pyne/fluka.py
+++ b/pyne/fluka.py
@@ -14,7 +14,9 @@ available to use.
 """
 
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
+
+QA_warn(__name__)
 
 # Mesh specific imports
 from pyne.mesh import Mesh, StatMesh, MeshError, HAVE_PYMOAB

--- a/pyne/gammaspec.py
+++ b/pyne/gammaspec.py
@@ -3,14 +3,13 @@ GammaSpectrum class, reads a .spe file Will in the future have functions
 for activity calculations.
 """
 
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 
 from pyne import spectanalysis
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 class GammaSpectrum(spectanalysis.PhSpectrum):

--- a/pyne/gui/aceviewer.py
+++ b/pyne/gui/aceviewer.py
@@ -7,8 +7,7 @@ module.
 """
 import sys
 from bisect import bisect_right
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 import matplotlib
@@ -23,7 +22,7 @@ from PyQt4.QtGui import *
 
 from pyne import ace
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 matplotlib.use('Qt4Agg')
 

--- a/pyne/gui/spectplots.py
+++ b/pyne/gui/spectplots.py
@@ -1,10 +1,9 @@
 """Plotting routines for spectrometry modules"""
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import matplotlib.pyplot as plt
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 def plot_spectrum(spect):

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -21,8 +21,7 @@ except AttributeError:
     collectionsAbc = collections
 cimport numpy as np
 import numpy as np
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 import os
 import sys
 if sys.version_info[0] >= 3:
@@ -47,7 +46,7 @@ cimport pyne.data as data
 import pyne.data as data
 
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Maximum 32-bit signed int
 DEF INT_MAX = 2147483647

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -10,8 +10,7 @@ from pyne cimport cpp_material
 import tables as tb
 import sys
 import os
-from pyne.utils import QAWarning
-from warnings import warn
+from pyne.utils import QA_warn
 import numpy as np
 
 # Cython imports
@@ -53,7 +52,7 @@ cimport pyne.data as data
 cimport pyne.material as material
 
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 _INTEGRAL_TYPES = (int, np.integer, np.bool_)
 

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -39,7 +39,7 @@ if HAVE_PYMOAB:
 else:
     warn("The PyMOAB optional dependency could not be imported. "
          "Some aspects of the mcnp module may be incomplete.",
-         QAWarning)
+         ImportWarning)
 
 if sys.version_info[0] > 2:
     def cmp(a, b):

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -24,13 +24,13 @@ from warnings import warn
 import numpy as np
 import tables
 
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 from pyne.material import Material
 from pyne.material import MultiMaterial
 from pyne import nucname
 from pyne.binaryreader import _BinaryReader, _FortranRecord
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Mesh specific imports
 

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -10,13 +10,12 @@ try:
 except ImportError:
     from collections import Iterable, Sequence
 from warnings import warn
-from pyne.utils import QAWarning, check_iterable
+from pyne.utils import QA_warn, check_iterable
 
 import numpy as np
 import tables as tb
 
-
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 try:
     from pymoab import core as mb_core, hcoord, scd, types

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     HAVE_PYMOAB = False
     warn("The PyMOAB optional dependency could not be imported. "
-         "Some aspects of the mesh module may be incomplete.", QAWarning)
+         "Some aspects of the mesh module may be incomplete.", ImportWarning)
 
 
 _BOX_DIMS_TAG_NAME = "BOX_DIMS"

--- a/pyne/njoy.py
+++ b/pyne/njoy.py
@@ -26,12 +26,11 @@ Original Copyright:
 from __future__ import print_function
 import os
 import time
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 warn("the NJOY module is untested and considered experimental", 
               RuntimeWarning)
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 class PyNjoyError(Exception):
     """Exception indicating an error in PyNjoy."""

--- a/pyne/openmc_utils.py
+++ b/pyne/openmc_utils.py
@@ -17,7 +17,6 @@ if sys.version_info[0] == 2:
 else:
     from html.parser import HTMLParser
 
-from pyne.utils import QAWarning
 from pyne.mesh import MeshTally, HAVE_PYMOAB
 if HAVE_PYMOAB:
     from pyne.mesh import NativeMeshTag
@@ -26,9 +25,9 @@ else:
          "Some aspects of the openmc module may be incomplete.",
          QAWarning)
 from pyne import nucname
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 try:
     import openmc

--- a/pyne/openmc_utils.py
+++ b/pyne/openmc_utils.py
@@ -23,7 +23,7 @@ if HAVE_PYMOAB:
 else:
     warn("The PyMOAB optional dependency could not be imported. "
          "Some aspects of the openmc module may be incomplete.",
-         QAWarning)
+         ImportWarning)
 from pyne import nucname
 from pyne.utils import QA_warn
 

--- a/pyne/origen22.py
+++ b/pyne/origen22.py
@@ -13,8 +13,7 @@ except ImportError:
     from collections import Mapping
 from copy import deepcopy
 from itertools import chain
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 
@@ -28,7 +27,7 @@ if sys.version_info[0] > 2:
     basestring = str
     unicode = str
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 BASE_TAPE9 = os.path.join(os.path.dirname(__file__), 'base_tape9.inp')
 

--- a/pyne/particle.pyx
+++ b/pyne/particle.pyx
@@ -69,8 +69,7 @@ from cython.operator cimport dereference as deref
 from cython.operator cimport preincrement as inc
 from libcpp.string cimport string as std_string
 
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 # local imports 
 cimport extra_types
@@ -83,7 +82,7 @@ cimport pyne.stlcontainers as conv
 import pyne.stlcontainers as conv
 
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # names
 cdef conv._SetStr names_proxy = conv.SetStr(False)

--- a/pyne/partisn.py
+++ b/pyne/partisn.py
@@ -43,7 +43,7 @@ if HAVE_PYMOAB:
 else:
     warn("The PyMOAB optional dependency could not be imported. "
          "All aspects of the partisn module are not imported.",
-         QAWarning)
+         ImportWarning)
 
 try:
     from pyne import dagmc

--- a/pyne/partisn.py
+++ b/pyne/partisn.py
@@ -21,7 +21,7 @@ import linecache
 import datetime
 from textwrap import wrap
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 import itertools
 
 import numpy as np
@@ -34,7 +34,7 @@ from pyne.material_library import MaterialLibrary
 from pyne import nucname
 from pyne.binaryreader import _BinaryReader, _FortranRecord
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Mesh specific imports
 

--- a/pyne/ptrac_to_hdf5.py
+++ b/pyne/ptrac_to_hdf5.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """Read a MCNP Ptrac file and save it in HDF5 format."""
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import tables
 
@@ -12,7 +11,7 @@ try:
 except ImportError:
     from . import _argparse as argparse
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 def main():
     argparser = argparse.ArgumentParser(description="write the contents of a MCNP PTRAC file to a HDF5 table")

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -1,6 +1,5 @@
 from os.path import isfile
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 import numpy as np
 
 from pyne.mesh import Mesh
@@ -8,7 +7,7 @@ from pyne.mcnp import Meshtal
 from pyne.alara import mesh_to_fluxin, record_to_geom, photon_source_to_hdf5, \
     photon_source_hdf5_to_mesh, responses_output_zone
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 def resolve_mesh(mesh_reference, tally_num=None, flux_tag="n_flux",

--- a/pyne/rxdata.py
+++ b/pyne/rxdata.py
@@ -4,9 +4,9 @@ try:
 except AttributeError:
     collectionsAbc = collections
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 class RxLib(object):

--- a/pyne/rxname.pyx
+++ b/pyne/rxname.pyx
@@ -142,8 +142,7 @@ from cython.operator cimport dereference as deref
 from cython.operator cimport preincrement as inc
 from libcpp.string cimport string as std_string
 
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 # local imports
 cimport extra_types
@@ -157,7 +156,7 @@ import pyne.stlcontainers as conv
 
 
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # names
 cdef conv._SetStr names_proxy = conv.SetStr(False)

--- a/pyne/serpent.py
+++ b/pyne/serpent.py
@@ -2,13 +2,12 @@ import re
 import sys
 import numpy as np
 import pdb
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 if sys.version_info[0] > 2:
     basestring = str
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 _if_idx_str_serpent1 = (
     'if (exist("idx", "var"));\n'

--- a/pyne/source.pyx
+++ b/pyne/source.pyx
@@ -6,10 +6,9 @@ cimport numpy as np
 
 from pyne import stlcontainers
 
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 cdef class PointSource:
     """

--- a/pyne/spectanalysis.py
+++ b/pyne/spectanalysis.py
@@ -4,14 +4,13 @@
   will have functions for general spectrum processing
 
 """
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 
 import copy
 
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 
 class PhSpectrum(object):

--- a/pyne/tally.pyx
+++ b/pyne/tally.pyx
@@ -18,10 +18,9 @@ cimport numpy as np
 
 from pyne import stlcontainers
 
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 cdef vector[int] to_vector_int(value):
     cdef vector[int] value_proxy

--- a/pyne/transmute/chainsolve.py
+++ b/pyne/transmute/chainsolve.py
@@ -4,8 +4,7 @@
    Analysis," a Ph.D. Dissertation, University of Wisconsin, Madison, WI, 1999.
 """
 from __future__ import division
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 from scipy import linalg
@@ -21,7 +20,7 @@ from pyne.xs.data_source import NullDataSource, EAFDataSource
 from pyne.xs.cache import XSCache
 from pyne.xs.channels import sigma_a
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 class Transmuter(object):
     """A class for transmuting materials using an ALARA-like chain solver."""

--- a/pyne/transmute/origen22.py
+++ b/pyne/transmute/origen22.py
@@ -9,8 +9,7 @@ try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 
@@ -24,7 +23,7 @@ from pyne.material import Material, from_atom_frac
 from pyne.xs.data_source import NullDataSource, SimpleDataSource, EAFDataSource
 from pyne.xs.cache import XSCache
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 class Transmuter(object):
     """A class for transmuting materials using ORIGEN v2.2."""

--- a/pyne/utils.py
+++ b/pyne/utils.py
@@ -15,7 +15,7 @@ class QAWarning(UserWarning):
     pass
 
 def QA_warn(module_name):
-    warn(module_name + " is not yet QA compliant.", QAWarning)
+    warn(module_name + " is not yet fully QA compliant.", QAWarning)
 
 
 time_conv_dict = {'as': 1e-18,

--- a/pyne/utils.py
+++ b/pyne/utils.py
@@ -1,6 +1,8 @@
 from __future__ import division
 import os
 
+from warnings import warn
+
 from distutils.dir_util import remove_tree
 import filecmp
 from io import open
@@ -9,9 +11,12 @@ from pyne._utils import fromstring_split, fromstring_token, endftod,\
                         use_fast_endftod, fromendf_tok, toggle_warnings,\
                         use_warnings, fromendl_tok
 
-
 class QAWarning(UserWarning):
     pass
+
+def QA_warn(module_name):
+    warn(module_name + " is not yet QA compliant.", QAWarning)
+
 
 time_conv_dict = {'as': 1e-18,
                   'attosec': 1e-18,

--- a/pyne/utils.py
+++ b/pyne/utils.py
@@ -15,7 +15,8 @@ class QAWarning(UserWarning):
     pass
 
 def QA_warn(module_name):
-    warn(module_name + " is not yet fully QA compliant.", QAWarning)
+    if ('PYNE_QA_WARN' in os.environ):
+        warn(module_name + " is not yet fully QA compliant.", QAWarning)
 
 
 time_conv_dict = {'as': 1e-18,

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -14,9 +14,11 @@ try:
 except ImportError:
     pass
 from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+import numpy as np
+
+QA_warn(__name__)
 
 
 if HAVE_PYMOAB:
@@ -24,7 +26,7 @@ if HAVE_PYMOAB:
 else:
     warn("The PyMOAB optional dependency could not be imported. "
          "Some aspects of the variance reduction module may be incomplete.",
-         QAWarning)
+         ImportWarning)
 
 
 def cadis(adj_flux_mesh, adj_flux_tag, q_mesh, q_tag,

--- a/pyne/xs/cache.py
+++ b/pyne/xs/cache.py
@@ -2,7 +2,6 @@
 cross-sections from provided nuclear data sets."""
 import sys
 import inspect
-from warnings import warn
 
 from itertools import product
 try:
@@ -17,9 +16,9 @@ from pyne import nucname
 from pyne.pyne_config import pyne_conf
 from pyne.xs.models import partial_energy_matrix, phi_g, same_arr_or_none
 from pyne.xs import data_source
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 if sys.version_info[0] > 2:
   basestring = str

--- a/pyne/xs/channels.py
+++ b/pyne/xs/channels.py
@@ -11,8 +11,7 @@ try:
     collectionsAbc = collections.abc
 except AttributeError:
     collectionsAbc = collections
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 import numpy as np
 import scipy.integrate
@@ -27,7 +26,7 @@ from . import models
 from . import cache
 from .models import group_collapse
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 if sys.version_info[0] > 2:
   basestring = str

--- a/pyne/xs/data_source.py
+++ b/pyne/xs/data_source.py
@@ -5,8 +5,7 @@ from __future__ import division
 import os
 import io
 import sys
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 try:
     from StringIO import StringIO
@@ -31,7 +30,7 @@ from pyne import ace
 from pyne.data import MeV_per_K
 from pyne.xs.models import partial_energy_matrix, group_collapse, same_arr_or_none
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 IO_TYPES = (io.IOBase, StringIO)
 

--- a/pyne/xs/models.pyx
+++ b/pyne/xs/models.pyx
@@ -1,8 +1,7 @@
 """This module provides physical cross-section models and helper functions."""
 from __future__ import division
 
-from warnings import warn
-from pyne.utils import QAWarning
+from pyne.utils import QA_warn
 
 cimport numpy as np
 import numpy as np
@@ -17,7 +16,7 @@ from scipy.special import erf
 #from scipy import integrate
 #import metasci.mathematics.integrate as msmintegrate
 
-warn(__name__ + " is not yet QA compliant.", QAWarning)
+QA_warn(__name__)
 
 # Bolzmann's constant in MeV/K
 k = constants.physical_constants['Boltzmann constant in eV/K'][0] * (1.0E-6)

--- a/scripts/expand_tags.py
+++ b/scripts/expand_tags.py
@@ -24,7 +24,7 @@ def main():
         from pymoab import types
     except ImportError:
         warn("The PyMOAB optional dependency could not be imported. "
-             "Some aspects of the mesh module may be incomplete.", QAWarning)
+             "Some aspects of the mesh module may be incomplete.", ImportWarning)
 
     try:
         m = Mesh(structured=True, mesh=args.mesh_file)


### PR DESCRIPTION
PyNE issues QA warnings excessively which may impact the reception by some audiences.    This PR aims to "flip the bit" on QA and only issue warnings when an environment variable has been set.

The first step is to move all QA warnings to a single imported function call.

Now also check an ENV variable to decide whether or not we issue QA warning