### PR TITLE
auto update copyright year

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Next Version
 
 **Maintenance**
 
+   * Auto-update copyright year in docs (#1369)
+
 v0.7.3
 ======
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 import os
 import sys
 import warnings
+import datetime
 
 from pyne.utils import QAWarning
 import cloud_sptheme as csp
@@ -49,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PyNE'
-copyright = u'2011-2019, The PyNE Development Team'
+copyright = u'2011-{0}, The PyNE Development Team'.format(datetime.datetime.now().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
## Description
Changes to `docs/conf.py` to automatically update the copyright year in the website.

## Motivation and Context
Related to #1347.

## Changes
Documentation update.

## Behavior

## Other Information

## Changelog file
All pull requests are required to update the [CHANGELOG](https://github.com/pyne/pyne/blob/develop/CHANGELOG.rst) file with the PR.  Your update can take different forms including:

* creating a new entry describing your change, including a reference to this pull request number
* adding a reference to your pull request number to an exist entry if that entry can include your changes