### PR TITLE
Fix test variancereduction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Next Version
    * Attribution for the atomic mass data in the data theory doc page (#1387)
    * specify encoding when reading files in amalgamation (#1386)
    * little fix for usage of filesystem::canonical() for windows... (#1390)
+   * fix random test failure of test_variancereduction
 
 **Maintenance**
 

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -237,3 +237,4 @@ def magic(meshtally, tag_name, tag_name_error, **kwargs):
     # Create wwinp mesh
     wwinp = Wwinp()
     wwinp.read_mesh(meshtally.mesh)
+    return meshtally

--- a/tests/test_variancereduction.py
+++ b/tests/test_variancereduction.py
@@ -188,29 +188,29 @@ def test_magic_e_total():
     assert_array_almost_equal(tally.ww_x[:], expected_ww[:])
 
 
-def test_magic_single_e():
-    """Test a single energy group MAGIC case"""
-
-    # create mesh
-    coords = [[0, 1, 2], [-1, 3, 4], [10, 12]]
-    flux_data = [1.2, 3.3, 1.6, 1.7]
-    flux_error = [0.11, 0.013, 0.14, 0.19]
-    tally = Mesh(structured=True, structured_coords=coords)
-
-    tally.particle = "neutron"
-    tally.e_bounds = [0.0, 1.0]
-    tally.n_flux = NativeMeshTag(1, float)
-    tally.n_flux[:] = flux_data
-
-    tally.n_rel_error = NativeMeshTag(1, float)
-    tally.n_rel_error[:] = flux_error
-
-    tolerance = 0.15
-    null_value = 0.001
-
-    tally = magic(tally, "n_flux", "n_rel_error",
-          tolerance=tolerance, null_value=null_value)
-
-    expected_ww = [0.181818182, 0.5, 0.2424242, 0.001]
-
-    assert_array_almost_equal(tally.ww_x[:], expected_ww[:])
+#def test_magic_single_e():
+#    """Test a single energy group MAGIC case"""
+#
+#    # create mesh
+#    coords = [[0, 1, 2], [-1, 3, 4], [10, 12]]
+#    flux_data = [1.2, 3.3, 1.6, 1.7]
+#    flux_error = [0.11, 0.013, 0.14, 0.19]
+#    tally = Mesh(structured=True, structured_coords=coords)
+#
+#    tally.particle = "neutron"
+#    tally.e_bounds = [0.0, 1.0]
+#    tally.n_flux = NativeMeshTag(1, float)
+#    tally.n_flux[:] = flux_data
+#
+#    tally.n_rel_error = NativeMeshTag(1, float)
+#    tally.n_rel_error[:] = flux_error
+#
+#    tolerance = 0.15
+#    null_value = 0.001
+#
+#    tally = magic(tally, "n_flux", "n_rel_error",
+#          tolerance=tolerance, null_value=null_value)
+#
+#    expected_ww = [0.181818182, 0.5, 0.2424242, 0.001]
+#
+#    assert_array_almost_equal(tally.ww_x[:], expected_ww[:])

--- a/tests/test_variancereduction.py
+++ b/tests/test_variancereduction.py
@@ -188,29 +188,29 @@ def test_magic_e_total():
     assert_array_almost_equal(tally.ww_x[:], expected_ww[:])
 
 
-#def test_magic_single_e():
-#    """Test a single energy group MAGIC case"""
-#
-#    # create mesh
-#    coords = [[0, 1, 2], [-1, 3, 4], [10, 12]]
-#    flux_data = [1.2, 3.3, 1.6, 1.7]
-#    flux_error = [0.11, 0.013, 0.14, 0.19]
-#    tally = Mesh(structured=True, structured_coords=coords)
-#
-#    tally.particle = "neutron"
-#    tally.e_bounds = [0.0, 1.0]
-#    tally.n_flux = NativeMeshTag(1, float)
-#    tally.n_flux[:] = flux_data
-#
-#    tally.n_rel_error = NativeMeshTag(1, float)
-#    tally.n_rel_error[:] = flux_error
-#
-#    tolerance = 0.15
-#    null_value = 0.001
-#
-#    magic(tally, "n_flux", "n_rel_error",
-#          tolerance=tolerance, null_value=null_value)
-#
-#    expected_ww = [0.181818182, 0.5, 0.2424242, 0.001]
-#
-#    assert_array_almost_equal(tally.ww_x[:], expected_ww[:])
+def test_magic_single_e():
+    """Test a single energy group MAGIC case"""
+
+    # create mesh
+    coords = [[0, 1, 2], [-1, 3, 4], [10, 12]]
+    flux_data = [1.2, 3.3, 1.6, 1.7]
+    flux_error = [0.11, 0.013, 0.14, 0.19]
+    tally = Mesh(structured=True, structured_coords=coords)
+
+    tally.particle = "neutron"
+    tally.e_bounds = [0.0, 1.0]
+    tally.n_flux = NativeMeshTag(1, float)
+    tally.n_flux[:] = flux_data
+
+    tally.n_rel_error = NativeMeshTag(1, float)
+    tally.n_rel_error[:] = flux_error
+
+    tolerance = 0.15
+    null_value = 0.001
+
+    tally = magic(tally, "n_flux", "n_rel_error",
+          tolerance=tolerance, null_value=null_value)
+
+    expected_ww = [0.181818182, 0.5, 0.2424242, 0.001]
+
+    assert_array_almost_equal(tally.ww_x[:], expected_ww[:])

--- a/tests/test_variancereduction.py
+++ b/tests/test_variancereduction.py
@@ -121,7 +121,7 @@ def test_magic_below_tolerance():
     tally.n_rel_error = NativeMeshTag(1, float)
     tally.n_rel_error[:] = flux_error
 
-    magic(tally, "n_total_flux", "n_rel_error")
+    tally = magic(tally, "n_total_flux", "n_rel_error")
 
     expected_ww = [0.181818182, 0.5, 0.2424242, 0.2575757576]
 
@@ -148,7 +148,7 @@ def test_magic_multi_bins():
     tolerance = 0.15
     null_value = 0.001
 
-    magic(tally, "n_flux", "n_rel_error",
+    tally = magic(tally, "n_flux", "n_rel_error",
           tolerance=tolerance, null_value=null_value)
 
     expected_ww = [[0.2307692308, 0.5],
@@ -179,9 +179,10 @@ def test_magic_e_total():
     tolerance = 0.15
     null_value = 0.001
 
-    magic(tally, "n_total_flux", "n_rel_error",
+    tally = magic(tally, "n_total_flux", "n_rel_error",
           tolerance=tolerance, null_value=null_value)
 
+    
     expected_ww = [0.181818182, 0.5, 0.2424242, 0.001]
 
     assert_array_almost_equal(tally.ww_x[:], expected_ww[:])


### PR DESCRIPTION
## Description
This PR tries to fix the random testing failure of test_variancereduction.

## Motivation and Context
The `test_variancereduction.py` sometimes fails even a PR has nothing to do with variance reduction, for example, the PR #1397 .
But if you rerun the tests, the `test_variancereduction.py` may succeed without any error.

## Changes
This PR updates the meshtally by returning it from `variancereduction.magic` to avoid the wrong reference.

## Behavior
It is hoped to avoid the wrong reference of meshtally after `magic`.

