### PR TITLE
Remove extra flag that prevented linking FORTRAN executables.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -233,6 +233,7 @@ v0.7.0 RC2
    * updates tutorials and examples to python3 syntax to avoid failures (#1271)
    * added a welcome bot for first PR, Issue, and merge (#1287)
    * allow spatial solvers to be built in conda environments (#1305)
+   * ensure that ENSDF fortran tools are linked correctly. (#1306)
    * allow spatial solvers to be turned on/off at time of setup (#1308)
 
 * Code cleanup

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -101,7 +101,7 @@ macro(pyne_setup_fortran)
   if(Fortran_COMPILER_NAME MATCHES "gfortran.*")
     # gfortran
     set(CMAKE_Fortran_FLAGS_RELEASE
-        "-funroll-all-loops -c -fpic -fdefault-real-8 -fdefault-double-8")
+        "-funroll-all-loops -fpic -fdefault-real-8 -fdefault-double-8")
     set(CMAKE_Fortran_FLAGS_DEBUG
         "-c -fpic -fdefault-real-8 -fdefault-double-8")
   elseif(Fortran_COMPILER_NAME MATCHES "ifort.*")

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -103,7 +103,7 @@ macro(pyne_setup_fortran)
     set(CMAKE_Fortran_FLAGS_RELEASE
         "-funroll-all-loops -fpic -fdefault-real-8 -fdefault-double-8")
     set(CMAKE_Fortran_FLAGS_DEBUG
-        "-c -fpic -fdefault-real-8 -fdefault-double-8")
+        "-fpic -fdefault-real-8 -fdefault-double-8")
   elseif(Fortran_COMPILER_NAME MATCHES "ifort.*")
     # ifort (untested)
     set(CMAKE_Fortran_FLAGS_RELEASE "-f77rtl -O2 -r8")


### PR DESCRIPTION
Final linking ENSDF fortran-based helper apps was prevented by a spurious `-c` in the linking line.

That has been removed...