### PR TITLE
dedicated changlog workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,37 +4,20 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'workflow/docker_publish.yml'
+      - 'docker/**'
   push:
     branches:
       - develop
+    paths-ignore:
+      - 'workflow/docker_publish.yml'
+      - 'docker/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
 jobs:
-  changelog_update:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    container:
-      image: alpine:3.14
-
-    name: Is Changelog up-to-date ?
-    steps:
-      - name: Install latest git
-        run: |
-          apk add --no-cache bash git openssh
-          git --version
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
-    
-      - name: Housekeeping
-        run: |
-          cd $GITHUB_WORKSPACE
-          ci/changelog_test.sh
-
-
   BuildTest:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -1,0 +1,35 @@
+name: Standard Build and Test
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  changelog_update:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.14
+
+    name: Is Changelog up-to-date ?
+    steps:
+      - name: Install latest git
+        run: |
+          apk add --no-cache bash git openssh
+          git --version
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+    
+      - name: Housekeeping
+        run: |
+          cd $GITHUB_WORKSPACE
+          ci/changelog_test.sh
+

--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -1,4 +1,4 @@
-name: Standard Build and Test
+name: Changelog check
 
 on:
   # allows us to run workflows manually

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Next Version
 **New Capabilities**
 
 **Change**
+- exclude docker related stuff from build_test (#1404)
+- move changelog test in its own workflow (#1404)
 
 **Fix**
 


### PR DESCRIPTION
this move changelog check in a dedicated workflow

adds path constrain (ignore) to build_test so won't run on docker changes