### PR TITLE
adding the missing const begin() end() for MaterialLibrary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Next Version
 
 **Change**
 
-   * Now attribute a number to material when adding them into a material library (#1334)
+   * Now attribute a number to material when adding them into a material library (#1334 & #1350)
    * Update OVA link in the docs (#1348)
    * Bump license date to 2020 (#1348)
 

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -151,9 +151,11 @@ class MaterialLibrary {
   typedef mat_map::const_iterator const_iterator;
   iterator begin() { return material_library.begin(); }
   iterator end() { return material_library.end(); }
-
+  const_iterator begin() const { return material_library.begin(); }
+  const_iterator end() const { return material_library.end(); }
   const_iterator cbegin() const { return material_library.cbegin(); }
   const_iterator cend() const { return material_library.cend(); }
+
   std::size_t size() const { return material_library.size(); }
   bool emtpy() const { return material_library.empty(); }
   std::size_t count(std::string mat_name) const {

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -157,7 +157,7 @@ class MaterialLibrary {
   const_iterator cend() const { return material_library.cend(); }
 
   std::size_t size() const { return material_library.size(); }
-  bool emtpy() const { return material_library.empty(); }
+  bool empty() const { return material_library.empty(); }
   std::size_t count(std::string mat_name) const {
     return material_library.count(mat_name);
   }


### PR DESCRIPTION
This add some of the missing API to allow the MAterialLibrary to act as a `map<string, shared_ptr<Material>>`