### PR TITLE
Fix variance reduction (VR) test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Next Version
 
 **Fix**
 
+   * fixing VR test
+
 **Maintenance**
 
 v0.7.5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Next Version
 
 **Fix**
 
-   * fixing VR test
+   * fixing VR test (#1399)
 
 **Maintenance**
 

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -192,7 +192,6 @@ def magic(meshtally, tag_name, tag_name_error, **kwargs):
     if total:
         # get value tagged on the mesh itself
         root_tag[meshtally] = np.max(meshtally.e_bounds[:])
-        max_val = np.max(meshtally.vals[:])
 
         vals = []
         errors = []

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -169,8 +169,8 @@ def magic(meshtally, tag_name, tag_name_error, **kwargs):
         meshtally.particle = mcnp(particle).lower()
 
     # Create tags for values and errors
-    meshtally.vals = NativeMeshTag(mesh=meshtally, name=tag_name)
-    meshtally.errors = NativeMeshTag(mesh=meshtally, name=tag_name_error)
+    meshtally.vals = meshtally.tags[tag_name]
+    meshtally.errors = meshtally.tags[tag_name_error]
 
     # Create weight window tags
     tag_size = meshtally.vals[0].size


### PR DESCRIPTION
## Description
Change the way that data is allocated in the magic method to fix a test.

## Motivation and Context
Our CI testing was sporadically failing - about 1/4 times - when testing the magic method.  There was confidence in the code, so the test was ignored and/or relaunched to pass.

## Changes
This is a bug fix.

## Behavior
The test reliably passes now.  Because it didn't fail reliably in CI, it is difficult to demonstrate in CI.  The author has run the test multiple times (~20) without any failures.

## Other Information
This fix is appropriate to resolve this error, but may not actually address the root cause. (#1400)
