### PR TITLE
Update version numbers for release 0.7.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -24,7 +24,7 @@ Note, please do not include screenshots or snippets of code that is export contr
 
 **Please complete the following information regarding your system:**<br/>
  - OS: [e.g. ubuntu Linux]
- - PyNE Version: [e.g. 0.7.0]
+ - PyNE Version: [e.g. 0.7.1]
  - Versions of dependencies installed with: [e.g. HDF5 1.10]
 
 **Additional Context**<br/>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Next Version
    * Update conda install instruction. (#1324)
 * move join_string declaration in utils header to allow amalgamate PyNE to be compiled with clang
 
+* Bug fixes
+   * Update version numbering for release v0.7.0 (#)
+
 v0.7.0
 ====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Next Version
 * move join_string declaration in utils header to allow amalgamate PyNE to be compiled with clang
 
 * Bug fixes
-   * Update version numbering for release v0.7.0 (#)
+   * Update version numbering for release v0.7.0 (#1326)
 
 v0.7.0
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Next Version
 * move join_string declaration in utils header to allow amalgamate PyNE to be compiled with clang
 
 * Bug fixes
-   * Update version numbering for release v0.7.0 (#1326)
+   * Update version numbering for release v0.7.1 (#1326)
 
 v0.7.0
 ====================

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -28,9 +28,9 @@ using the conda package manager can be installed by running the command::
 If you want to install PyNE with the correct package specification, try
 ``pkg_name=version=build_string``.
 
-For example, if you want to install ``pyne version=0.7.0`` with build option ``moab_openmc``, you would enter::
+For example, if you want to install ``pyne version=0.7.1`` with build option ``moab_openmc``, you would enter::
 
-    conda install -c conda-forge pyne=0.7.0=moab_openmc*
+    conda install -c conda-forge pyne=0.7.1=moab_openmc*
 
 where version should be replaced with the version number to be installed.
 

--- a/docs/install/source.rst
+++ b/docs/install/source.rst
@@ -103,6 +103,6 @@ do its best to find relevant nuclear data elsewhere on your machine
 or from public sources on the internet.
 
 
-.. _zip: https://github.com/pyne/pyne/zipball/0.5.1
-.. _tar: https://github.com/pyne/pyne/tarball/0.5.1
+.. _zip: https://github.com/pyne/pyne/zipball/0.7.1
+.. _tar: https://github.com/pyne/pyne/tarball/0.7.1
 .. _GitHub: http://github.com/pyne/pyne

--- a/pyne/__init__.py
+++ b/pyne/__init__.py
@@ -2,7 +2,7 @@ import os
 from warnings import warn
 
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 if os.name == 'nt':
     p = os.environ['PATH'].split(';')

--- a/pyne/__init__.py
+++ b/pyne/__init__.py
@@ -2,7 +2,7 @@ import os
 from warnings import warn
 
 
-__version__ = '0.5.11'
+__version__ = '0.7.0'
 
 if os.name == 'nt':
     p = os.environ['PATH'].split(';')

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if '.' not in sys.path:
 def absexpanduser(x): return os.path.abspath(os.path.expanduser(x))
 
 
-VERSION = '0.7.0'
+VERSION = '0.7.1'
 IS_NT = os.name == 'nt'
 LOCALDIR = absexpanduser('~/.local')
 CMAKE_BUILD_TYPES = {

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if '.' not in sys.path:
 def absexpanduser(x): return os.path.abspath(os.path.expanduser(x))
 
 
-VERSION = '0.5.11'
+VERSION = '0.7.0'
 IS_NT = os.name == 'nt'
 LOCALDIR = absexpanduser('~/.local')
 CMAKE_BUILD_TYPES = {

--- a/setup_sub.py
+++ b/setup_sub.py
@@ -23,7 +23,7 @@ else:
 from distutils.core import setup
 
 
-VERSION = '0.5.11'
+VERSION = '0.7.0'
 IS_NT = os.name == 'nt'
 
 

--- a/setup_sub.py
+++ b/setup_sub.py
@@ -23,7 +23,7 @@ else:
 from distutils.core import setup
 
 
-VERSION = '0.7.0'
+VERSION = '0.7.1'
 IS_NT = os.name == 'nt'
 
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,7 +13,7 @@ extern "C" double endftod_(char *str, int len);
 
 std::string pyne::PYNE_DATA = "";
 std::string pyne::NUC_DATA_PATH = "";
-std::string pyne::VERSION = "0.7.0";
+std::string pyne::VERSION = "0.7.1";
 
 void pyne::pyne_start() {
 #if defined __WIN_MSVC__

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,7 +13,7 @@ extern "C" double endftod_(char *str, int len);
 
 std::string pyne::PYNE_DATA = "";
 std::string pyne::NUC_DATA_PATH = "";
-std::string pyne::VERSION = "0.5.11";
+std::string pyne::VERSION = "0.7.0";
 
 void pyne::pyne_start() {
 #if defined __WIN_MSVC__


### PR DESCRIPTION
It looks like the version numbers didn't get updated from 0.5.11 to 0.7.0 with the latest release. This means `pyne.__version__` reports the old number. This PR changes the version numbers in the code to 0.7.0. Not sure if this is how you want to catch this or if you just want to update to an appropriate number at the time of the next release.