### PR TITLE
Set CMP0074 regarding *_ROOT CMake variables.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next Version
 
 **Change**
 
+   * Setting CMP0074 in CMakeLists.txt to allow `*_ROOT` variables in the CMake command.
    * Change the e_bounds tag unit from eV to MeV (#1353)
    * Add functions to tag the decay_time, source_intensity and version to source.h5m (#1352)
 
@@ -18,7 +19,7 @@ Next Version
 
 **Maintenance**
 
-v0.7.3 
+v0.7.3
 ======
 
 **Change**
@@ -27,7 +28,7 @@ v0.7.3
    * Bump license date to 2020 (#1348)
    * Add the energy boundaries to photon source file (#1341)
    * Add a new source sampling sampler without e_bounds (#1341)
-   
+
 **Fix**
    * Compatibility fix with MCNP6 ptracs. (#1336)
    * Add some missing pieces in MaterialLibrary API to match std::unordered_map one (#1350)
@@ -38,7 +39,7 @@ v0.7.2
 **Change**
 
    * Now attribute a number to material when adding them into a material library (#1334)
- 
+
 **Fix**
 
    * change the ref address of the materials group in the nuc_data.h5 material_library (to match new format) (#1337)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Defines the CMake commands/policies
 cmake_minimum_required(VERSION 3.0.0)
-
+cmake_policy(SET CMP0074 NEW)
 # Make the scripts available in the 'cmake' directory available for the
 # 'include()' command, 'find_package()' command.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
@@ -84,7 +84,7 @@ MESSAGE("--    HDF5 Library directories: ${HDF5_LIBRARY_DIRS}")
 MESSAGE("--    HDF5 Libraries: ${HDF5_C_LIBRARIES}")
 MESSAGE("--    HDF5 library version: ${HDF5_VERSION}")
 
-# Version 1.12 of HDF5 deprecates the H5Oget_info_by_idx(), 
+# Version 1.12 of HDF5 deprecates the H5Oget_info_by_idx(),
 # H5O_info_t() and H5Oget_info_by_name() interfaces.
 # Thus, we give these flags to allow usage of the old interface in newer
 # versions of HDF5.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Defines the CMake commands/policies
 cmake_minimum_required(VERSION 3.0.0)
-cmake_policy(SET CMP0074 NEW)
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+  cmake_policy(SET CMP0074 NEW)
+endif()
 # Make the scripts available in the 'cmake' directory available for the
 # 'include()' command, 'find_package()' command.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")


### PR DESCRIPTION
## Description

Resolves #1359. Set's the CMake policy to allow use of the `*_ROOT` variables in the CMake command generated by `setup.py`.


