### PR TITLE
update the address of the materials group for the hash checking

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,11 @@ Next Version
 ====================
 
 **Change**
+
    * Now attribute a number to material when adding them into a material library (#1334)
 
 **Fix**
+
    * change the ref address of the materials group in the nuc_data.h5 material_library (to match new format) (#1337)
 
 v0.7.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Next Version
 **Change**
    * Now attribute a number to material when adding them into a material library (#1334)
 
+**Fix**
+   * change the ref address of the materials group in the nuc_data.h5 material_library (to match new format) (#1337)
+
 v0.7.1
 ====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Next Version
 **Fix**
 
    * change the ref address of the materials group in the nuc_data.h5 material_library (to match new format) (#1337)
+   * clean the remaining calls to the old material_library write_hdf5 API
 
 v0.7.1
 ====================

--- a/pyne/dbgen/hashtools.py
+++ b/pyne/dbgen/hashtools.py
@@ -12,7 +12,7 @@ from .. import data
 QA_warn(__name__)
 
 # list of nodes from distinct data sets
-nodelist = ['/atomic_mass', '/material_library',
+nodelist = ['/atomic_mass', '/material_library/materials',
             '/neutron/eaf_xs', '/neutron/scattering_lengths',
             '/neutron/simple_xs', '/decay', '/dose_factors']
 

--- a/pyne/dbgen/materials_library.py
+++ b/pyne/dbgen/materials_library.py
@@ -128,7 +128,7 @@ def parse_materials(mats, lines):
 # Writes to file
 def make_materials_compendium(nuc_data, matslib):
     """Adds materials compendium to nuc_data.h5."""
-    matslib.write_hdf5(nuc_data, datapath="/materials")
+    matslib.write_hdf5(nuc_data)
 
 
 def make_matslib(fname):

--- a/pyne/dbgen/materials_library.py
+++ b/pyne/dbgen/materials_library.py
@@ -128,8 +128,7 @@ def parse_materials(mats, lines):
 # Writes to file
 def make_materials_compendium(nuc_data, matslib):
     """Adds materials compendium to nuc_data.h5."""
-    matslib.write_hdf5(nuc_data, datapath="/material_library/materials",
-                       nucpath="/material_library/nucid")
+    matslib.write_hdf5(nuc_data, datapath="/materials")
 
 
 def make_matslib(fname):

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -50,7 +50,7 @@ def setup():
         urlretrieve(o2benchurl, H5NAME)
         sys.stderr.write("done.\n")
         sys.stderr.flush()
-    MATS = MaterialLibrary(H5NAME, "/materials")
+    MATS = MaterialLibrary(H5NAME)
     with open('o2hls.json', 'r') as f:
         O2HLS = json.load(f)
     O2HLS = {int(nuc): v for nuc, v in O2HLS.items()}

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -149,8 +149,8 @@ def test_matlib_json():
 def test_matlib_hdf5_nuc_data():
     matlib = MaterialLibrary()
     matlib.from_hdf5(nuc_data, "/materials")
-    matlib.write_hdf5("matlib_test.h5", "/materials")
-    mat_lib_load_test = MaterialLibrary("matlib_test.h5", "/materials")
+    matlib.write_hdf5("matlib_test.h5")
+    mat_lib_load_test = MaterialLibrary("matlib_test.h5")
     os.remove("matlib_test.h5")
     for key in matlib:
         assert_mat_almost_equal(matlib[key], mat_lib_load_test[key])

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -95,7 +95,7 @@ def test_against_nuc_data():
     if not os.path.isfile(nuc_data):
         raise RuntimeError(
             "Tests require nuc_data.h5. Please run nuc_data_make.")
-    obs_matslib = MaterialLibrary(nuc_data, "/materials")
+    obs_matslib = MaterialLibrary(nuc_data)
     gasoline = Material({
         "H": 0.157000,
         "C": 0.843000,

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -95,7 +95,7 @@ def test_against_nuc_data():
     if not os.path.isfile(nuc_data):
         raise RuntimeError(
             "Tests require nuc_data.h5. Please run nuc_data_make.")
-    obs_matslib = MaterialLibrary(nuc_data)
+    obs_matslib = MaterialLibrary(nuc_data, "/materials")
     gasoline = Material({
         "H": 0.157000,
         "C": 0.843000,
@@ -148,7 +148,7 @@ def test_matlib_json():
 
 def test_matlib_hdf5_nuc_data():
     matlib = MaterialLibrary()
-    matlib.from_hdf5(nuc_data)
+    matlib.from_hdf5(nuc_data, "/materials")
     matlib.write_hdf5("matlib_test.h5", "/materials")
     mat_lib_load_test = MaterialLibrary("matlib_test.h5", "/materials")
     os.remove("matlib_test.h5")

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -95,8 +95,7 @@ def test_against_nuc_data():
     if not os.path.isfile(nuc_data):
         raise RuntimeError(
             "Tests require nuc_data.h5. Please run nuc_data_make.")
-    obs_matslib = MaterialLibrary(nuc_data,
-                                  datapath="/material_library/materials")
+    obs_matslib = MaterialLibrary(nuc_data)
     gasoline = Material({
         "H": 0.157000,
         "C": 0.843000,
@@ -149,7 +148,7 @@ def test_matlib_json():
 
 def test_matlib_hdf5_nuc_data():
     matlib = MaterialLibrary()
-    matlib.from_hdf5(nuc_data, datapath="/material_library/materials")
+    matlib.from_hdf5(nuc_data)
     matlib.write_hdf5("matlib_test.h5", "/materials")
     mat_lib_load_test = MaterialLibrary("matlib_test.h5", "/materials")
     os.remove("matlib_test.h5")


### PR DESCRIPTION
New API of the MaterialLibrary write (in HDF5) the `materials` group in the `/maerial_library` dataset.

this reflect that change for hash checking.