### PR TITLE
Update conda install instruction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -204,6 +204,7 @@ IMPORTANT: Python 2 is no longer supported as of this release.  Some packages ma
    * Fix broken links (#1311)
    * Update install instructions (#1238 & #1315)
    * Update New Developers Guide
+   * Update conda install instruction
 
 * Improvements in building and testing
    * require contributor to change CHANGELOG

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ pyne Change Log
 Next Version
 ====================
 
+**Maintenance**
+
+* Documentation Changes
+   * Update conda install instruction. (#1324)
 
 v0.7.0
 ====================
@@ -204,7 +208,6 @@ IMPORTANT: Python 2 is no longer supported as of this release.  Some packages ma
    * Fix broken links (#1311)
    * Update install instructions (#1238 & #1315)
    * Update New Developers Guide
-   * Update conda install instruction
 
 * Improvements in building and testing
    * require contributor to change CHANGELOG

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -20,7 +20,7 @@ To list all of the versions of PyNE available on `conda-forge
 
     conda search -c conda-forge pyne
 
-Binary distributions of the latest release for mac and linux (64-bit) 
+Binary distributions of the latest release for linux (64-bit) 
 using the conda package manager can be installed by running the command::
 
     conda install -c conda-forge pyne
@@ -28,9 +28,9 @@ using the conda package manager can be installed by running the command::
 If you want to install PyNE with the correct package specification, try
 ``pkg_name=version=build_string``.
 
-For example, if you want to install ``pyne version=0.7.0`` with build option ``moab_openmc_py36he21c9c4_1``, you would enter::
+For example, if you want to install ``pyne version=0.7.0`` with build option ``moab_openmc``, you would enter::
 
-    conda install -c conda-forge pyne=0.7.0=moab_openmc_py36h094fa6c_0
+    conda install -c conda-forge pyne=0.7.0=moab_openmc*
 
 where version should be replaced with the version number to be installed.
 

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -14,9 +14,24 @@ option when installing conda.
 --------------------------
 Binary Package (For Users)
 --------------------------
+
+To list all of the versions of `pyne` available on `conda-forge
+<https://conda-forge.github.io/>`_ channel, in your terminal window run:
+
+    conda search -c conda-forge pyne
+
 Binary distributions of the latest release for mac and linux (64-bit) 
-using the conda package manager can be installed by running the command::
+using the conda package manager can be installed by running the command:
 
     conda install -c conda-forge pyne
+
+If you want to install PyNE with the correct package specification, try
+``pkg_name=version=build_string``.
+
+For example, if you want to install `pyne` `version=0.7.0` with build option `moab_openmc_py36he21c9c4_1`, you would enter:
+
+    conda install -c conda-forge pyne=0.7.0=moab_openmc_py36h094fa6c_0
+
+where version should be replaced with the version number to be installed.
 
 Conda binaries do not have moab/pymoab/mesh support (yet).

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -15,20 +15,20 @@ option when installing conda.
 Binary Package (For Users)
 --------------------------
 
-To list all of the versions of `pyne` available on `conda-forge
-<https://conda-forge.github.io/>`_ channel, in your terminal window run:
+To list all of the versions of PyNE available on `conda-forge
+<https://conda-forge.github.io/>`_ channel, in your terminal window run::
 
     conda search -c conda-forge pyne
 
 Binary distributions of the latest release for mac and linux (64-bit) 
-using the conda package manager can be installed by running the command:
+using the conda package manager can be installed by running the command::
 
     conda install -c conda-forge pyne
 
 If you want to install PyNE with the correct package specification, try
 ``pkg_name=version=build_string``.
 
-For example, if you want to install `pyne` `version=0.7.0` with build option `moab_openmc_py36he21c9c4_1`, you would enter:
+For example, if you want to install ``pyne version=0.7.0`` with build option ``moab_openmc_py36he21c9c4_1``, you would enter::
 
     conda install -c conda-forge pyne=0.7.0=moab_openmc_py36h094fa6c_0
 


### PR DESCRIPTION
Currently, `pyne` has several build options on `conda-forge` channel. 
```
conda install -c conda-forge pkg_name=version=build_string
```
will help users to install `pyne` with the specific build option.
