### PR TITLE
Allowing MaterialLibrary to behave like an unordered_map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ pyne Change Log
 Next Version
 ====================
 
+**New Capabilities**
+   * Adding unordered_map like API to MaterialLibrary pointing directly to the nested unordered_map
+
 **Maintenance**
 
 * Documentation Changes

--- a/pyne/cpp_material_library.pxd
+++ b/pyne/cpp_material_library.pxd
@@ -2,7 +2,7 @@
 from libcpp.set cimport set
 from libcpp.string cimport string as std_string
 from libcpp.set cimport set as std_set
-from libcpp.unordered_map cimport unordered_map
+from libcpp.unordered_map cimport unordered_map as cpp_umap
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from libcpp cimport bool
@@ -40,7 +40,10 @@ cdef extern from "material_library.h" namespace "pyne":
         cpp_material.Material get_material(std_string) except +
         shared_ptr[cpp_material.Material] get_material_ptr( std_string ) except +
         
-        unordered_map[std_string, shared_ptr[cpp_material.Material]] get_mat_library() except + 
+        cpp_umap[std_string, shared_ptr[cpp_material.Material]] get_mat_library() except + 
         std_set[std_string] get_keylist() except +
         std_set[int] get_nuclist() except +
         int size() except +
+        cpp_umap[std_string, shared_ptr[cpp_material.Material]].iterator begin() except +
+        cpp_umap[std_string, shared_ptr[cpp_material.Material]].iterator end() except +
+

--- a/pyne/material_library.pxd
+++ b/pyne/material_library.pxd
@@ -23,4 +23,4 @@ cdef class _MaterialLibrary:
     cdef cpp_set[int] get_nuclist(self)
 
 cdef cpp_umap[std_string, shared_ptr[cpp_material.Material]] dict_to_map_str_matp(dict)
-cdef dict map_to_dict_str_matp(cpp_umap[std_string, shared_ptr[cpp_material.Material]])
+cdef dict matlib_to_dict_str_matp(cpp_material_library.MaterialLibrary)

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -251,7 +251,7 @@ cdef class _MaterialLibrary:
         self.del_material(ensure_material_key(key))
 
     def __iter__(self):
-        mat_lib_dict = map_to_dict_str_matp(self._inst.get_mat_library())
+        mat_lib_dict = matlib_to_dict_str_matp(deref(self._inst))
         self._iter_mat_lib = mat_lib_dict
         mat_lib_iter = iter(mat_lib_dict)
         return mat_lib_iter
@@ -292,12 +292,12 @@ cdef cpp_umap[std_string, shared_ptr[cpp_material.Material]] dict_to_map_str_mat
 
     return cppmap
 
-# u_map<string, Material *> to python dict
-cdef dict map_to_dict_str_matp(cpp_umap[std_string, shared_ptr[cpp_material.Material]] cppmap):
+# MaterialLibrary to python dict
+cdef dict matlib_to_dict_str_matp(cpp_material_library.MaterialLibrary cpp_mat_lib):
     pydict = {}
-    cdef cpp_umap[std_string, shared_ptr[cpp_material.Material]].iterator mapiter = cppmap.begin()
+    cdef cpp_umap[std_string, shared_ptr[cpp_material.Material]].iterator mapiter = cpp_mat_lib.begin()
 
-    while mapiter != cppmap.end():
+    while mapiter != cpp_mat_lib.end():
         py_mat = material.Material(free_mat=False)
         ( < material._Material > py_mat).mat_pointer = (deref(mapiter).second).get()
         pydict[ < char * > deref(mapiter).first.c_str()] = py_mat

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -143,11 +143,24 @@ class MaterialLibrary {
    * \return std::set<int>
    */
   pyne::nuc_set get_nuclist() const { return nuclist; }
-  /**
-   * \brief Get the szie of the Library
-   * \return int
-   */
-  int size() const { return material_library.size(); }
+
+  /** Set of method allowing MaterialLibrary to behave like a undordered_map, 
+   * pointing directly to the nested material_library
+  **/
+  typedef mat_map::iterator iterator;
+  typedef mat_map::const_iterator const_iterator;
+  iterator begin() { return material_library.begin(); }
+  iterator end() { return material_library.end(); }
+
+  const_iterator cbegin() const { return material_library.cbegin(); }
+  const_iterator cend() const { return material_library.cend(); }
+  std::size_t size() const { return material_library.size(); }
+  bool emtpy() const {return material_library.empty(); }
+  std::size_t count(std::string mat_name) const {
+    return material_library.count(mat_name);
+  }
+  std::shared_ptr<Material>& operator[] ( const std::string& k ) {return material_library[k];}
+  std::shared_ptr<Material>& operator[] ( std::string&& k ) {return material_library[k];}
 
  private:
   /**

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -144,9 +144,9 @@ class MaterialLibrary {
    */
   pyne::nuc_set get_nuclist() const { return nuclist; }
 
-  /** Set of method allowing MaterialLibrary to behave like a undordered_map, 
+  /** Set of method allowing MaterialLibrary to behave like a undordered_map,
    * pointing directly to the nested material_library
-  **/
+   **/
   typedef mat_map::iterator iterator;
   typedef mat_map::const_iterator const_iterator;
   iterator begin() { return material_library.begin(); }
@@ -155,12 +155,16 @@ class MaterialLibrary {
   const_iterator cbegin() const { return material_library.cbegin(); }
   const_iterator cend() const { return material_library.cend(); }
   std::size_t size() const { return material_library.size(); }
-  bool emtpy() const {return material_library.empty(); }
+  bool emtpy() const { return material_library.empty(); }
   std::size_t count(std::string mat_name) const {
     return material_library.count(mat_name);
   }
-  std::shared_ptr<Material>& operator[] ( const std::string& k ) {return material_library[k];}
-  std::shared_ptr<Material>& operator[] ( std::string&& k ) {return material_library[k];}
+  std::shared_ptr<Material>& operator[](const std::string& k) {
+    return material_library[k];
+  }
+  std::shared_ptr<Material>& operator[](std::string&& k) {
+    return material_library[k];
+  }
 
  private:
   /**


### PR DESCRIPTION
this add most the the `unodered_map` API to the MaterialLibrary front-end.

this API link directly to the nested unordered_map (the material_library) to simplify calls.