### PR TITLE
Correct reference for atomic mass data in theory manual

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Next Version
      
 **Fix**
 
+   * Attribution for the atomic mass data in the data theory doc page (#1387)
+
 **Maintenance**
 
 

--- a/docs/theorymanual/data.rst
+++ b/docs/theorymanual/data.rst
@@ -11,7 +11,7 @@ fundamental nuclear data stored in the `nuc_data.h5` HDF5 database. These
 include the following distinct datasets:
 
 * Fundamental constants common to nuclear engineering problems
-* Atomic mass data (JAEA)
+* Atomic mass data (AMDC)
 * Natural isotopic abundance data (IUPAC2009)
 * Energy/fission (ORIGEN-S) 
 * Gamma Energy/fission (ORIGEN-S)
@@ -28,6 +28,7 @@ Additional Information
 **********************
 For further information, please see:
 
+* `Atomic Mass Data Center (AMDC) <https://www-nds.iaea.org/amdc/>`_
 * `The ENSDF manual <https://www-nds.iaea.org/public/documents/ensdf/ensdf-manual.pdf>`_, 
 * `IAEA nuclear data section <https://www-nds.iaea.org/>`_, 
 * `ORIGEN-S data <https://info.ornl.gov/sites/publications/Files/Pub57380.pdf>`_,


### PR DESCRIPTION
## Description
Corrects the reference for atomic mass data in the data theory manual page, and adds a link to the AMDC.

## Motivation and Context
The atomic mass data was attributed to JAEA, but looking back through old discussions on the PyNE groups it looks like PyNE has  always used AMDC atomic mass data.

Note: I'm not aware if JAEA publish atomic mass data or not: I've not checked.

## Changes
Self-explanatory

## Behavior

## Other Information

## Changelog file
Will commit an entry now after finding out the number of this PR.