### PR TITLE
Return pointer for the member variable in ValueError::what()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next Version
 
 **Change**
 
+   * Update pyne::ValueError to return a pointer to a stored string instead of an out-of-scope string. (#1358)
    * Change the e_bounds tag unit from eV to MeV (#1353)
    * Add functions to tag the decay_time, source_intensity and version to source.h5m (#1352)
 
@@ -18,7 +19,7 @@ Next Version
 
 **Maintenance**
 
-v0.7.3 
+v0.7.3
 ======
 
 **Change**
@@ -27,7 +28,7 @@ v0.7.3
    * Bump license date to 2020 (#1348)
    * Add the energy boundaries to photon source file (#1341)
    * Add a new source sampling sampler without e_bounds (#1341)
-   
+
 **Fix**
    * Compatibility fix with MCNP6 ptracs. (#1336)
    * Add some missing pieces in MaterialLibrary API to match std::unordered_map one (#1350)
@@ -38,7 +39,7 @@ v0.7.2
 **Change**
 
    * Now attribute a number to material when adding them into a material library (#1334)
- 
+
 **Fix**
 
    * change the ref address of the materials group in the nuc_data.h5 material_library (to match new format) (#1337)

--- a/src/utils.h
+++ b/src/utils.h
@@ -134,7 +134,7 @@ namespace pyne {
   std::string join_to_string(std::vector<T> vect, std::string delimiter = " "){
     std::stringstream out;
     out << std::setiosflags(std::ios::fixed) << std::setprecision(6);
-    
+
     // ensure there is at least 1 element in the vector
     if (vect.size() == 0)
       return out.str();
@@ -164,7 +164,7 @@ namespace pyne {
   // File Helpers
   /// Returns true if the file can be found.
   bool file_exists(std::string strfilename);
-  
+
   // turns the filename string into the full file path
   std::string get_full_filepath(char* filename);
   // turns the filename string into the full file path
@@ -222,20 +222,17 @@ namespace pyne {
     /// constructor with the filename \a fname.
     ValueError(std::string msg)
     {
-      message = msg;
+      message = "ValueError: " + msg;
     };
 
     /// Creates a helpful error message.
     virtual const char* what() const throw()
     {
-      std::string msgstr ("ValueError: ");
-      if (!message.empty())
-        msgstr += message;
-      const char* msgstr_rtn = msgstr.c_str();
+      const char* msgstr_rtn = message.c_str();
       return msgstr_rtn;
     };
 
-  private:
+  protected:
     std::string message; ///< extra message for the user.
   };
 


### PR DESCRIPTION
A proposed fix for #1357.

The main change here is that the `"ValueError: "` prefix is added in the constructor instead of in the `::what` method. The main consequence here is that extracting the original message becomes more tricky, but in practice, I think this an exceedingly rare use case for the object.

Just a note that this is _fix_, but the best long term solution may be to inherit from `std::runtime_error` or the like, which manages the error message and any exceptions that may arise from the internal string's construction (i.e. `ValueErrror::message`) as well.