### PR TITLE
move join_to_string declaration in the header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Next Version
 
 * Documentation Changes
    * Update conda install instruction. (#1324)
+* move join_string declaration in utils header to allow amalgamate PyNE to be compiled with clang
 
 v0.7.0
 ====================

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -319,26 +319,6 @@ std::vector<std::string> pyne::split_string(std::string particles_list, std::str
 }
 
 
-
-template<typename T>
-std::string pyne::join_to_string(std::vector<T> vect, std::string delimiter){
-  std::stringstream out;
-  out << std::setiosflags(std::ios::fixed) << std::setprecision(6);
-  
-  // ensure there is at least 1 element in the vector
-  if (vect.size() == 0)
-    return out.str();
-  // no delimiter needed before the first element
-  out << vect[0];
-  for( int i = 1; i < vect.size(); i++)
-    out << delimiter << vect[i];
-  return out.str();
-}
-template std::string pyne::join_to_string(std::vector<int> vect, std::string delimiter);
-template std::string pyne::join_to_string(std::vector<double> vect,
-                                 std::string delimiter);
-template std::string pyne::join_to_string(std::vector<std::string> vect, std::string delimiter);
-
 //
 // Math Helpers
 //

--- a/src/utils.h
+++ b/src/utils.h
@@ -131,7 +131,24 @@ namespace pyne {
 
   // join the vector element into a string, each values will be delimited ny the delimiter
   template<typename T>
-  std::string join_to_string(std::vector<T> vect, std::string delimiter = " ");
+  std::string join_to_string(std::vector<T> vect, std::string delimiter = " "){
+    std::stringstream out;
+    out << std::setiosflags(std::ios::fixed) << std::setprecision(6);
+    
+    // ensure there is at least 1 element in the vector
+    if (vect.size() == 0)
+      return out.str();
+    // no delimiter needed before the first element
+    out << vect[0];
+    for( int i = 1; i < vect.size(); i++)
+      out << delimiter << vect[i];
+    return out.str();
+  };
+  template std::string join_to_string(std::vector<int> vect,
+                                      std::string delimiter);
+  template std::string join_to_string(std::vector<double> vect,
+                                  std::string delimiter);
+  template std::string join_to_string(std::vector<std::string> vect, std::string delimiter);
 
   /// Finds the slope of a line from the points (\a x1, \a y1) and (\a x2, \a y2).
   double slope (double x2, double y2, double x1, double y1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -147,7 +147,7 @@ namespace pyne {
   template std::string join_to_string(std::vector<int> vect,
                                       std::string delimiter);
   template std::string join_to_string(std::vector<double> vect,
-                                  std::string delimiter);
+                                      std::string delimiter);
   template std::string join_to_string(std::vector<std::string> vect, std::string delimiter);
 
   /// Finds the slope of a line from the points (\a x1, \a y1) and (\a x2, \a y2).


### PR DESCRIPTION
Clang didn't like to the way the declaration of `join_to_string` was...

Moving everything int header fixed it....

this is required to amalgamated PyNE and compile it with `clang`. see svalinn/DAGMC#700