### PR TITLE
change tag name on CI docker images

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,14 +5,14 @@ on:
   workflow_dispatch:
   pull_request:
     paths-ignore:
-      - 'workflow/docker_publish.yml'
+      - '.github/workflows/docker_publish.yml'
       - 'docker/**'
       - 'CHANGELOG.rst'
   push:
     branches:
       - develop
     paths-ignore:
-      - 'workflow/docker_publish.yml'
+      - '.github/workflows/docker_publish.yml'
       - 'docker/**'
       - 'CHANGELOG.rst'
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -41,7 +41,7 @@ jobs:
           build-args: |
             py_version=3.6
             build_pyne=NO
-          tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3_pyne-deps:latest
+          tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3_pyne-deps:ci_testing
 
       - name: Set up Docker Buildx
         id: buildx
@@ -69,7 +69,7 @@ jobs:
             build_pyne=NO
             build_moab=YES
             enable_pymoab=YES
-          tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3_pymoab_pyne-deps:latest
+          tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3_pymoab_pyne-deps:ci_testing
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-${{ github.sha }}
 
 
@@ -169,7 +169,7 @@ jobs:
             build_hdf5=${{ env.HDF5 }}
             install_openmc=${{ env.HDF5 }}
           cache-from: type=local,src=/tmp/.buildx-cache-${{ github.sha }}
-          tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:latest
+          tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:ci_testing
 
   cleanup_cache:
     if: always()
@@ -217,7 +217,7 @@ jobs:
 
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:latest
+      image: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:ci_testing
 
     steps:
       - name: setup
@@ -301,5 +301,11 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v1.0.0
         with:
-          src: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:latest
+          src: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:ci_testing
           dst: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:stable
+
+      - name: Push Image to stable img
+        uses: akhilerm/tag-push-action@v1.0.0
+        with:
+          src: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:ci_testing
+          dst: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Next Version
 **Maintenance**
    * removing old circle-ci related stuff (#1405)
    * adds a manual trigger for docker build workflow (#1406)
+   * clarify the tag name for docker images generated in CI (#1407)
 
 v0.7.5
 ======


### PR DESCRIPTION
## Description
Change the tag used for generating temporary docker images for testing from `latest` to `ci_testing`.

## Motivation and Context
We have been using `latest` as the temporary tag for docker images during testing, but this is a common/default tag used for the most recent stable build.  This change uses `ci_testing` while testing and then changes is it to `stable` and `latest` when done.

