### PR TITLE
Update to MOAB 5.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Next Version
 
 **Maintenance**
 
+   * update MOAB version to 5.3.0 in CI docker image (#1391)
+
 
 v0.7.4
 ======

--- a/docker/make_pyne_docker_image.py
+++ b/docker/make_pyne_docker_image.py
@@ -103,7 +103,7 @@ def main():
     description = 'Build a docker image for PyNE'
     parser = ap.ArgumentParser(description=description)
 
-    py_version = 'Require a specific python version'
+    py_version = 'Require a specific python version (default: 3)'
     parser.add_argument('--py_version', type=int, help=py_version,
                         default=3)
 
@@ -112,34 +112,34 @@ def main():
     parser.add_argument('--hdf5_version', help=custom_hdf5,
                         default='')
 
-    moab = 'Build and install MOAB'
+    moab = 'Build and install MOAB (default: False)'
     parser.add_argument('--moab', help=moab,
                         action='store_true', default=False)
 
-    dagmc = 'Build and install DAGMC'
+    dagmc = 'Build and install DAGMC (default: False)'
     parser.add_argument('--dagmc', help=dagmc,
                         action='store_true', default=False)
 
-    pymoab = 'Enable pymoab'
+    pymoab = 'Enable pymoab (default: False)'
     parser.add_argument('--pymoab', help=pymoab,
                         action='store_true', default=False)
 
-    openmc = 'Install OpenMC python API'
+    openmc = 'Install OpenMC python API (default: False)'
     parser.add_argument('--openmc', help=openmc,
                         action='store_true', default=False)
 
-    all_deps = 'Add all dependencies'
+    all_deps = 'Add all dependencies (default: False)'
     parser.add_argument('--all', '-a', '-all', help=all_deps,
                         action='store_true', default=False)
 
-    deps = 'Dependencies only'
+    deps = 'Dependencies only (default: False)'
     parser.add_argument('--deps', help=deps,
                         action='store_true', default=False)
 
-    name = 'Set docker image name'
+    name = 'Set docker image name (default: "")'
     parser.add_argument('--name', help=name, default='')
 
-    push = 'Push docker image on dockerhub'
+    push = 'Push docker image on dockerhub (default: False)'
     parser.add_argument('--push', '-p', '-push', help=push,
                         action='store_true', default=False)
 

--- a/docker/make_pyne_docker_image.py
+++ b/docker/make_pyne_docker_image.py
@@ -85,7 +85,7 @@ def build_docker(args):
             if args.openmc:
                 raise ValueError("OpenMC Python API does not support python2!")
         elif args.py_version == 3:
-            docker_args += ["--build-arg", "py_version=3.7"]
+            docker_args += ["--build-arg", "py_version=3.6"]
         else:
             print("Can only deal with python 2 or 3")
             return

--- a/docker/make_pyne_docker_image.py
+++ b/docker/make_pyne_docker_image.py
@@ -17,6 +17,7 @@ def consistancy_check(args):
     args.moab = args.moab or args.dagmc or args.pymoab or args.openmc or args.all
     args.pymoab = args.pymoab or args.openmc or args.all
     args.dagmc = args.dagmc or args.openmc or args.all
+    args.openmc = args.openmc or args.all
 
     return args
 

--- a/docker/make_pyne_docker_image.py
+++ b/docker/make_pyne_docker_image.py
@@ -84,7 +84,7 @@ def build_docker(args):
             if args.openmc:
                 raise ValueError("OpenMC Python API does not support python2!")
         elif args.py_version == 3:
-            docker_args += ["--build-arg", "py_version=3.6"]
+            docker_args += ["--build-arg", "py_version=3.7"]
         else:
             print("Can only deal with python 2 or 3")
             return

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 # Ubuntu Setup
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ARG py_version=3.6
+ARG py_version=3.7
 
 ENV HOME /root
 RUN if [ "${py_version%.?}" -eq 3 ] ; \

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -98,7 +98,7 @@ RUN if [ "$build_moab" = "YES" ] || [ "$enable_pymoab" = "YES" ] ; then \
         && cd $HOME/opt \
         && mkdir moab \
         && cd moab \
-        && git clone --single-branch -b 5.2.1 https://bitbucket.org/fathomteam/moab \
+        && git clone --single-branch -b 5.3.0 https://bitbucket.org/fathomteam/moab \
         && cd moab \
         && mkdir build \
         && cd build \

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 # Ubuntu Setup
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ARG py_version=3.7
+ARG py_version=3.6
 
 ENV HOME /root
 RUN if [ "${py_version%.?}" -eq 3 ] ; \


### PR DESCRIPTION
## Description
Change the version of MOAB that is built for the CI docker images to 5.3.0 because of their new release.

