### PR TITLE
Update MCNP material reader to support default library identifier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ v0.7.0 RC2
    * Functions to read OpenMC state point file to get meshtally data
 
 * MCNP Support
-  * Default library reading capability from material card, such as nlib, plib and etc.
+  * Default library reading capability from material card, such as nlib, plib and etc. (#1269)
 
 * File scripts/activation_responses.py to get activation responses data for ALARA output file for better visualization. Responses include:
    * decay heat

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ v0.7.0 RC2
    * Add options to install OpenMC Python API
    * Functions to read OpenMC state point file to get meshtally data
 
+* MCNP Support
+  * Default library reading capability from material card, such as nlib, plib and etc.
+
 * File scripts/activation_responses.py to get activation responses data for ALARA output file for better visualization. Responses include:
    * decay heat
    * specific activity

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,9 +27,6 @@ v0.7.0 RC2
    * Add options to install OpenMC Python API
    * Functions to read OpenMC state point file to get meshtally data
 
-* MCNP Support
-  * Default library reading capability from material card, such as nlib, plib and etc. (#1269)
-
 * File scripts/activation_responses.py to get activation responses data for ALARA output file for better visualization. Responses include:
    * decay heat
    * specific activity
@@ -45,6 +42,9 @@ v0.7.0 RC2
    * first step for the GT-CADIS workflow, further steps to follow
 
 **Enhancements to Previous Capabilities**
+
+* MCNP Support
+  * Default library reading capability from material card, such as nlib, plib and etc. (#1316)
 
 * Turn off QA warnings by default and enable with env variable 'PYNE_QA_WARN' (#1268)
 * Enhancements of Material and MaterialLibrary capabilities

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1400,16 +1400,22 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     line_index = 1
     line = linecache.getline(filename, mat_line + line_index)
     lib_id = {}
+    lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
     # people sometimes put comments in materials and then this loop breaks                                                                                       # so we need to keep reading if we encounter comments
     while len(line.split()) > 0 and (line[0:5] == '     ' or line[0].lower() == 'c'):
         
         # For deafult cross-section library. Requires a seperate line(s) of library indicator
         # in material card 
-        lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+        
+        #if line.split()[0][0:4] in lib_name:
+        #    for item in line.split():
+        #        lib_id[item.split('=')[0]] = item.split('=')[1]
+        
+        # This is a new sloution to any case
         for token in line.split():
             if '=' in token:
                 if token.split('=')[0] in lib_name:
-                    lib_id[token.split('=')[0]] = item.split('=')[1]
+                    lib_id[token.split('=')[0]] = token.split('=')[1]
 
         # make sure element/isotope is not commented out
         if line.split()[0][0] != 'c' and line.split()[0][0] != 'C' \
@@ -1430,6 +1436,11 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     table_ids = {}
     for i in range(1, len(data_string.split())):
         if i & 1 == 1:
+
+            # Eliminates default library indicators
+            if data_string.split()[i].split('=')[0] in lib_name:
+                continue
+                
             zzzaaam = str(nucname.zzaaam(
                 nucname.mcnp_to_id(data_string.split()[i].split('.')[0])))
 
@@ -1438,6 +1449,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
                 nucvec[zzzaaam] += float(data_string.split()[i+1])
             else:
                 nucvec[zzzaaam] = float(data_string.split()[i+1])
+            
 
             if len(data_string.split()[i].split('.')) > 1:
                 table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
@@ -1537,7 +1549,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         finished_mat = mat
 
     return finished_mat
-
 
 class Wwinp(Mesh):
     """A Wwinp object stores all of the information from a single MCNP WWINP

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1417,6 +1417,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     nucvec = {}
     table_ids = {}
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+    default_libs = {}
 
     # skip the first token that is the material card identifier
     token_list = data_string.split()[1:]
@@ -1426,7 +1427,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         if '=' in token:
             lib_name, lib_num = token.split('=')
             if lib_name in lib_names:
-                mat.metadata[lib_name.upper()] = lib_num
+                default_libs[lib_name.upper()] = lib_num
         else:
             nuc_info = token.split('.')
             zzzaaam = str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
@@ -1463,6 +1464,8 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         mat = Material(nucvec=nucvec)
 
     mat.metadata['table_ids'] = table_ids
+    for lib_name, lib_num in default_libs.items():
+        mat.metadata[lib_name] = lib_num
     mat.metadata['mat_number'] = data_string.split()[0][1:]
 
     # collect metadata, if present

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1399,7 +1399,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # collect all material card data on one string
     line_index = 1
     line = linecache.getline(filename, mat_line + line_index)
-    lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
     # people sometimes put comments in materials and then this loop breaks                                                                                       # so we need to keep reading if we encounter comments
     while len(line.split()) > 0 and (line[0:5] == '     ' or line[0].lower() == 'c'):
         # make sure element/isotope is not commented out
@@ -1417,13 +1416,14 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # create dictionaries nucvec and table_ids
     nucvec = {}
     table_ids = {}
-    table_ids['default'] = {}
+    lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
     for i in range(1, len(data_string.split())):
+        # Reads default library indicators
+        token = data_string.split()[i].split('=')[0]
+        if token in lib_name:
+           table_ids[token] = data_string.split()[i].split('=')[1]             
+           continue
         if i & 1 == 1:
-            # Eliminates default library indicators
-            token = data_string.split()[i]
-            if token.split('=')[0] in lib_name:
-                table_ids['default'][.split('=')[0]] = token.split('=')[1]
             zzzaaam = str(nucname.zzaaam(
                 nucname.mcnp_to_id(token.split('.')[0])))
 
@@ -1434,7 +1434,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
                 nucvec[zzzaaam] = float(data_string.split()[i+1])
             if len(token.split('.')) > 1:
                 table_ids[str(zzzaaam)] = token.split('.')[1]
-
 
     # Check to see it material is definted my mass or atom fracs.
     # Do this by comparing the first non-zero fraction to the rest

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1406,9 +1406,10 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         # For deafult cross-section library. Requires a seperate line(s) of library indicator
         # in material card 
         lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
-        if line.split()[0][0:4] in lib_name:
-            for item in line.split():
-                lib_id[item.split('=')[0]] = item.split('=')[1]
+        for token in line.split():
+            if '=' in token:
+                if token.split('=')[0] in lib_name:
+                    lib_id[token.split('=')[0]] = item.split('=')[1]
 
         # make sure element/isotope is not commented out
         if line.split()[0][0] != 'c' and line.split()[0][0] != 'C' \

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1423,7 +1423,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
             # Eliminates default library indicators
             if data_string.split()[i].split('=')[0] in lib_name:
                 continue
-                
             zzzaaam = str(nucname.zzaaam(
                 nucname.mcnp_to_id(data_string.split()[i].split('.')[0])))
 

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1399,13 +1399,25 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # collect all material card data on one string
     line_index = 1
     line = linecache.getline(filename, mat_line + line_index)
+    lib_id = {}
     # people sometimes put comments in materials and then this loop breaks                                                                                       # so we need to keep reading if we encounter comments
     while len(line.split()) > 0 and (line[0:5] == '     ' or line[0].lower() == 'c'):
+        
+        # For deafult cross-section library. Requires a seperate line(s) of library indicator
+        # in material card 
+        lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+        if line.split()[0][0:4] in lib_name:
+            for item in line.split():
+                lib_id[item.split('=')[0]] = item.split('=')[1]
+
         # make sure element/isotope is not commented out
-        if line.split()[0][0] != 'c' and line.split()[0][0] != 'C':
+        if line.split()[0][0] != 'c' and line.split()[0][0] != 'C' \
+                                     and (line.split()[0][0:4] not in lib_name):
+
             data_string += line.split('$')[0]
             line_index += 1
             line = linecache.getline(filename, mat_line + line_index)
+            
         # otherwise this not a line we care about, move on and
         # skip lines that start with c or C
         else:
@@ -1428,6 +1440,8 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
             if len(data_string.split()[i].split('.')) > 1:
                 table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
+            else:
+                table_ids[str(zzzaaam)] = lib_id
 
     # Check to see it material is definted my mass or atom fracs.
     # Do this by comparing the first non-zero fraction to the rest

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1431,7 +1431,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
                 nucvec[zzzaaam] += float(data_string.split()[i+1])
             else:
                 nucvec[zzzaaam] = float(data_string.split()[i+1])
-            
             if len(data_string.split()[i].split('.')) > 1:
                 table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
 

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1537,6 +1537,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     return finished_mat
 
+
 class Wwinp(Mesh):
     """A Wwinp object stores all of the information from a single MCNP WWINP
     file. Weight window lower bounds are stored on a structured mesh. Only

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,7 +1415,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {'default': dict() }
+    table_ids = {'default': dict()}
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
 
     # skip the first token that is the material card identifier
@@ -1429,13 +1429,13 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
                 table_ids['default'][lib_name] = lib_num
         else:
             nuc_info = token.split('.')
-            zzzaaam =str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
+            zzzaaam = str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
             # this allows us to read nuclides that are repeated
             nuc_frac = token_list.pop(0)
             if zzzaaam in nucvec.keys():
                 nucvec[zzzaaam] += float(nuc_frac)
             else:
-                nucvec[zzzaaam] = float(nuc_frac)        
+                nucvec[zzzaaam] = float(nuc_frac)
             if len(nuc_info) > 1:
                 table_ids[str(zzzaaam)] = nuc_info[1]
 

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,7 +1415,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {'default': None}
+    table_ids = {'default': dict() }
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
 
     # skip the first token that is the material card identifier

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,7 +1415,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {'default': dict()}
+    table_ids = {}
     lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
 
     # skip the first token that is the material card identifier
@@ -1426,7 +1426,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
         if '=' in token:
             lib_name, lib_num = token.split('=')
             if lib_name in lib_names:
-                table_ids['default'][lib_name] = lib_num
+                mat.metadata[lib_name.upper()] = lib_num
         else:
             nuc_info = token.split('.')
             zzzaaam = str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1403,12 +1403,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
     # people sometimes put comments in materials and then this loop breaks                                                                                       # so we need to keep reading if we encounter comments
     while len(line.split()) > 0 and (line[0:5] == '     ' or line[0].lower() == 'c'):
-        # This line reads deafult cross-section library from material card 
-        for token in line.split():
-            if '=' in token:
-                if token.split('=')[0] in lib_name:
-                    lib_id[token.split('=')[0]] = token.split('=')[1]
-
         # make sure element/isotope is not commented out
         if line.split()[0][0] != 'c' and line.split()[0][0] != 'C':
             data_string += line.split('$')[0]
@@ -1439,11 +1433,15 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
             else:
                 nucvec[zzzaaam] = float(data_string.split()[i+1])
             
-
             if len(data_string.split()[i].split('.')) > 1:
                 table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
-            else:
-                table_ids[str(zzzaaam)] = lib_id
+
+    # This lines read default library indicators from material card.            
+    for token in data_string.split():
+        if '=' in token:
+            if token.split('=')[0] in lib_name:
+                lib_id[token.split('=')[0]] = token.split('=')[1]
+                table_ids["default"] = lib_id    
 
     # Check to see it material is definted my mass or atom fracs.
     # Do this by comparing the first non-zero fraction to the rest

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1399,7 +1399,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # collect all material card data on one string
     line_index = 1
     line = linecache.getline(filename, mat_line + line_index)
-    lib_id = {}
     lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
     # people sometimes put comments in materials and then this loop breaks                                                                                       # so we need to keep reading if we encounter comments
     while len(line.split()) > 0 and (line[0:5] == '     ' or line[0].lower() == 'c'):
@@ -1418,28 +1417,24 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # create dictionaries nucvec and table_ids
     nucvec = {}
     table_ids = {}
+    table_ids['default'] = {}
     for i in range(1, len(data_string.split())):
         if i & 1 == 1:
             # Eliminates default library indicators
-            if data_string.split()[i].split('=')[0] in lib_name:
-                continue
+            token = data_string.split()[i]
+            if token.split('=')[0] in lib_name:
+                table_ids['default'][.split('=')[0]] = token.split('=')[1]
             zzzaaam = str(nucname.zzaaam(
-                nucname.mcnp_to_id(data_string.split()[i].split('.')[0])))
+                nucname.mcnp_to_id(token.split('.')[0])))
 
             # this allows us to read nuclides that are repeated
             if zzzaaam in nucvec.keys():
                 nucvec[zzzaaam] += float(data_string.split()[i+1])
             else:
                 nucvec[zzzaaam] = float(data_string.split()[i+1])
-            if len(data_string.split()[i].split('.')) > 1:
-                table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
+            if len(token.split('.')) > 1:
+                table_ids[str(zzzaaam)] = token.split('.')[1]
 
-    # This lines read default library indicators from material card.            
-    for token in data_string.split():
-        if '=' in token:
-            if token.split('=')[0] in lib_name:
-                lib_id[token.split('=')[0]] = token.split('=')[1]
-                table_ids["default"] = lib_id    
 
     # Check to see it material is definted my mass or atom fracs.
     # Do this by comparing the first non-zero fraction to the rest

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1411,8 +1411,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
                     lib_id[token.split('=')[0]] = token.split('=')[1]
 
         # make sure element/isotope is not commented out
-        if line.split()[0][0] != 'c' and line.split()[0][0] != 'C' \
-                                     and (line.split()[0][0:4] not in lib_name):
+        if line.split()[0][0] != 'c' and line.split()[0][0] != 'C':
 
             data_string += line.split('$')[0]
             line_index += 1

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1425,15 +1425,14 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
            continue
         if i & 1 == 1:
             zzzaaam = str(nucname.zzaaam(
-                nucname.mcnp_to_id(token.split('.')[0])))
-
+                nucname.mcnp_to_id(data_string.split()[i].split('.')[0])))
             # this allows us to read nuclides that are repeated
             if zzzaaam in nucvec.keys():
                 nucvec[zzzaaam] += float(data_string.split()[i+1])
             else:
-                nucvec[zzzaaam] = float(data_string.split()[i+1])
-            if len(token.split('.')) > 1:
-                table_ids[str(zzzaaam)] = token.split('.')[1]
+                nucvec[zzzaaam] = float(data_string.split()[i+1])        
+            if len(data_string.split()[i].split('.')) > 1:
+                table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
 
     # Check to see it material is definted my mass or atom fracs.
     # Do this by comparing the first non-zero fraction to the rest

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1415,24 +1415,29 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
     # create dictionaries nucvec and table_ids
     nucvec = {}
-    table_ids = {}
-    lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
-    for i in range(1, len(data_string.split())):
-        # Reads default library indicators
-        token = data_string.split()[i].split('=')[0]
-        if token in lib_name:
-           table_ids[token] = data_string.split()[i].split('=')[1]             
-           continue
-        if i & 1 == 1:
-            zzzaaam = str(nucname.zzaaam(
-                nucname.mcnp_to_id(data_string.split()[i].split('.')[0])))
+    table_ids = {'default': None}
+    lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+
+    # skip the first token that is the material card identifier
+    token_list = data_string.split()[1:]
+    while len(token_list) > 0:
+        token = token_list.pop(0)
+
+        if '=' in token:
+            lib_name, lib_num = token.split('=')
+            if lib_name in lib_names:
+                table_ids['default'][lib_name] = lib_num
+        else:
+            nuc_info = token.split('.')
+            zzzaaam =str(nucname.zzaaam(nucname.mcnp_to_id(nuc_info[0])))
             # this allows us to read nuclides that are repeated
+            nuc_frac = token_list.pop(0)
             if zzzaaam in nucvec.keys():
-                nucvec[zzzaaam] += float(data_string.split()[i+1])
+                nucvec[zzzaaam] += float(nuc_frac)
             else:
-                nucvec[zzzaaam] = float(data_string.split()[i+1])        
-            if len(data_string.split()[i].split('.')) > 1:
-                table_ids[str(zzzaaam)] = data_string.split()[i].split('.')[1]
+                nucvec[zzzaaam] = float(nuc_frac)        
+            if len(nuc_info) > 1:
+                table_ids[str(zzzaaam)] = nuc_info[1]
 
     # Check to see it material is definted my mass or atom fracs.
     # Do this by comparing the first non-zero fraction to the rest

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1403,7 +1403,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     lib_name = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
     # people sometimes put comments in materials and then this loop breaks                                                                                       # so we need to keep reading if we encounter comments
     while len(line.split()) > 0 and (line[0:5] == '     ' or line[0].lower() == 'c'):
-        
         # This line reads deafult cross-section library from material card 
         for token in line.split():
             if '=' in token:
@@ -1412,7 +1411,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
         # make sure element/isotope is not commented out
         if line.split()[0][0] != 'c' and line.split()[0][0] != 'C':
-
             data_string += line.split('$')[0]
             line_index += 1
             line = linecache.getline(filename, mat_line + line_index)
@@ -1428,7 +1426,6 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     table_ids = {}
     for i in range(1, len(data_string.split())):
         if i & 1 == 1:
-
             # Eliminates default library indicators
             if data_string.split()[i].split('=')[0] in lib_name:
                 continue

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1404,14 +1404,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # people sometimes put comments in materials and then this loop breaks                                                                                       # so we need to keep reading if we encounter comments
     while len(line.split()) > 0 and (line[0:5] == '     ' or line[0].lower() == 'c'):
         
-        # For deafult cross-section library. Requires a seperate line(s) of library indicator
-        # in material card 
-        
-        #if line.split()[0][0:4] in lib_name:
-        #    for item in line.split():
-        #        lib_id[item.split('=')[0]] = item.split('=')[1]
-        
-        # This is a new sloution to any case
+        # This line reads deafult cross-section library from material card 
         for token in line.split():
             if '=' in token:
                 if token.split('=')[0] in lib_name:

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -1416,7 +1416,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
     # create dictionaries nucvec and table_ids
     nucvec = {}
     table_ids = {}
-    lib_names = ['nlib', 'plib', 'hlib', 'pnlib', 'elib']
+    lib_names = ['NLIB', 'PLIB', 'HLIB', 'PNLIB', 'ELIB']
     default_libs = {}
 
     # skip the first token that is the material card identifier
@@ -1426,7 +1426,7 @@ def mat_from_inp_line(filename, mat_line, densities='None'):
 
         if '=' in token:
             lib_name, lib_num = token.split('=')
-            if lib_name in lib_names:
+            if lib_name.upper() in lib_names:
                 default_libs[lib_name.upper()] = lib_num
         else:
             nuc_info = token.split('.')

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -903,7 +903,7 @@ std::string pyne::Material::phits(std::string frac_type, bool mult_den) {
   oss << " ]" << std::endl;
 
   // check for metadata
-  std::string keyworkds[6] = {"GAS", "ESTEP", "NLIB", "PLIB", "ELIB", "HLIB"};
+  std::string keyworkds[6] = {"GAS", "ESTEP", "NLIB", "PLIB", "PNLIB", "ELIB", "HLIB"};
   for (auto keyword : keyworkds){
     if (metadata.isMember(keyword)){
       oss << "     "<< keyword << "=" << metadata[keyword].asInt() << std::endl;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -903,7 +903,7 @@ std::string pyne::Material::phits(std::string frac_type, bool mult_den) {
   oss << " ]" << std::endl;
 
   // check for metadata
-  std::string keyworkds[6] = {"GAS", "ESTEP", "NLIB", "PLIB", "PNLIB", "ELIB", "HLIB"};
+  std::string keyworkds[7] = {"GAS", "ESTEP", "NLIB", "PLIB", "PNLIB", "ELIB", "HLIB"};
   for (auto keyword : keyworkds){
     if (metadata.isMember(keyword)){
       oss << "     "<< keyword << "=" << metadata[keyword].asInt() << std::endl;

--- a/tests/mcnp_inp.txt
+++ b/tests/mcnp_inp.txt
@@ -34,4 +34,6 @@ C the comments continue
 C here are more
 c even more
 m2 1000.05c 2 8000 1 $ Testing single line capability
+m3 1000 2 8000 1 $ Default library reading capability
+   nlib=60c
 

--- a/tests/mcnp_inp.txt
+++ b/tests/mcnp_inp.txt
@@ -3,7 +3,8 @@ C  cells
   1  1  -19.1  -2323   $ These are just random surface numbers
   2  2  -0.9  -1222 1002 -4002                  
   3  2   1.005E-01 $ atom density of water (not molecule density)                           
-  4  3   -1.1 -1 -2 3 4
+  4  2   -1.1 -1 -2 3 4
+  5  3   -1.1 -1 -2 3 4
 C 4  2  -2.7 $ Testing comment out capability
 c
 c Check to make sure surface cards with transformations are not
@@ -34,6 +35,6 @@ C the comments continue
 C here are more
 c even more
 m2 1000.05c 2 8000 1 $ Testing single line capability
-m3 1000 2 8000 1 $ Default library reading capability
-   nlib=60c
-
+m3 1000 2 8000 1 
+     6000 3 hlib=42h $ Default library reading capability
+     nlib=60c plib=01p 

--- a/tests/mcnp_inp.txt
+++ b/tests/mcnp_inp.txt
@@ -3,7 +3,7 @@ C  cells
   1  1  -19.1  -2323   $ These are just random surface numbers
   2  2  -0.9  -1222 1002 -4002                  
   3  2   1.005E-01 $ atom density of water (not molecule density)                           
-  4  2   -1.1 -1 -2 3 4
+  4  3   -1.1 -1 -2 3 4
 C 4  2  -2.7 $ Testing comment out capability
 c
 c Check to make sure surface cards with transformations are not

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -518,9 +518,10 @@ def test_read_mcnp():
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
-            54.047494122635584, 1.1, 6.0, {"mat_number": "3",
-                "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
-                "table_ids": {}})
+            54.047494122635584, 1.1, 6.0, 
+            {"mat_number": "3",
+             "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
+             "table_ids": {}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -519,7 +519,8 @@ def test_read_mcnp():
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
             54.047494122635584, 1.1, 6.0, {"mat_number":"3",
-            "table_ids":{"hlib":"42h","nlib":"60c","plib":"01p"}})
+            "hlib":"42h","nlib":"60c","plib":"01p",
+            "table_ids":{}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -518,9 +518,9 @@ def test_read_mcnp():
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
-            54.047494122635584, 1.1, 6.0, 
+            54.047494122635584, 1.1, 6.0,
             {"mat_number": "3",
-             "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
+             "HLIB": "42h", "NLIB": "60c", "PLIB": "01p",
              "table_ids": {}})
     expected_multimaterial = MultiMaterial({
         Material(

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -557,7 +557,7 @@ def test_read_mcnp():
              "source": " internet",
              "table_ids": {'10000': "05c", "80000":{}}}): 1})
 
-    read_materials = mats_from_inp('bcc_unit_cell_den')
+    read_materials = mats_from_inp('mcnp_inp.txt')
     assert_almost_equal(expected_material, read_materials[1])
     assert_equal(expected_material_default_lib, read_materials[3])
     assert_equal(

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -514,16 +514,12 @@ def test_read_mcnp():
         "mat_number": "1",
         "name": " leu",
         "source": " Some http://URL.com",
-        "table_ids": {'922350': "15c", "922380":{}}})
+        "table_ids": {'922350': "15c"}})
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
-                60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
-                54.047494122635584, 1.1, 6.0, 
-                {"mat_number":"3","table_ids":{
-                "10000":{"hlib":"42h","nlib":"60c","plib":"01p"},
-                "60000":{"hlib":"42h","nlib":"60c","plib":"01p"},
-                "80000":{"hlib":"42h","nlib":"60c","plib":"01p"}}})
-
+            60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
+            54.047494122635584, 1.1, 6.0, {"mat_number":"3",
+            "table_ids":{"default":{"hlib":"42h","nlib":"60c","plib":"01p"}}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},
@@ -534,7 +530,7 @@ def test_read_mcnp():
              "mat_number": "2",
              "name": " water",
              "source": " internet",
-             "table_ids": {'10000': "05c", "80000":{}}}): 1,
+             "table_ids": {'10000': "05c"}}): 1,
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},
             -1.0,
@@ -545,7 +541,7 @@ def test_read_mcnp():
              "mat_number": "2",
              "name": " water",
              "source": " internet",
-             "table_ids": {'10000': "05c", "80000":{}}}): 1,
+             "table_ids": {'10000': "05c"}}): 1,
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},
             -1.0, 1.1, 3,
@@ -555,7 +551,7 @@ def test_read_mcnp():
              "mat_number": "2",
              "name": " water",
              "source": " internet",
-             "table_ids": {'10000': "05c", "80000":{}}}): 1})
+             "table_ids": {'10000': "05c"}}): 1})
 
     read_materials = mats_from_inp('mcnp_inp.txt')
     assert_almost_equal(expected_material, read_materials[1])

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -519,7 +519,7 @@ def test_read_mcnp():
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
             54.047494122635584, 1.1, 6.0, {"mat_number":"3",
-            "table_ids":{"default":{"hlib":"42h","nlib":"60c","plib":"01p"}}})
+            "table_ids":{"hlib":"42h","nlib":"60c","plib":"01p"}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -517,8 +517,8 @@ def test_read_mcnp():
         "table_ids": {'922350': "15c"}})
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378933776, 
-            60000000: 0.6666767493126631, 80000000: 0.29602491630814726}, 
-            54.047494122635584, 1.1, 6.0,
+            60000000: 0.6666767493126631, 80000000: 0.29602491630840305}, 
+            54.04749412269001, 1.1, 6.0,
             {"mat_number": "3",
              "HLIB": "42h", "NLIB": "60c", "PLIB": "01p",
              "table_ids": {}})
@@ -557,7 +557,7 @@ def test_read_mcnp():
 
     read_materials = mats_from_inp('mcnp_inp.txt')
     assert_almost_equal(expected_material, read_materials[1])
-    assert_almost_equal(expected_material_default_lib, read_materials[3])
+    assert_equal(expected_material_default_lib, read_materials[3])
     assert_equal(
         list(expected_multimaterial._mats.keys())[0].comp.keys(),
         list(read_materials[2]._mats.keys())[0].comp.keys())

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -557,7 +557,7 @@ def test_read_mcnp():
 
     read_materials = mats_from_inp('mcnp_inp.txt')
     assert_almost_equal(expected_material, read_materials[1])
-    assert_equal(expected_material_default_lib, read_materials[3])
+    assert_almost_equal(expected_material_default_lib, read_materials[3])
     assert_equal(
         list(expected_multimaterial._mats.keys())[0].comp.keys(),
         list(read_materials[2]._mats.keys())[0].comp.keys())

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -514,8 +514,15 @@ def test_read_mcnp():
         "mat_number": "1",
         "name": " leu",
         "source": " Some http://URL.com",
-        "table_ids": {'922350': "15c"}})
+        "table_ids": {'922350': "15c", "922380":{}}})
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
+    expected_material_default_lib = Material({10000000: 0.037298334378601375, 
+                60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
+                54.047494122635584, 1.1, 6.0, 
+                {"mat_number":"3","table_ids":{
+                "10000":{"hlib":"42h","nlib":"60c","plib":"01p"},
+                "60000":{"hlib":"42h","nlib":"60c","plib":"01p"},
+                "80000":{"hlib":"42h","nlib":"60c","plib":"01p"}}})
 
     expected_multimaterial = MultiMaterial({
         Material(
@@ -527,7 +534,7 @@ def test_read_mcnp():
              "mat_number": "2",
              "name": " water",
              "source": " internet",
-             "table_ids": {'10000': "05c"}}): 1,
+             "table_ids": {'10000': "05c", "80000":{}}}): 1,
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},
             -1.0,
@@ -538,7 +545,7 @@ def test_read_mcnp():
              "mat_number": "2",
              "name": " water",
              "source": " internet",
-             "table_ids": {'10000': "05c"}}): 1,
+             "table_ids": {'10000': "05c", "80000":{}}}): 1,
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},
             -1.0, 1.1, 3,
@@ -548,10 +555,11 @@ def test_read_mcnp():
              "mat_number": "2",
              "name": " water",
              "source": " internet",
-             "table_ids": {'10000': "05c"}}): 1})
+             "table_ids": {'10000': "05c", "80000":{}}}): 1})
 
-    read_materials = mats_from_inp('mcnp_inp.txt')
+    read_materials = mats_from_inp('bcc_unit_cell_den')
     assert_almost_equal(expected_material, read_materials[1])
+    assert_equal(expected_material_default_lib, read_materials[3])
     assert_equal(
         list(expected_multimaterial._mats.keys())[0].comp.keys(),
         list(read_materials[2]._mats.keys())[0].comp.keys())

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -518,9 +518,9 @@ def test_read_mcnp():
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
-            54.047494122635584, 1.1, 6.0, {"mat_number":"3",
-            "HLIB":"42h","NLIB":"60c","PLIB":"01p",
-            "table_ids":{}})
+            54.047494122635584, 1.1, 6.0, {"mat_number": "3",
+                "HLIB":  "42h", "NLIB":"60c", "PLIB": "01p",
+                "table_ids": {}})
     expected_multimaterial = MultiMaterial({
         Material(
             {10000000: 0.1118983878322976, 80000000: 0.8881016121677024},

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -516,8 +516,8 @@ def test_read_mcnp():
         "source": " Some http://URL.com",
         "table_ids": {'922350': "15c"}})
     expected_material.mass = -1.0  # to avoid reassignment to +1.0
-    expected_material_default_lib = Material({10000000: 0.037298334378601375, 
-            60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
+    expected_material_default_lib = Material({10000000: 0.037298334378933776, 
+            60000000: 0.6666767493126631, 80000000: 0.29602491630814726}, 
             54.047494122635584, 1.1, 6.0,
             {"mat_number": "3",
              "HLIB": "42h", "NLIB": "60c", "PLIB": "01p",

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -519,7 +519,7 @@ def test_read_mcnp():
     expected_material_default_lib = Material({10000000: 0.037298334378601375, 
             60000000: 0.6666767493132514, 80000000: 0.29602491630814726}, 
             54.047494122635584, 1.1, 6.0, {"mat_number":"3",
-            "hlib":"42h","nlib":"60c","plib":"01p",
+            "HLIB":"42h","NLIB":"60c","PLIB":"01p",
             "table_ids":{}})
     expected_multimaterial = MultiMaterial({
         Material(


### PR DESCRIPTION
This takes over #1269 by completing the required rebase for this change set to pass tests.