### PR TITLE
Mesh to fluxin progress bar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ v0.7.5
 
    * update MOAB version to 5.3.0 in CI docker image (#1391)
    * optimize the mesh_to_fluxin function in r2s step1 (#1397)
+   * use progress bar for mesh_to_fluxin function (#1400)
    * add package progress in docker image (#1402)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Next Version
    * adds a manual trigger for docker build workflow (#1406)
    * clarify the tag name for docker images generated in CI (#1407)
    * add ifbar to cleanup the code about progress bar (#1409)
+   * use ifbar to print progress of mesh_to_fluxin (#1401)
 
 v0.7.5
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,8 +42,7 @@ v0.7.5
 
    * update MOAB version to 5.3.0 in CI docker image (#1391)
    * optimize the mesh_to_fluxin function in r2s step1 (#1397)
-   * use progress bar for mesh_to_fluxin function (#1400)
-   * add package progress in docker image (#1402)
+   * use progress bar for mesh_to_fluxin function (#1401, #1402)
 
 
 v0.7.4

--- a/tests/test_alara.py
+++ b/tests/test_alara.py
@@ -62,6 +62,40 @@ def test_write_fluxin_single():
     if os.path.isfile(output):
         os.remove(output)
 
+def test_write_fluxin_single_without_bar():
+    """This function tests the flux_mesh_to_fluxin function for a single energy
+    group case.
+    """
+
+    if not HAVE_PYMOAB:
+        raise SkipTest
+
+    output_name = "fluxin.out"
+    forward_fluxin = os.path.join(thisdir, "files_test_alara",
+                                  "fluxin_single_forward.txt")
+    output = os.path.join(os.getcwd(), output_name)
+
+    flux_mesh = Mesh(structured=True,
+                     structured_coords=[[0, 1, 2], [0, 1, 2], [0, 1]])
+    tag_flux = flux_mesh.tag(name="flux", size=1, dtype=float)
+    flux_data = [1, 2, 3, 4]
+    ves = flux_mesh.structured_iterate_hex("xyz")
+    for i, ve in enumerate(ves):
+        flux_mesh.flux[i] = flux_data[i]
+
+    # test forward writting
+    mesh_to_fluxin(flux_mesh, "flux", output_name, False, print_progress=False)
+
+    with open(output) as f:
+        written = f.readlines()
+
+    with open(forward_fluxin) as f:
+        expected = f.readlines()
+
+    assert_equal(written, expected)
+    if os.path.isfile(output):
+        os.remove(output)
+
 
 def test_write_fluxin_multiple():
     """This function tests the flux_mesh_to_fluxin function for a multiple


### PR DESCRIPTION
## Description
This PR uses a progress bar to show the progress of `alara.mesh_to_fluxin`.

## Motivation and Context
The progress print is useful for loops that take a relatively long time. The progress package can be used to do it.

## Behavior
The progress bar for `alara.mesh_to_fluxin` looks like this:
```
Writing alara fluxin |################################| 100.0% - 0s
```

## Performance
The running time of alara.mesh_to_fluxin is recorded as below, it gives the behavior change before/after this PR. 

|number of volume elements| 100 | 1000 | 10000 |
|------------|----|----|----|
| without progress bar |  1.8e-2 | 0.14 | 1.46 | 
| with progress bar | 1.75e-2 | 0.167 | 1.67 |

A slight performance down (14% slower) is acceptable as the `alara.mesh_to_fluxin` does not take too much time now.

## Others
The progress bar can be applied to other functions/loops in PyNE. That's could be done if people like it.

