### PR TITLE
limits build_test and housekeeping to pull_request trigger only

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,14 +9,7 @@ on:
       - '.github/workflows/changelog_test.yml'
       - 'docker/**'
       - 'CHANGELOG.rst'
-  push:
-    branches:
-      - develop
-    paths-ignore:
-      - '.github/workflows/docker_publish.yml'
-      - '.github/workflows/changelog_test.yml'
-      - 'docker/**'
-      - 'CHANGELOG.rst'
+
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -4,9 +4,7 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - develop
+
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Next Version
 **Change**
    * exclude docker related stuff from build_test (#1404 #1408)
    * move changelog test in its own workflow (#1404)
+   * limits some workflows to pull_request trigger only (#1410)
 
 **Fix**
 


### PR DESCRIPTION
we run the exact `build_test` and `housekeeping` with the exact same condition on push(merge) and pull_request, 

I think it is a bit overkill and will trigger things in forks without people necessarily be aware of them...
so I thought we might as well limit ourselves to pull_request....