### PR TITLE
stop CI testing Python 2

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -9,8 +9,8 @@ Executors
 ---------
 The `executors` define aliases to the environment to run the different jobs. In our case these are
 different docker images containing different combinations of the optional
-dependencies of PyNE (`MOAB`, `pyMOAB`, `DAGMC`) in one of the two supported
-Python versions (Python 2.7 or Python 3.6).
+dependencies of PyNE (`MOAB`, `pyMOAB`, `DAGMC`) in the supported
+Python version (Python 3.6).
 
 
 Commands
@@ -52,8 +52,8 @@ nosetests using the provided `flag`.
         - `flags` (string): flags to be use when running the PyNE nosetests
 
 
-`website_build_push`: pull the Python 2.7 build with all the PyNE optional
-depedencies `python2_dagmc_pymoab` saved image (using `pull_container` command),
+`website_build_push`: pull the Python 3.6 build with all the PyNE optional
+depedencies `python3_dagmc_pymoab` saved image (using `pull_container` command),
 build the website, and push it to the `pyne.github.com` repo.
     
     - `arguments`:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,6 @@ version: 2.1
 # Alias the environment on which run the different jobs
 # i.e. in this case, docker image in which the jobs will be run
 executors:
-    py2:
-        docker:
-            - image: pyne/ubuntu_18.04_py2_pyne-deps:latest
-    py2_dagmc:
-        docker:
-            - image: pyne/ubuntu_18.04_py2_dagmc_pyne-deps:latest
-    py2_pymoab:
-        docker:
-            - image: pyne/ubuntu_18.04_py2_pymoab_pyne-deps:latest
-    py2_dagmc_pymoab:
-        docker:
-            - image: pyne/ubuntu_18.04_py2_dagmc_pymoab_pyne-deps:latest
     py3:
         docker:
             - image: pyne/ubuntu_18.04_py3_pyne-deps:latest
@@ -236,30 +224,11 @@ jobs:
             flags: "python3"
             build: "python3_dagmc_pymoab_openmc"
 
-# Python 2 jobs
-# With PyMOAB & DAGMC
-  py2_dagmc_pymoab_build:
-    executor:
-      name: py2_dagmc_pymoab
-    working_directory: ~/repo
-    steps:
-      - checkout_build:
-          flags: "--moab $HOME/opt/moab --dagmc $HOME/opt/dagmc"
-          build: "python2_dagmc_pymoab"
-  py2_dagmc_pymoab_test:
-    executor:
-      name: py2_dagmc_pymoab
-    working_directory: ~/repo
-    steps:
-      - run_test:
-          flags: "python2"
-          build: "python2_dagmc_pymoab"
-
 # Website
 # Build and push the website
   # build_push_website_test:
   #   executor:
-  #     name: py2_dagmc_pymoab
+  #     name: py3_dagmc_pymoab
   #   working_directory: ~/repo
   #   steps:
   #     - website_build_push:
@@ -267,7 +236,7 @@ jobs:
 
   # build_push_website_deploy:
   #   executor:
-  #     name: py2_dagmc_pymoab
+  #     name: py3_dagmc_pymoab
   #   working_directory: ~/repo
   #   steps:
   #     - website_build_push:
@@ -322,18 +291,9 @@ workflows:
           requires:
             - py3_dagmc_pymoab_openmc_build
 
-      - py2_dagmc_pymoab_build:
-          requires:
-            - py3_dagmc_pymoab_build
-      - py2_dagmc_pymoab_test:
-          requires:
-            - py2_dagmc_pymoab_build
-
-
     #  # Build/Push test website
     #   - build_push_website_test:
     #       requires:
-    #         - py2_dagmc_pymoab_test
     #         - py3_dagmc_pymoab_test
     #       filters:
     #         branches:
@@ -344,7 +304,6 @@ workflows:
       # # only done on tags
       # - build_push_website_deploy:
       #     requires:
-      #       - py2_dagmc_pymoab_test
       #       - py3_dagmc_pymoab_test
       #     filters:
       #       branches:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -204,6 +204,7 @@ v0.7.0 RC2
 
 * Improvements in building and testing
    * require contributor to change CHANGELOG
+   * stopped all testing in Python 2 (#1321)
    * now get the base branch name from github and check change against it
       (inspired by https://github.com/NarrativeScience/circleci-orb-ghpr/blob/master/src/commands/get-pr-info.yml)
    * Expand testing matrix to include:


### PR DESCRIPTION
Now that we no longer support python 2 we should no longer test on python 2