### PR TITLE
get PR_BASE information in CI

### DIFF
--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -1,31 +1,14 @@
 #!/bin/sh
 
 # default main repo setup
-master_repo="https://github.com/pyne/pyne.git"
-default_branch="develop"
-
-apt-get update -y
-apt-get install -y --fix-missing curl jq
 PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
 API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"
 PR_RESPONSE=$(curl "$PR_REQUEST_URL")
 PR_BASE_BRANCH=$(echo $PR_RESPONSE | jq -e '.base.ref' | tr -d '"')
 
-
-echo "*********"
-echo "*********"
-echo "*********"
-echo "*********"
-echo "MY WAR"
-echo "*********"
-echo "*********"
-echo $PR_BASE_BRANCH
-echo "*********"
-echo "*********"
-echo "*********"
-echo "*********"
-
+master_repo="https://github.com/pyne/pyne.git"
+default_branch=$PR_BASE_BRANCH
 
 # setup temp remote 
 git_remote_name=ci_changelog_`git log --pretty=format:'%h' -n 1`

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -4,7 +4,7 @@
 master_repo="https://github.com/pyne/pyne.git"
 default_branch="develop"
 
-
+apt-get install curl jq
 PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
 API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -4,7 +4,7 @@
 master_repo="https://github.com/pyne/pyne.git"
 default_branch="develop"
 
-apt-get install curl jq
+apt-get install -y curl jq
 PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
 API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -20,7 +20,7 @@ echo "*********"
 echo "MY WAR"
 echo "*********"
 echo "*********"
-echo $GITHUB_PR_BASE_BRANCH
+echo $PR_BASE_BRANCH
 echo "*********"
 echo "*********"
 echo "*********"

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -4,7 +4,7 @@
 master_repo="https://github.com/pyne/pyne.git"
 default_branch="develop"
 
-apt-get install -y curl jq
+apt-get install -y --fix-missing curl jq
 PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
 API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -4,6 +4,14 @@
 master_repo="https://github.com/pyne/pyne.git"
 default_branch="develop"
 
+
+PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
+API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"
+PR_RESPONSE=$(curl "$PR_REQUEST_URL")
+PR_BASE_BRANCH=$(echo $PR_RESPONSE | jq -e '.base.ref' | tr -d '"')
+
+
 echo "*********"
 echo "*********"
 echo "*********"

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -4,6 +4,19 @@
 master_repo="https://github.com/pyne/pyne.git"
 default_branch="develop"
 
+echo "*********"
+echo "*********"
+echo "*********"
+echo "*********"
+echo "MY WAR"
+echo "*********"
+echo "*********"
+echo $GITHUB_PR_BASE_BRANCH
+echo "*********"
+echo "*********"
+echo "*********"
+echo "*********"
+
 
 # setup temp remote 
 git_remote_name=ci_changelog_`git log --pretty=format:'%h' -n 1`

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -6,8 +6,7 @@ API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJEC
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"
 PR_RESPONSE=$(curl "$PR_REQUEST_URL")
 PR_BASE_BRANCH=$(echo $PR_RESPONSE | tr '\r\n' ' ' | jq -e '.base.ref' | tr -d '"')
-echo $PR_RESPONSE
-echo $PR_BASE_BRANCH
+echo "Testing changelog against $PR_BASE_BRANCH branch"
 
 master_repo="https://github.com/pyne/pyne.git"
 default_branch=$PR_BASE_BRANCH

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -5,7 +5,7 @@ PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
 API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"
 PR_RESPONSE=$(curl "$PR_REQUEST_URL")
-PR_BASE_BRANCH=$(echo $PR_RESPONSE | jq -e '.base.ref' | tr -d '"')
+PR_BASE_BRANCH=$(echo $PR_RESPONSE | tr '\r\n' ' ' | jq -e '.base.ref' | tr -d '"')
 echo $PR_RESPONSE
 echo $PR_BASE_BRANCH
 

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -6,6 +6,7 @@ API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJEC
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"
 PR_RESPONSE=$(curl "$PR_REQUEST_URL")
 PR_BASE_BRANCH=$(echo $PR_RESPONSE | jq -e '.base.ref' | tr -d '"')
+echo $PR_BASE_BRANCH
 
 master_repo="https://github.com/pyne/pyne.git"
 default_branch=$PR_BASE_BRANCH

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -4,6 +4,7 @@
 master_repo="https://github.com/pyne/pyne.git"
 default_branch="develop"
 
+apt-get update -y
 apt-get install -y --fix-missing curl jq
 PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed "s/.*\/pull\///")
 API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"

--- a/.circleci/changelog_test.sh
+++ b/.circleci/changelog_test.sh
@@ -6,6 +6,7 @@ API_GITHUB="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJEC
 PR_REQUEST_URL="$API_GITHUB/pulls/$PR_NUMBER"
 PR_RESPONSE=$(curl "$PR_REQUEST_URL")
 PR_BASE_BRANCH=$(echo $PR_RESPONSE | jq -e '.base.ref' | tr -d '"')
+echo $PR_RESPONSE
 echo $PR_BASE_BRANCH
 
 master_repo="https://github.com/pyne/pyne.git"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,10 +140,11 @@ commands:
 jobs:
 # CHANGELOG file checker
   changelog_update:
-    executor: 
-      name: py3
+    docker:
+      - image: alpine:3.7
     working_directory: ~/repo
     steps:
+      - run: apk add --no-cache bash curl jq git openssh
       - checkout
       - run:
           name: Checking CHANGELOG Update

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -183,7 +183,9 @@ v0.7.0 RC2
    * Changed Doc and Tutorial mentions of iPython notebooks to Jupyter notebooks (PR #1262)
 
 * Improvements in building and testing
-   * require contributor to change CHANGELOG
+   * require contributor to change 
+   * now get the base branch name from github and check change against it
+      (inspired by https://github.com/NarrativeScience/circleci-orb-ghpr/blob/master/src/commands/get-pr-info.yml)
    * Expand testing matrix to include:
       * python 2 vs 3
       * with vs without PyMOAB

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -183,7 +183,7 @@ v0.7.0 RC2
    * Changed Doc and Tutorial mentions of iPython notebooks to Jupyter notebooks (PR #1262)
 
 * Improvements in building and testing
-   * require contributor to change 
+   * require contributor to change CHANGELOG
    * now get the base branch name from github and check change against it
       (inspired by https://github.com/NarrativeScience/circleci-orb-ghpr/blob/master/src/commands/get-pr-info.yml)
    * Expand testing matrix to include:

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -53,7 +53,7 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             future  \
             matplotlib \
             tables \
-            scipy \		
+            scipy \
             jinja2
 # Required for CHANGELOG test
 RUN apt-get install -y curl jq

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -55,12 +55,6 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             tables \
             scipy \
             jinja2
-# Required for CHANGELOG test
-RUN apt-get install -y curl jq
-
-
-
-
 
 # make starting directory
 RUN mkdir -p $HOME/opt

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -50,7 +50,11 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             numpy \
             nose \
             cython \
-            future
+            future  \
+            matplotlib \
+            tables \
+            scipy \		
+            jinja2
 # Required for CHANGELOG test
 RUN apt-get install -y curl jq
 

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -50,7 +50,7 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             numpy \
             nose \
             cython \
-            future  \
+            future \
             matplotlib \
             tables \
             scipy \

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -15,8 +15,6 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             software-properties-common \
             wget \
             g++ \
-            curl \
-            jq \
             build-essential \
             python${PY_SUFIX}-setuptools \
             python${PY_SUFIX}-pip \
@@ -52,11 +50,10 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             numpy \
             nose \
             cython \
-            future \
-            matplotlib \
-            tables \
-            scipy \
-            jinja2
+            future
+# Required for CHANGELOG test
+RUN apt-get install -y curl jq
+
 
 
 

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -15,6 +15,8 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             software-properties-common \
             wget \
             g++ \
+            curl \
+            jq \
             build-essential \
             python${PY_SUFIX}-setuptools \
             python${PY_SUFIX}-pip \


### PR DESCRIPTION
This should allow us to recover the name of the base branch in CI when issuing a PR.

and test test the CHANGELOG against that branch and not the `develop` branch

this requires `curl` and `jq`