### PR TITLE
Update encoding in amalgamate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Next Version
 **Fix**
 
    * Attribution for the atomic mass data in the data theory doc page (#1387)
+   * specify encoding when reading files in amalgamation (#1386)
 
 **Maintenance**
 

--- a/amalgamate.py
+++ b/amalgamate.py
@@ -72,7 +72,7 @@ class AmalgamatedFile(object):
             _, ext = os.path.splitext(filename)
             comment_out = ext not in CODE_EXTS
         self._blocks.append('//\n// start of {0}\n//\n'.format(filename))
-        with open(filename, 'rt') as f:
+        with open(filename, 'rt', encoding='utf-8') as f:
             content = f.read()
         if comment_out:
             content = '// ' + content.replace('\n', '\n// ')


### PR DESCRIPTION
## Description

Specify character set encoding in amalgamate.py to support extended characters (e.g. in comments)

## Motivation and Context
Some files contain extended characters that should be supported.

## Changes
Bug fix

## Behavior
Amalgamation fails when reading a file with extended characters

## Changelog file
TBD 
