### PR TITLE
Deprecating py2 test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,13 +340,13 @@ workflows:
                 - develop
 
 
-      # only done on tags
-      - build_push_website_deploy:
-          requires:
-            - py2_dagmc_pymoab_test
-            - py3_dagmc_pymoab_test
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
+      # # only done on tags
+      # - build_push_website_deploy:
+      #     requires:
+      #       - py2_dagmc_pymoab_test
+      #       - py3_dagmc_pymoab_test
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,6 @@ workflows:
           requires:
             - py3_dagmc_pymoab_hdf5_12_build
 
-
       - py3_dagmc_pymoab_openmc_build:
           requires:
             - py3_dagmc_pymoab_build
@@ -322,7 +321,7 @@ workflows:
           requires:
             - py3_dagmc_pymoab_openmc_build
 
-       - py2_dagmc_pymoab_build:
+      - py2_dagmc_pymoab_build:
           requires:
             - py2_pymoab_build
       - py2_dagmc_pymoab_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,42 +236,6 @@ jobs:
             build: "python3_dagmc_pymoab_openmc"
 
 # Python 2 jobs
-# without optional depedencies
-  py2_build:
-    executor:
-      name: py2
-    working_directory: ~/repo
-    steps:
-      - checkout_build:
-          flags: ""
-          build: "python2"
-  py2_test:
-    executor:
-      name: py2
-    working_directory: ~/repo
-    steps:
-      - run_test:
-          flags: "python2"
-          build: "python2"
-
-# With PyMOAB
-  py2_pymoab_build:
-    executor:
-      name: py2_pymoab
-    working_directory: ~/repo
-    steps:
-      - checkout_build:
-          flags: "--moab $HOME/opt/moab"
-          build: "python2_pymoab"
-  py2_pymoab_test:
-    executor:
-      name: py2_pymoab
-    working_directory: ~/repo
-    steps:
-      - run_test:
-          flags: "python2"
-          build: "python2_pymoab"
-
 # With PyMOAB & DAGMC
   py2_dagmc_pymoab_build:
     executor:
@@ -358,19 +322,7 @@ workflows:
           requires:
             - py3_dagmc_pymoab_openmc_build
 
-      - py2_build
-      - py2_test:
-          requires:
-            - py2_build
-
-      - py2_pymoab_build:
-          requires:
-            - py2_build
-      - py2_pymoab_test:
-          requires:
-            - py2_pymoab_build
-
-      - py2_dagmc_pymoab_build:
+       - py2_dagmc_pymoab_build:
           requires:
             - py2_pymoab_build
       - py2_dagmc_pymoab_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ workflows:
 
       - py2_dagmc_pymoab_build:
           requires:
-            - py2_pymoab_build
+            - py3_dagmc_pymoab_build
       - py2_dagmc_pymoab_test:
           requires:
             - py2_dagmc_pymoab_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,15 +329,15 @@ workflows:
             - py2_dagmc_pymoab_build
 
 
-     # Build/Push test website
-      - build_push_website_test:
-          requires:
-            - py2_dagmc_pymoab_test
-            - py3_dagmc_pymoab_test
-          filters:
-            branches:
-              only:
-                - develop
+    #  # Build/Push test website
+    #   - build_push_website_test:
+    #       requires:
+    #         - py2_dagmc_pymoab_test
+    #         - py3_dagmc_pymoab_test
+    #       filters:
+    #         branches:
+    #           only:
+    #             - develop
 
 
       # # only done on tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,21 +256,21 @@ jobs:
 
 # Website
 # Build and push the website
-  build_push_website_test:
-    executor:
-      name: py2_dagmc_pymoab
-    working_directory: ~/repo
-    steps:
-      - website_build_push:
-          push_option: "test"
+  # build_push_website_test:
+  #   executor:
+  #     name: py2_dagmc_pymoab
+  #   working_directory: ~/repo
+  #   steps:
+  #     - website_build_push:
+  #         push_option: "test"
 
-  build_push_website_deploy:
-    executor:
-      name: py2_dagmc_pymoab
-    working_directory: ~/repo
-    steps:
-      - website_build_push:
-          push_option: "root"
+  # build_push_website_deploy:
+  #   executor:
+  #     name: py2_dagmc_pymoab
+  #   working_directory: ~/repo
+  #   steps:
+  #     - website_build_push:
+  #         push_option: "root"
 
 
 # Workflow part:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -206,6 +206,7 @@ v0.7.0 RC2
    * Removed iPython check from ``setup.py`` and added Jupyter to be an optional dependency in documentation (#1273)
    * Install Python dependencies with Pip instead of APT in Dockerfile
    * Remove if block in travis-run-tests.sh (just run nosetests)
+   * Deprecating most of the python 2 tests. Only testing python2 with pyMOAB and DAGMC deps.
 
 * Code cleanup
    * Formatting improvements


### PR DESCRIPTION
this remove most of the python2 tests.
Only keeping python2 PyNE tests with all (pyMOAB and DAGMC) dependencies.