### PR TITLE
limit changelog check to PR only

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   changelog_update:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     container:
       image: alpine:3.14

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Next Version
 * uses GithubAction to build the docker image used in CI (#1394)
 
 **Change**
-   * CI uses GithubAction instead of CIrcleCI (#1393)
+   * CI uses GithubAction instead of CIrcleCI (#1393, #1395)
 
 **Fix**
 


### PR DESCRIPTION
Tweak the Github Action CI to only check the changelog on PR and not on merge