### PR TITLE
changelog update for 0.7.5 microrelease

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,9 +17,11 @@ v0.7.5
 ======
 
 **New Capabilities**
-* uses GithubAction to build the docker image used in CI (#1394)
+
+   * uses GithubAction to build the docker image used in CI (#1394)
 
 **Change**
+
    * CI uses GithubAction instead of CIrcleCI (#1393, #1395)
 
 **Fix**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ PyNE Change Log
 Next Version
 ============
 
+**New Capabilities**
+
+**Change**
+
+**Fix**
+
+**Maintenance**
+
 v0.7.5
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ PyNE Change Log
 Next Version
 ============
 
+v0.7.5
+======
+
 **New Capabilities**
 * uses GithubAction to build the docker image used in CI (#1394)
 


### PR DESCRIPTION
## Description
Move the Changelog forward to issue a microrelease v0.7.5

## Motivation and Context
With the update to MOAB 5.3.0 in testing this microrelease allows distribution of different versions that depend clearly on that update.

## Changes
Introduce  a new version number in the changelog.

