### PR TITLE
Jupyter (formerly iPython) not needed in setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -203,6 +203,7 @@ v0.7.0 RC2
    * Add functions to do file, file block, line, and string almost the same
      compare functions in pyne/utils.py
    * make data available as replacement for data.pyne.io (#1261, #1265)
+   * Removed iPython check from ``setup.py`` and added Jupyter to be an optional dependency in documentation (#1273)
 
 * Code cleanup
    * Formatting improvements

--- a/docs/devsguide/testing.rst
+++ b/docs/devsguide/testing.rst
@@ -32,12 +32,13 @@ passing.
 Example Testing
 ---------------
 The examples directory should also be kept up-to-date as much as possible.
-PyNE examples are either in Python files or Jupyter notebooks. This means that
-to test the examples requires a recent version of Jupyter.  Furthermore, the 
-examples themseleves may have many other optional dependencies.  Don't be alarmed
-if testing the examples fails do to a lack of having a dependency installed.
-For this reason, testing the examples is not as important as unit tests, but still
-should be done occassionally.
+PyNE examples are either in Python files or `Jupyter notebooks
+<https://jupyter.org/>`_. This means that to test the examples requires a
+recent version of Jupyter.  Furthermore, the examples themseleves may have many
+other optional dependencies.  Don't be alarmed if testing the examples fails do
+to a lack of having a dependency installed.  For this reason, testing the
+examples is not as important as unit tests, but still should be done
+occassionally.
 
 To run the examples automatically, go to the examples directory and run the 
 ``execer.py`` file from the root pyne dir.
@@ -51,7 +52,7 @@ To run the examples automatically, go to the examples directory and run the
 Tutorial Testing
 ----------------
 Tutorial testing is very similar to example testing except that all of the 
-tutorials are Jupyter notebooks.
+tutorials are `Jupyter notebooks <https://jupyter.org/>`_.
 
 To run the tutorials automatically, go to the tutorial directory and run the 
 ``execer.py`` file from the root pyne dir.

--- a/docs/devsguide/testing.rst
+++ b/docs/devsguide/testing.rst
@@ -35,7 +35,7 @@ The examples directory should also be kept up-to-date as much as possible.
 PyNE examples are either in Python files or `Jupyter notebooks
 <https://jupyter.org/>`_. This means that to test the examples requires a
 recent version of Jupyter.  Furthermore, the examples themseleves may have many
-other optional dependencies.  Don't be alarmed if testing the examples fails do
+other optional dependencies.  Don't be alarmed if testing the examples fails due
 to a lack of having a dependency installed.  For this reason, testing the
 examples is not as important as unit tests, but still should be done
 occassionally.
@@ -72,4 +72,3 @@ you can chain the following BASH commands together::
       ../execer.py || cd ..
 
 Happy testing!
-

--- a/docs/install/linux_source.rst
+++ b/docs/install/linux_source.rst
@@ -20,10 +20,14 @@ PyNE has the following dependencies:
    #. `Python 2.7 <http://www.python.org/>`_
    #. `LAPACK <http://www.netlib.org/lapack/>`_
    #. `BLAS <http://www.netlib.org/blas/>`_
+   #. `Jinja2 <http://jinja.pocoo.org/>`_
 
 Optional Depenendencies:
    #. `MOAB <https://press3.mcs.anl.gov/sigma/moab-library>`_
    #. `PyTAPS <https://pythonhosted.org/PyTAPS/index.html>`_
+
+To run tutorial and examples:
+   #. `jupyter <http://jupyter.org/>`_
 
 Most of the dependencies are readily available through package managers.  Once
 all the dependencies are installed, PyNE can be installed. Download and unzip

--- a/docs/install/linux_source.rst
+++ b/docs/install/linux_source.rst
@@ -17,7 +17,7 @@ PyNE has the following dependencies:
    #. `Cython <http://cython.org/>`_ (>= 0.19.1)
    #. `HDF5 <http://www.hdfgroup.org/HDF5/>`_
    #. `PyTables <http://www.pytables.org/>`_
-   #. `Python 2.7 <http://www.python.org/>`_
+   #. `Python <http://www.python.org/>`_
    #. `LAPACK <http://www.netlib.org/lapack/>`_
    #. `BLAS <http://www.netlib.org/blas/>`_
    #. `Jinja2 <http://jinja.pocoo.org/>`_

--- a/readme.rst
+++ b/readme.rst
@@ -33,7 +33,7 @@ PyNE has the following dependencies:
    #. `Cython <http://cython.org/>`_ (>= 0.19.1)
    #. `HDF5 <http://www.hdfgroup.org/HDF5/>`_
    #. `PyTables <http://www.pytables.org/>`_
-   #. `Python 2.7 <http://www.python.org/>`_
+   #. `Python <http://www.python.org/>`_
    #. `LAPACK <http://www.netlib.org/lapack/>`_
    #. `BLAS <http://www.netlib.org/blas/>`_
    #. `Jinja2 <http://jinja.pocoo.org/>`_

--- a/readme.rst
+++ b/readme.rst
@@ -25,7 +25,6 @@ Installation
 Dependencies
 ------------
 PyNE has the following dependencies:
-
    #. `Fortran compiler <https://gcc.gnu.org/wiki/GFortran>`_
    #. `C++ compiler <https://gcc.gnu.org/>`_
    #. `CMake <http://www.cmake.org/>`_ (>= 2.8.5)
@@ -43,8 +42,10 @@ Optional Depenendencies:
    #. `MOAB <https://press3.mcs.anl.gov/sigma/moab-library>`_
    #. `PyTAPS <https://pythonhosted.org/PyTAPS/index.html>`_
 
-Additionally, building the documentation requires the following:
+To run tutorial and examples:
+   #. `jupyter <http://jupyter.org/>`_
 
+Additionally, building the documentation requires the following:
    #. `Sphinx <http://sphinx-doc.org/>`_
    #. `sphinxcontrib-bibtex <https://pypi.python.org/pypi/sphinxcontrib-bibtex/>`_
    #. `PrettyTable <https://code.google.com/p/prettytable/>`_

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ def assert_ubuntu_version():
 def assert_dep_versions():
     assert_np_version()
     assert_ubuntu_version()
-    assert_ipython_version()
 
 
 def ssl_context():

--- a/setup.py
+++ b/setup.py
@@ -101,19 +101,6 @@ def assert_np_version():
         raise ValueError(msg)
 
 
-def assert_ipython_version():
-    try:
-        import IPython
-    except ImportError:
-        return
-    low = (1, 2, 1)
-    v = IPython.__version__.split('-')[0]
-    cur = tuple(map(int, v.split('.')))
-    if cur < low:
-        msg = "ipython version is too low! {0} (have) < 2.0.0 (min)".format(v)
-        raise ValueError(msg)
-
-
 def assert_ubuntu_version():
     v = platform.uname()
     for itm in v:


### PR DESCRIPTION
This PR resolves issue #810 by deleting the ipython check from setup.py. Since it is an optional dependency, it has been added as such to the appropriate documentation. 