### PR TITLE
Fix integer division and z typo in tutorial/01-nuclide-naming.ipynb

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,7 @@ v0.7.0 RC2
    * remove Origen 2.2: H1 Cross Section for PyNE repo not supporting necessary inputs to reproduce the example.
    * in mesh basic tutorial, add broken yt warning
    * in endf reader example, cross-section plots from ENDF/B-VII.1 and updated module for deprecated urlretrieve to requests (#1297, #1226)
+   * change to integer division in example in nuclide naming tutorial, fix typo (#1310)
 
 * Changes in source sampling for mesh-based Monte Carlo sources
    * Add statistics summary output of find_cell failure in source sampling.

--- a/tutorial/01-nuclide-naming.ipynb
+++ b/tutorial/01-nuclide-naming.ipynb
@@ -227,22 +227,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "94.2420001\n",
-      "242.00010000000475\n",
+      "95\n",
+      "242\n",
       "1\n"
      ]
     }
    ],
    "source": [
     "# Am-242m\n",
-    "nuc = 942420001\n",
+    "nuc = 952420001\n",
     "\n",
     "# Z-number\n",
-    "z = nuc/10000000\n",
+    "z = nuc//10000000\n",
     "print(z)\n",
     "\n",
     "# A-number\n",
-    "a = (nuc/10000)%1000\n",
+    "a = (nuc//10000)%1000\n",
     "print(a)\n",
     "\n",
     "# state\n",
@@ -266,7 +266,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "94\n",
+      "95\n",
       "242\n",
       "1\n"
      ]


### PR DESCRIPTION
This is a fix for the nuclide naming tutorial notebook. It address an issue created by the switch to [true division](https://www.python.org/dev/peps/pep-0238/) for the `/` operator between Python 2 and 3. Using `//` instead, the fixed version works both on Python 2 and 3.

The PR also fixes a typo in the example it concerned, as the atomic number was Pu (94) not Am (95).