### PR TITLE
Adding yt warning to examples notebooks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -89,7 +89,7 @@ v0.7.0 RC2
    * in material_library example, updated import and class usage to reflect MaterialLibrary changes (#1280)
    * Removed QA warnings
    * in ACE Module example, change urllib for requests
->>>>>>> changelog
+   * adds broken yt warning to examples notebooks, updates deprecated urlretrieve to requests (#1295)
 
 * Changes in source sampling for mesh-based Monte Carlo sources
    * Add statistics summary output of find_cell failure in source sampling.

--- a/examples/discretized_teapot.ipynb
+++ b/examples/discretized_teapot.ipynb
@@ -1,12 +1,19 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Known error: This notebook requires [yt](https://yt-project.org/) to visualize the results. Yt needs to be updated to work properly first. Updates are currently being made to yt's frontends to make this PyNE integration work."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from urllib.request import urlretrieve\n",
+    "import requests\n",
     "from os import path, getcwd, remove\n",
     "from numpy import linspace, bitwise_or\n",
     "\n",
@@ -20,14 +27,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "faceted_file = path.join(getcwd(), 'teapot.h5m')\n",
     "if not path.isfile(faceted_file):\n",
     "    url = \"http://data.pyne.io/teapot.h5m\"\n",
-    "    urlretrieve(url, faceted_file)\n",
+    "    r = requests.get(url)\n",
+    "    with open(\"teapot.h5m\", \"wb\") as outfile:\n",
+    "        outfile.write(r.content)\n",
     "load(faceted_file)"
    ]
   },

--- a/examples/fng_model.ipynb
+++ b/examples/fng_model.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Known error: This notebook requires [yt](https://yt-project.org/) to visualize the results. Yt needs to be updated to work properly first. Updates are currently being made to yt's frontends to make this PyNE integration work."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -12,19 +19,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "# If necessary files aren't in the current dir, download them\n",
+    "import os\n",
+    "import requests\n",
+    "\n",
     "if not os.path.isfile(\"mcnp_n_impr_fluka.h5m\"):\n",
-    "    from urllib.request import urlretrieve\n",
-    "    urlretrieve(\"http://data.pyne.io/mcnp_n_impr_fluka.h5m\", \"mcnp_n_impr_fluka.h5m\")\n",
+    "    r = requests.get(\"http://data.pyne.io/mcnp_n_impr_fluka.h5m\")\n",
+    "    with open(\"mcnp_n_impr_fluka.h5m\", \"wb\") as outfile:\n",
+    "        outfile.write(r.content)\n",
     "    \n",
     "if not os.path.isfile(\"fng_usrbin22.h5m\"):\n",
     "    # fng_usrbin22.h5m is a large file\n",
     "    # needs to be downloaded in chunks\n",
-    "    import requests\n",
     "    r = requests.get(\"http://data.pyne.io/fng_usrbin22.h5m\", stream=True)\n",
     "    with open(\"fng_usrbin22.h5m\" , 'wb') as file:\n",
     "        for chunk in r.iter_content(chunk_size=1024):\n",
@@ -110,22 +120,6 @@
     "s.annotate_triangle_facets(points, plot_args={\"colors\": 'black'})\n",
     "s.display()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/mesh_tags.ipynb
+++ b/examples/mesh_tags.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Known error: This notebook requires [yt](https://yt-project.org/) to visualize the results. Yt needs to be updated to work properly first. Updates are currently being made to yt's frontends to make this PyNE integration work."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Let's Explore PyNE Meshes!"
    ]
   },


### PR DESCRIPTION
This addresses a comment in issue #1276 about warning users about the broken yt problem. The notebooks are not rerun, and can't be until the yt changes are made. Also fixes urllib to requests where necessary. 