### PR TITLE
Add dockerhub authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,21 +6,39 @@ executors:
     py3:
         docker:
             - image: pyne/ubuntu_18.04_py3_pyne-deps:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
     py3_dagmc:
         docker:
             - image: pyne/ubuntu_18.04_py3_dagmc_pyne-deps:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
     py3_pymoab:
         docker:
             - image: pyne/ubuntu_18.04_py3_pymoab_pyne-deps:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
     py3_dagmc_pymoab:
         docker:
             - image: pyne/ubuntu_18.04_py3_dagmc_pymoab_pyne-deps:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
     py3_dagmc_pymoab_hdf5_12:
         docker:
             - image: pyne/ubuntu_18.04_py3_hdf5-1_12_0_dagmc_pymoab_pyne-deps:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
     py3_dagmc_pymoab_openmc:
         docker:
             - image: pyne/ubuntu_18.04_py3_dagmc_pymoab_openmc_pyne-deps:latest
+              auth:
+                username: $DOCKERHUB_USER
+                password: $DOCKERHUB_PASS
 
 
 # Commands:
@@ -252,6 +270,7 @@ workflows:
   build_and_test:
     jobs:
       - changelog_update:
+          context: Dockerhub
           filters:
             branches:
               ignore: develop
@@ -259,35 +278,45 @@ workflows:
               ignore: /.*/   
       
       - py3_build
+          context: Dockerhub
       - py3_test:
+          context: Dockerhub
           requires:
             - py3_build
 
       - py3_pymoab_build:
+          context: Dockerhub
           requires:
             - py3_build
       - py3_pymoab_test:
+          context: Dockerhub
           requires:
             - py3_pymoab_build
 
       - py3_dagmc_pymoab_build:
+          context: Dockerhub
           requires:
             - py3_pymoab_build
       - py3_dagmc_pymoab_test:
+          context: Dockerhub
           requires:
             - py3_dagmc_pymoab_build
 
       - py3_dagmc_pymoab_hdf5_12_build:
+          context: Dockerhub
           requires:
             - py3_dagmc_pymoab_build
       - py3_dagmc_pymoab_hdf5_12_test:
+          context: Dockerhub
           requires:
             - py3_dagmc_pymoab_hdf5_12_build
 
       - py3_dagmc_pymoab_openmc_build:
+          context: Dockerhub
           requires:
             - py3_dagmc_pymoab_build
       - py3_dagmc_pymoab_openmc_test:
+          context: Dockerhub
           requires:
             - py3_dagmc_pymoab_openmc_build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ workflows:
             tags:
               ignore: /.*/   
       
-      - py3_build
+      - py3_build:
           context: Dockerhub
       - py3_test:
           context: Dockerhub

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Next Version
    * change the ref address of the materials group in the nuc_data.h5 material_library (to match new format) (#1337)
    * clean the remaining calls to the old material_library write_hdf5 API
 
+**Maintenance**
+   * Add dockerhub authorization for pulling images
+
 v0.7.1
 ====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Next Version
    * clean the remaining calls to the old material_library write_hdf5 API
 
 **Maintenance**
-   * Add dockerhub authorization for pulling images
+   * Add dockerhub authentication for pulling images
 
 v0.7.1
 ====================


### PR DESCRIPTION
This PR adds Docker Hub authentication for CI according to upcoming changes on Docker Hub policy.
A context has been created in PyNE CI under the name `Dockerhub`