### PR TITLE
use except + in transmuters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Next Version
 **Fix**
 
    * An e_bounds reading problem when old sampler is used without e_bounds text file (#1353)
+   * Fix the compatibility problem of transmuters with numpy version v1.19.x
 
 **Maintenance**
 

--- a/pyne/cpp_transmuters.pxd
+++ b/pyne/cpp_transmuters.pxd
@@ -5,6 +5,6 @@ from libcpp.vector cimport vector
 
 cdef extern from "transmuters.h" namespace "pyne::transmuters":
 
-    map[int, double] cram(vector[double], const map[int, double]) except +ValueError
-    map[int, double] cram(vector[double], const map[int, double], const int) except +ValueError
+    map[int, double] cram(vector[double], const map[int, double]) except +
+    map[int, double] cram(vector[double], const map[int, double], const int) except +
 


### PR DESCRIPTION
## Description
A build failure related to Numpy , Cython and `cpp_transmuters.pxd` is reported in https://github.com/pyne/pyne/issues/1340. 
This error happens when Numpy 1.19.x is used.
The solution is proposed in https://github.com/pyne/pyne/issues/1340#issuecomment-752052914, and presented in this PR.

## Changes
Change the way to raise an Except to avoid build failure with numpy v1.19.x.
