### PR TITLE
Now adds number material when added to a MaterialLibrary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ pyne Change Log
 Next Version
 ====================
 
-
+**Change**
+   * Now attribute a number to material when adding them into a material library (#1334)
 
 v0.7.1
 ====================

--- a/src/material_library.cpp
+++ b/src/material_library.cpp
@@ -152,6 +152,14 @@ int pyne::MaterialLibrary::ensure_material_number(pyne::Material& mat) const {
       warning(msg);
     }
   }
+  if (mat_number == -1) {
+    if (!mat_number_set.empty())
+      mat_number = *mat_number_set.rbegin() + 1;
+    else {
+      mat_number = 1;
+    }
+    mat.metadata["mat_number"] = mat_number;
+  }
   return mat_number;
 }
 
@@ -169,13 +177,6 @@ std::string pyne::MaterialLibrary::ensure_material_name_and_number(
       mat_name = mat.metadata["name"].asString();
     }
   } else {
-    if (mat_number == -1) {
-      if (!mat_number_set.empty())
-        mat_number = *mat_number_set.rbegin() + 1;
-      else {
-        mat_number = 1;
-      }
-    }
     mat_name = "_" + std::to_string(mat_number);
     mat.metadata["name"] = mat_name;
   }


### PR DESCRIPTION
this change the behavior of  the `add_material()` of the `MaterialLibrary`, if no number were associated to the material :
- before: a number was found and used to name the material if it had no name (the number was not attributed
to the material)
- now: a number is found and attributed to the material if it has none...