### PR TITLE
Optimize mesh to fluxin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Next Version
 **Maintenance**
 
    * update MOAB version to 5.3.0 in CI docker image (#1391)
+   * optimize the mesh_to_fluxin function in r2s step1 (#1397)
 
 
 v0.7.4

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -99,14 +99,14 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
         if not sub_voxel:
             for i, mat, ve in flux_mesh:
                 f.write(_output_flux_block(ve, tag_flux, reverse))
-                if print_progress > 0 and i % print_progress == 0:
+                if print_progress > 0 and i > 0 and i % print_progress == 0:
                     print(f"processing mesh element {i}")
         else:
             ves = list(flux_mesh.iter_ve())
             for i, row in enumerate(cell_fracs):
                 if len(cell_mats[row['cell']].comp) != 0:
                     f.write(_output_flux_block(ves[row['idx']], tag_flux, reverse))
-                if print_progress > 0 and i % print_progress == 0:
+                if print_progress > 0 and i > 0 and i % print_progress == 0:
                     print(f"processing mesh element {row['idx']}")
 
 

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -19,6 +19,7 @@ import numpy as np
 import tables as tb
 from io import open
 import re
+from memory_profiler import profile
 
 QA_warn(__name__)
 
@@ -41,6 +42,7 @@ response_strings = {'decay_heat': 'Total Decay Heat',
                     'wdr': 'WDR/Clearance index',
                     'photon_source': 'Photon Source Distribution'}
 
+@profile
 def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
                    reverse=False, sub_voxel=False, cell_fracs=None,
                    cell_mats=None, print_progress=100000):
@@ -98,23 +100,27 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
     # is requested
     output_list = []
     output = u""
+    f = open(fluxin, "w")
     if not sub_voxel:
         for i, mat, ve in flux_mesh:
             # append each block to list
-            output_list.append(_output_flux_block(ve, tag_flux, reverse))
+#            output_list.append(_output_flux_block(ve, tag_flux, reverse))
+            f.write(_output_flux_block(ve, tag_flux, reverse))
             if print_progress > 0 and i % print_progress == 0:
                 print(f"processing mesh element {i}")
     else:
         ves = list(flux_mesh.iter_ve())
         for i, row in enumerate(cell_fracs):
             if len(cell_mats[row['cell']].comp) != 0:
-                output_list.append(_output_flux_block(ves[row['idx']], tag_flux, reverse))
+#                output_list.append(_output_flux_block(ves[row['idx']], tag_flux, reverse))
+                f.write(_output_flux_block(ves[row['idx']], tag_flux, reverse))
             if print_progress > 0 and i % print_progress == 0:
                 print(f"processing mesh element {row['idx']}")
 
-    output = ''.join([value for value in output_list])
-    with open(fluxin, "w") as f:
-        f.write(output)
+#    output = ''.join([value for value in output_list])
+    f.close()
+#    with open(fluxin, "w") as f:
+#        f.write(output)
 
 
 def photon_source_to_hdf5(filename, nucs='all', chunkshape=(10000,)):

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -84,6 +84,7 @@ def mesh_to_fluxin(flux_mesh, flux_tag, fluxin="fluxin.out",
     print_progress: int, optional
         If desired, the number of processed events can be printed to the
         console each N loops by passing the print_progress=N parameter.
+        The print progress can be turned off by by setting print_progess=0.
     """
 
     tag_flux = flux_mesh.get_tag(flux_tag)
@@ -986,33 +987,6 @@ def cram(N, t, n_0, order):
             order)
         raise ValueError(msg)
 
-
-def _output_flux(ve, tag_flux, output, start, stop, direction):
-    """
-    This function is used to get neutron flux for fluxin
-
-    Parameters
-    ----------
-    ve : entity, a mesh sub-voxel
-    tag_flux : array, neutron flux of the sub-voxel
-    output : string
-    start : int
-    stop : int
-    direction: int
-    """
-
-    count = 0
-    flux_data = np.atleast_1d(tag_flux[ve])
-    for i in range(start, stop, direction):
-        output += u"{:.6E} ".format(flux_data[i])
-        # fluxin formatting: create a new line
-        # after every 6th entry
-        count += 1
-        if count % 6 == 0:
-            output += u"\n"
-
-    output += u"\n\n"
-    return output
 
 def _output_flux_block(ve, tag_flux, reverse):
     """

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -8,7 +8,6 @@ from pyne.mcnp import Meshtal
 from pyne.alara import mesh_to_fluxin, record_to_geom, photon_source_to_hdf5, \
     photon_source_hdf5_to_mesh, responses_output_zone
 from pyne import openmc_utils
-import time
 
 QA_warn(__name__)
 
@@ -154,11 +153,8 @@ def irradiation_setup(flux_mesh, cell_mats, cell_fracs, alara_params,
     if output_material:
         m.cell_fracs_to_mats(cell_fracs, cell_mats)
 
-    time0 = time.time()
     mesh_to_fluxin(m, flux_tag, fluxin, reverse,
                    sub_voxel, cell_fracs, cell_mats)
-    time1 = time.time()
-    print(f"mesh_to_fluxin time: {time1-time0}")
     record_to_geom(m, cell_fracs, cell_mats, alara_inp, alara_matlib,
                    sub_voxel=sub_voxel)
 

--- a/pyne/r2s.py
+++ b/pyne/r2s.py
@@ -8,6 +8,7 @@ from pyne.mcnp import Meshtal
 from pyne.alara import mesh_to_fluxin, record_to_geom, photon_source_to_hdf5, \
     photon_source_hdf5_to_mesh, responses_output_zone
 from pyne import openmc_utils
+import time
 
 QA_warn(__name__)
 
@@ -153,8 +154,11 @@ def irradiation_setup(flux_mesh, cell_mats, cell_fracs, alara_params,
     if output_material:
         m.cell_fracs_to_mats(cell_fracs, cell_mats)
 
+    time0 = time.time()
     mesh_to_fluxin(m, flux_tag, fluxin, reverse,
                    sub_voxel, cell_fracs, cell_mats)
+    time1 = time.time()
+    print(f"mesh_to_fluxin time: {time1-time0}")
     record_to_geom(m, cell_fracs, cell_mats, alara_inp, alara_matlib,
                    sub_voxel=sub_voxel)
 


### PR DESCRIPTION
## Description
Modify the string concatenation method to speed up function `alara.mesh_to_fluxin` irradiation setup of r2s step.

## Motivation and Context
For R2S with fine mesh with a large amount of volume elements, the current R2S step1 takes a very long time (several days for 400,000 volume elements).
Most of the time is used in the function of alara.mesh_to_fluxin, more specifically, the `alara._output_flux`.
The reason is the low efficiency of string concatenation.

## Changes
Put the string segments into a list, and then concatenation with join. See [here](https://waymoot.org/home/python_string/#:~:text=%20Efficient%20String%20Concatenation%20in%20Python%20%201,build%20the%20string%20and%20the%20amount...%20More%20) for reference.

## Behavior
The running time of alara.mesh_to_fluxin is recorded as below, it gives the behavior change before/after this PR. 
|number of volume elements| 4 | 100 | 1000 | 10000 | 386,848 |
|------------|----|---|---|---| --- |
|mesh_to_fluxin running time before change (s)| 3e-3 | 1e-2 | 0.39 | 36.3 | several days |
|mesh_to_fluxin running time after change (s) | 1.0e-3 | 1.8e-2 | 0.14 | 1.46 | 685.9 |
