### PR TITLE
Fix to __delitem__ method of MaterialLibrary. 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Next Version
 
    * An e_bounds reading problem when old sampler is used without e_bounds text file (#1353)
    * Fix the compatibility problem of transmuters with numpy version v1.19.x
+   * Fix to MaterialLibrary.__delitem__ to call the underlying instance.
 
 **Maintenance**
 

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -248,7 +248,8 @@ cdef class _MaterialLibrary:
         return self._inst.size()
 
     def __delitem__(self, key):
-        self.del_material(ensure_material_key(key))
+        c_key = ensure_material_key(key)
+        self._inst.del_material(< std_string > c_key)
 
     def __iter__(self):
         mat_lib_dict = matlib_to_dict_str_matp(deref(self._inst))

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -226,3 +226,31 @@ def test_matlib_query():
     matlib["leu"] = mat_leu
     matlib_leu = matlib["leu"]
     assert_mat_almost_equal(mat_leu, matlib_leu)
+
+def test_matlib_delete():
+    water = Material()
+    water.from_atom_frac({10000000: 2.0, 80000000: 1.0})
+    water.metadata["name"] = "Aqua sera."
+
+    pubr3 = Material({
+        "Br": 0.500617,
+        "Pu-238": 0.000250,
+        "Pu-239": 0.466923,
+        "Pu-240": 0.029963,
+        "Pu-241": 0.001998,
+        "Pu-242": 0.000250
+    },
+        density=6.75,
+        metadata={"name": "Plutonium Bromide"}).expand_elements()
+
+    lib = {"pubr3": pubr3, "aqua": water}
+    matlib = MaterialLibrary(lib)
+
+    # test delete methods
+    matlib.remove_material("pubr3")
+
+    assert len(matlib) == 1
+
+    del matlib["aqua"]
+
+    assert len(matlib) == 0


### PR DESCRIPTION
This fixes a call in `MaterialLibrary.__delitem__`. Also adds a couple of tests for the material removal methods of the `MaterialLibrary`.