### PR TITLE
extend Bar to IfBar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Next Version
    * removing old circle-ci related stuff (#1405)
    * adds a manual trigger for docker build workflow (#1406)
    * clarify the tag name for docker images generated in CI (#1407)
+   * add ifbar to cleanup the code about progress bar (#1409)
 
 v0.7.5
 ======

--- a/pyne/utils.py
+++ b/pyne/utils.py
@@ -6,6 +6,7 @@ from warnings import warn
 from distutils.dir_util import remove_tree
 import filecmp
 from io import open
+from progress.bar import Bar
 
 from pyne._utils import fromstring_split, fromstring_token, endftod,\
                         use_fast_endftod, fromendf_tok, toggle_warnings,\
@@ -457,3 +458,17 @@ def check_iterable(obj):
         print(obj.__str__(), "is not iterable")
         return False
     return True
+
+class IfBar(Bar):
+    def __init__(self, *args, **kwargs):
+        self.show = kwargs.get('show', True)
+        if self.show:
+            super().__init__(*args, **kwargs)
+
+    def next(self):
+        if self.show:
+            super().next()
+
+    def finish(self):
+        if self.show:
+            super().finish()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -364,5 +364,16 @@ def test_check_iterable():
     assert(utils.check_iterable(obj))
 
 
+def test_ifbar():
+    loops = 100
+    bar = utils.IfBar("if bar print", max=loops, suffix='%(percent).1f%% - %(eta)ds', show=True)
+    for i in range(loops):
+        bar.next()
+    bar.finish()
+    bar = utils.IfBar("if bar print", max=loops, suffix='%(percent).1f%% - %(eta)ds', show=False)
+    for i in range(loops):
+        bar.next()
+    bar.finish()
+
 if __name__ == "__main__":
     nose.runmodule()


### PR DESCRIPTION
## Description
Add a IfBar for eaiser turn on/off of the progress print.

## Motivation and Context
Truning on/off of  `progress.bar` make the code messy. This PR add a extended IfBar according to the suggestion of @gonuke [here](https://github.com/pyne/pyne/pull/1401#discussion_r675255868).

## Changes
The `class IfBar` in `pyne.utils`, and a test.

## Others
The `IfBar` will hopefully make the code of progress bar in #1401 cleaner.

