### PR TITLE
Fixes for nuc_data_make to work from scratch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,10 @@ v0.7.6
    * add ifbar to cleanup the code about progress bar (#1409)
    * use ifbar to print progress of mesh_to_fluxin (#1401)
    * pep8 formatting applied to all py files (#1436)
+   * * Fixes for nuc_data_make (#1333)
+      * new download location for KAERI data archive
+      * do not try to download missing (super heavy) data from KAERI
+      * update material_library writing interface
 
 v0.7.5
 ======
@@ -157,7 +161,7 @@ v0.7.1
 ======
 
 **New Capabilities**
-   * Adding unordered_map like API to MaterialLibrary pointing directly to the nested unordered_map
+   * Adding unordered_map like API to MaterialLibrary pointing directly to the nested unordered_map (#1330)
 
 **Maintenance**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Next Version
 ============
 **Fix**
    * Fix Type Mismatch Error in PyNE's ENSDF Processing Module (#1519)
+   * Fixes for nuc_data_make (#1333)
+      * new download location for KAERI data archive
+      * do not try to download missing (super heavy) data from KAERI
+      * update material_library writing interface
 
 v0.7.8
 ======
@@ -69,10 +73,6 @@ v0.7.6
    * add ifbar to cleanup the code about progress bar (#1409)
    * use ifbar to print progress of mesh_to_fluxin (#1401)
    * pep8 formatting applied to all py files (#1436)
-   * * Fixes for nuc_data_make (#1333)
-      * new download location for KAERI data archive
-      * do not try to download missing (super heavy) data from KAERI
-      * update material_library writing interface
 
 v0.7.5
 ======

--- a/pyne/dbgen/materials_library.py
+++ b/pyne/dbgen/materials_library.py
@@ -135,7 +135,7 @@ def parse_materials(mats, lines):
 # Writes to file
 def make_materials_compendium(nuc_data, matslib):
     """Adds materials compendium to nuc_data.h5."""
-    matslib.write_hdf5(nuc_data)
+    matslib.write_hdf5(nuc_data, datapath="/material_library/materials")
 
 
 def make_matslib(fname):

--- a/pyne/dbgen/simple_xs.py
+++ b/pyne/dbgen/simple_xs.py
@@ -29,19 +29,19 @@ def grab_kaeri_simple_xs(build_dir=""):
     build_dir : str
         Major directory to place html files in. 'KAERI/' will be appended.
     """
-    zip_path = os.path.join(build_dir, "kaeri.zip")
-    zip_url = "http://data.pyne.io/kaeri.zip"
+    zip_path = os.path.join(build_dir, 'kaeri.zip')
+    zip_url = 'http://raw.githubusercontent.com/pyne/data/master/kaeri.zip'
     if not os.path.exists(zip_path):
         print("  grabbing {0} and placing it in {1}".format(zip_url, zip_path))
         urllib.urlretrieve(zip_url, zip_path)
-        try:
-            zf = ZipFile(zip_path)
-            for name in zf.namelist():
-                if not os.path.exists(os.path.join(build_dir, name)):
-                    print("    extracting {0} from {1}".format(name, zip_path))
-                    zf.extract(name, build_dir)
-        finally:
-            zf.close()
+    try:
+        zf = ZipFile(zip_path)
+        for name in zf.namelist():
+            if not os.path.exists(os.path.join(build_dir, name)):
+                print("    extracting {0} from {1}".format(name, zip_path))
+                zf.extract(name, build_dir)
+    finally:
+        zf.close()
 
     # Add kaeri to build_dir
     build_dir = os.path.join(build_dir, "KAERI")
@@ -56,10 +56,10 @@ def grab_kaeri_simple_xs(build_dir=""):
     for element in nucname.name_zz.keys():
         htmlfile = element.upper() + ".html"
         if htmlfile not in already_grabbed:
-            grab_kaeri_nuclide(element.upper(), build_dir)
-        all_nuclides = all_nuclides | parse_for_all_isotopes(
-            os.path.join(build_dir, htmlfile)
-        )
+            pass
+        else:
+            all_nuclides = all_nuclides | parse_for_all_isotopes(os.path.join(build_dir, 
+                                                                          htmlfile))
 
     # Grab nuclide XS summary files
     for nuc in sorted(all_nuclides):
@@ -165,10 +165,11 @@ def parse_simple_xs(build_dir=""):
     # Grab and parse elemental summary files.
     all_nuclides = set()
     for element in nucname.name_zz.keys():
-        htmlfile = element.upper() + ".html"
-        all_nuclides = all_nuclides | parse_for_all_isotopes(
-            os.path.join(build_dir, htmlfile)
-        )
+        htmlfile = element.upper() + '.html'
+        # missing data for newer super-heavy elements
+        if os.path.exists(os.path.join(build_dir,htmlfile)):
+            all_nuclides = all_nuclides | parse_for_all_isotopes(os.path.join(build_dir, 
+                                                                          htmlfile))
     all_nuclides = sorted([nucname.id(nuc) for nuc in all_nuclides])
     energy_tables = dict(
         [

--- a/pyne/dbgen/simple_xs.py
+++ b/pyne/dbgen/simple_xs.py
@@ -30,7 +30,7 @@ def grab_kaeri_simple_xs(build_dir=""):
         Major directory to place html files in. 'KAERI/' will be appended.
     """
     zip_path = os.path.join(build_dir, 'kaeri.zip')
-    zip_url = 'http://raw.githubusercontent.com/pyne/data/master/kaeri.zip'
+    zip_url = 'https://raw.githubusercontent.com/pyne/data/master/kaeri.zip'
     if not os.path.exists(zip_path):
         print("  grabbing {0} and placing it in {1}".format(zip_url, zip_path))
         urllib.urlretrieve(zip_url, zip_path)
@@ -55,9 +55,7 @@ def grab_kaeri_simple_xs(build_dir=""):
     all_nuclides = set()
     for element in nucname.name_zz.keys():
         htmlfile = element.upper() + ".html"
-        if htmlfile not in already_grabbed:
-            pass
-        else:
+        if htmlfile in already_grabbed:
             all_nuclides = all_nuclides | parse_for_all_isotopes(os.path.join(build_dir, 
                                                                           htmlfile))
 


### PR DESCRIPTION
This set of changes is intended to allow `nuc_data_make` to function correctly when working from scratch rather than from the prebuilt data.

* Changes to KAERI data:
   * different download location for zip file
   * don't try to download missing data (super-heavy elements) from KAERI, it's no longer available
* Changes to writing material library for new interface