### PR TITLE
Create materials from radionuclide activities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,8 @@ v0.7.0 RC2
       * increased precision of the material density reported in the comment card
         for an MCNP material to 5 decimal places
       * Adds tests to tests/test:materials.py:test_decay_heat(self) to check more isotopes
+      * Adds from_activity() to create or redefine materials using radionuclide
+        activities
 
 * Bug fixes in serpent support
    * in serpent.py, function VOL_serp2_fix() to correct for

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -109,6 +109,7 @@ cdef extern from "material.h" namespace "pyne":
         vector[pair[double, double]] gammas() except +
         vector[pair[double, double]] xrays() except +
         vector[pair[double, double]] photons(bool) except +
+        void from_activity(map[int, double]) except +
 
         Material decay(double) except +
         Material cram(vector[double]) except +

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1268,17 +1268,20 @@ cdef class _Material:
             val = <double> value
             if isinstance(key, int):
                 key_zz = <int> nucname.id(key)
-                if 0 == act.count(key_zz):
-                    act[key_zz] = 0.0
-                act[key_zz] = act[key_zz] + val
             elif isinstance(key, basestring):
                 key_zz = nucname.id(key)
-                if 0 == act.count(key_zz):
-                    act[key_zz] = 0.0
-                act[key_zz] = act[key_zz] + val
             else:
                 raise TypeError("Activity keys must be integers, "
                         "or strings.")
+
+            dc = data.decay_const(key_zz)
+            if dc == 0.0 and val == 0.0:
+                continue
+            elif dc == 0.0:
+                raise ValueError("Activity keys must be radionuclides.")
+            elif 0 == act.count(key_zz):
+                act[key_zz] = 0.0
+            act[key_zz] = act[key_zz] + val
 
         self.mat_pointer.from_activity(act)
 

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1274,12 +1274,7 @@ cdef class _Material:
                 raise TypeError("Activity keys must be integers, "
                         "or strings.")
 
-            dc = data.decay_const(key_zz)
-            if dc == 0.0 and val == 0.0:
-                continue
-            elif dc == 0.0:
-                raise ValueError("Activity keys must be radionuclides.")
-            elif 0 == act.count(key_zz):
+            if 0 == act.count(key_zz):
                 act[key_zz] = 0.0
             act[key_zz] = act[key_zz] + val
 

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -638,7 +638,9 @@ cdef class _Material:
 
 
     def activity(self):
-        """This provides the activity of the comp of the material.
+        """This provides the activity of the comp of the material. It assumes
+        that the mass of the material is given in units of [grams] and returns
+        activities in units of [Bq].
 
         Returns
     -------
@@ -1236,7 +1238,8 @@ cdef class _Material:
     def from_activity(self, activities):
         """from_activity(activities)
         Loads the material composition based on a mapping of radionuclide
-        activities.
+        activities. It assumes that activities are supplied in units of [Bq]
+        and sets the material mass to units of [grams].
 
         Parameters
         ----------
@@ -1863,7 +1866,10 @@ def from_atom_frac(atom_fracs, double mass=-1.0, double density=-1.0,
 def from_activity(activities, double mass=-1.0, double density=-1.0,
                    double atoms_per_molecule=-1.0, metadata=None):
     """from_activity(activities, double mass=-1.0, double atoms_per_molecule=-1.0)
-    Create a Material from a mapping of radionuclide activities.
+    Create a Material from a mapping of radionuclide activities. If mass < 0.0,
+    it assumes the activities are supplied in units of [Bq] and sets the
+    material mass to units of [grams]. Otherewise when mass >= 0.0, it
+    treats the supplied activities as relative activities.
 
     Parameters
     ----------

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -2013,6 +2013,20 @@ std::vector<std::pair<double, double> > pyne::Material::normalize_radioactivity(
   return normed;
 }
 
+void pyne::Material::from_activity(std::map<int, double> activities) {
+  // activities must be of the form {nuc: act}, eg, tritium
+  //  10030: 1.0
+
+  // clear existing components
+  comp.clear();
+
+  for (std::map<int, double>::iterator acti = activities.begin(); acti != activities.end(); acti++) {
+    comp[acti->first] = (acti->second) * pyne::atomic_mass(acti->first) / \
+                        pyne::N_A / pyne::decay_const(acti->first);
+  }
+  norm_comp();
+}
+
 
 #ifdef PYNE_DECAY
 pyne::Material pyne::Material::decay(double t) {

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -2020,9 +2020,13 @@ void pyne::Material::from_activity(std::map<int, double> activities) {
   // clear existing components
   comp.clear();
 
-  for (std::map<int, double>::iterator acti = activities.begin(); acti != activities.end(); acti++) {
+  for (std::map<int, double>::iterator acti = activities.begin();
+       acti != activities.end(); acti++) {
+    double dc = pyne::decay_const(acti->first);
+    if (dc == 0.0 && (acti->second) == 0.0) continue;
+    else if (dc == 0.0) throw std::invalid_argument("Activity keys must be radionuclides.");
     comp[acti->first] = (acti->second) * pyne::atomic_mass(acti->first) / \
-                        pyne::N_A / pyne::decay_const(acti->first);
+                        pyne::N_A / dc;
   }
   norm_comp();
 }

--- a/src/material.h
+++ b/src/material.h
@@ -440,6 +440,9 @@ namespace pyne
     /// so the sum of the intensities is one
     std::vector<std::pair<double, double> > normalize_radioactivity(
       std::vector<std::pair<double, double> > unnormed);
+    /// Sets the composition, mass, and atoms_per_molecule of this material to those
+    /// calculated from \a activities, a mapping of radionuclides to activities.
+    void from_activity(std::map<int, double> activities);
 
 #ifdef PYNE_DECAY
     /// Decays this material for a given amount of time in seconds

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -309,6 +309,15 @@ class TestMaterialMethods(TestCase):
         assert_equal(mat.mass, 15.0)
         assert_equal(mat.molecular_mass(), 237.8986195419686)
 
+        mat = Material()
+        mat.from_activity({'H': 0.0, 'H3': 1.0, 'O16': 0.0})
+        assert_equal(mat.comp, {10030000: 1.0})
+        assert_equal(mat.mass, 2.8091613926886366e-15)
+
+        mat = Material()
+        hto = {'H': 1.0, 'H3': 1.0, 'O16': 1.0}
+        assert_raises(ValueError, mat.from_activity, hto)
+
 
     def test_decay_heat_stable(self):
         mat = Material({922350000: 0.05, 922380000: 0.95}, 15)
@@ -1083,6 +1092,14 @@ def test_from_activity_func():
     assert_equal(mat.mass, 15.0)
     assert_equal(mat.molecular_mass(), 237.8986195419686)
 
+    hto = {'H': 0.0, 'H3': 1.0, 'O16': 0.0}
+    mat = from_activity(hto)
+    assert_equal(mat.comp, {10030000: 1.0})
+    assert_equal(mat.mass, 2.8091613926886366e-15)
+
+    hto = {'H': 1.0, 'H3': 1.0, 'O16': 1.0}
+    assert_raises(ValueError, from_activity, hto)
+    
 
 
 def test_from_hdf5_func_protocol_0():

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -12,8 +12,8 @@ from nose.tools import assert_equal, assert_not_equal, assert_raises, raises, \
 from pyne.utils import QAWarning
 warnings.simplefilter("ignore", QAWarning)
 from pyne import nuc_data
-from pyne.material import Material, from_atom_frac, from_hdf5, from_text, \
-    MapStrMaterial, MultiMaterial
+from pyne.material import Material, from_atom_frac, from_activity, from_hdf5, \
+    from_text, MapStrMaterial, MultiMaterial
 from pyne import jsoncpp
 from pyne import data
 from pyne import nucname
@@ -297,6 +297,17 @@ class TestMaterialMethods(TestCase):
         exp = {922350000: 59953.15151320379, 922380000: 177216.65219208886}
         assert_equal(set(obs), set(exp))
         assert_equal(set(obs.values()), set(exp.values()))
+
+
+    def test_from_activity(self):
+        mat = Material()
+        mat.from_activity({922350000: 59953.15101810882,
+                           922380000: 177216.65112976026})
+        assert_equal(mat.atoms_per_molecule, -1.0)
+        assert_equal(mat.comp[922350000], 0.05)
+        assert_equal(mat.comp[922380000], 0.95)
+        assert_equal(mat.mass, 15.0)
+        assert_equal(mat.molecular_mass(), 237.8986195419686)
 
 
     def test_decay_heat_stable(self):
@@ -1060,6 +1071,17 @@ def test_from_atom_frac_func():
     assert_almost_equal(mat.comp[922350000], 0.4376375781743612, 15)
     assert_almost_equal(mat.comp[922380000], 0.4432361674078869, 15)
     assert_almost_equal(mat.molecular_mass()/268.53718683220006, 1.0, 15)
+
+
+
+def test_from_activity_func():
+    leu = {922350000: 59953.15101810882, 922380000: 177216.65112976026}
+    mat = from_activity(leu)
+    assert_equal(mat.atoms_per_molecule, -1.0)
+    assert_equal(mat.comp[922350000], 0.05)
+    assert_equal(mat.comp[922380000], 0.95)
+    assert_equal(mat.mass, 15.0)
+    assert_equal(mat.molecular_mass(), 237.8986195419686)
 
 
 
@@ -2090,7 +2112,7 @@ def test_decay_u235_h3():
         # with spontaneous fission
         assert_mat_almost_equal(exp_sf, obs)
     else:
-        assert_true(False, "Observed material does not have corrent length")
+        assert_true(False, "Observed material does not have correct length")
 
 
 def test_cram_h3():

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -299,20 +299,20 @@ class TestMaterialMethods(TestCase):
         assert_equal(set(obs.values()), set(exp.values()))
 
 
-    def test_from_activity(self):
+    def test_from_activity_meth(self):
         mat = Material()
-        mat.from_activity({922350000: 59953.15101810882,
-                           922380000: 177216.65112976026})
+        mat.from_activity({922350000: 59953.15151320379,
+                           922380000: 177216.65219208886})
         assert_equal(mat.atoms_per_molecule, -1.0)
         assert_equal(mat.comp[922350000], 0.05)
         assert_equal(mat.comp[922380000], 0.95)
         assert_equal(mat.mass, 15.0)
-        assert_equal(mat.molecular_mass(), 237.8986195419686)
+        assert_equal(mat.molecular_mass(), 237.8986180886295)
 
         mat = Material()
         mat.from_activity({'H': 0.0, 'H3': 1.0, 'O16': 0.0})
         assert_equal(mat.comp, {10030000: 1.0})
-        assert_equal(mat.mass, 2.8091613926886366e-15)
+        assert_equal(mat.mass, 2.809161396488766e-15)
 
         mat = Material()
         hto = {'H': 1.0, 'H3': 1.0, 'O16': 1.0}
@@ -1084,22 +1084,22 @@ def test_from_atom_frac_func():
 
 
 def test_from_activity_func():
-    leu = {922350000: 59953.15101810882, 922380000: 177216.65112976026}
+    leu = {922350000: 59953.15151320379, 922380000: 177216.65219208886}
     mat = from_activity(leu)
     assert_equal(mat.atoms_per_molecule, -1.0)
     assert_equal(mat.comp[922350000], 0.05)
     assert_equal(mat.comp[922380000], 0.95)
     assert_equal(mat.mass, 15.0)
-    assert_equal(mat.molecular_mass(), 237.8986195419686)
+    assert_equal(mat.molecular_mass(), 237.8986180886295)
 
     hto = {'H': 0.0, 'H3': 1.0, 'O16': 0.0}
     mat = from_activity(hto)
     assert_equal(mat.comp, {10030000: 1.0})
-    assert_equal(mat.mass, 2.8091613926886366e-15)
+    assert_equal(mat.mass, 2.809161396488766e-15)
 
     hto = {'H': 1.0, 'H3': 1.0, 'O16': 1.0}
     assert_raises(ValueError, from_activity, hto)
-    
+
 
 
 def test_from_hdf5_func_protocol_0():


### PR DESCRIPTION
One thing I noticed from Issue #1223 was that there wasn't an easy way in PyNE to create a material using activities of radionuclides. This PR adds `from_activity()` and `Material.from_activity()` to create materials based on dictionaries of radionuclides and associated activities. They are akin to how the `from_atom_frac()` routines can be used to create materials based on maps of atom fractions.

The new functions mean PyNE can be easily used for pure decay calculations, e.g. decay 10 Bq of tritium for one half life:
```
>>> H3 = Material()
>>> H3.from_activity({'H3': 10.0})
>>> H3.decay(12.32*365.25*24*60*60).activity()
{10030000: 5.0, 20030000: 0.0}
```

The PR contains docstrings & tests for the new routines, but I didn't attempt to rebuild the docs or update the change log. Suggestions or edits welcome.