### PR TITLE
added operator capability for NativeMeshTag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,8 @@ Next Version
    * Add the workflow to support PyNE R2S with DAG-OpenMC (#1355)
    * Add vector capabilities to the _do_ops() method in mesh.py (#1371)
    * Add tests for multiplication of vector-valued tags by scalars and scalar-valued tags (#1374)
-   * Add tests for multiplication of vector-valued tags by elements of other tags (#1376)
+   * Add multiplication operator for NativeMeshTag and corresponding tests (#1376)
+   * Incorporate native use of multiplication symbol for NativeMeshTag (#1411)
      
 **Fix**
 

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -583,7 +583,7 @@ class NativeMeshTag(Tag):
             self.mesh.mesh.tag_set_data(tag, list(self.mesh.iter_ve()), data)
 
 
-    def mult(self, multiplier):
+    def __mul__(self, multiplier):
         """Multiplication operator for NativeMeshTag. Multiplies self by the multiplier using 
         NumPy slicing if applicable. Multiplier can be any of the following types: int, float, 
         ndarray, list, NativeMeshTag. Throws error if shapes are incorrect """

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -879,52 +879,52 @@ def test_nativetag_mult():
     m.peach[:] = [1.5, 2.5]
     m.tangerine = NativeMeshTag(1, float) 
     m.tangerine[:] = [5.0, 10.0]
-    obs = m.peach.mult(m.tangerine)
+    obs = m.peach * m.tangerine
     exp = [7.5, 25.0]
     assert_array_almost_equal(obs, exp) #multiplying two scalar-valued tags
     
     m.plum = NativeMeshTag(2, float)
     m.plum[:] = [[5.0, 10.0], [15.0, 20.0]]
-    obs = m.peach.mult(m.plum)
+    obs = m.peach * m.plum
     exp = [[7.5, 15.0], [37.5, 50.0]]
     assert_array_almost_equal(obs, exp) #multiplying scalar-valued tag by vector-valued tag
     
-    obs = m.plum.mult(m.tangerine)
+    obs = m.plum * m.tangerine
     exp = [[25.0, 100.0], [75.0, 200.0]]
     assert_array_almost_equal(obs, exp) #multiplying vector-valued tag by scalar-valued tag
     
     m.grapefruit = NativeMeshTag(2, float)
     m.grapefruit[:] = [[2.0, 4.0], [3.0, 6.0]]
-    obs = m.plum.mult(m.grapefruit)
+    obs = m.plum * m.grapefruit
     exp = [[10.0, 40.0], [45.0, 120.0]]
     assert_array_almost_equal(obs, exp) #multiplying two vector-valued tags
 
     cherry = 12
-    exp = m.plum.mult(cherry)
+    exp = m.plum * cherry
     obs = [[60.0, 120.0], [180.0, 240.0]]
     assert_array_almost_equal(obs, exp) #multiplying by int
     
     cherry = 5.0
-    exp = m.plum.mult(cherry)
+    exp = m.plum * cherry
     obs = [[25.0, 50.0], [75.0, 100.0]]
     assert_array_almost_equal(obs, exp) #multiplying by float
     
     cherry = [1.0, 2.0]
-    exp = m.grapefruit.mult(cherry)
+    exp = m.grapefruit * cherry
     obs = [[2.0, 8.0], [3.0, 12.0]]
     assert_array_almost_equal(obs, exp) #mulitplying by list
     
     cherry = np.asarray(cherry)
-    exp = m.plum.mult(cherry)
+    exp = m.plum * cherry
     obs = [[5.0, 20.0], [15.0, 40.0]]
     assert_array_almost_equal(obs, exp) #multiplying by ndarray
 
     cherry = "twelve"
-    assert_raises(TypeError, m.plum.mult, cherry) #using invalid multiplier type
+    assert_raises(TypeError, m.plum.__mul__, cherry) #using invalid multiplier type
     
     m.quince = NativeMeshTag(3, float)
     m.quince[:] = [[1.0, 2.0, 4.0], [5.0, 6.0, 8.0]]
-    assert_raises(ValueError, m.quince.mult, m.grapefruit)
+    assert_raises(ValueError, m.quince.__mul__, m.grapefruit)
 
 
 def test_comptag():


### PR DESCRIPTION
Please follow these guidelines when making a Pull Request.
This template was adapted from [here](https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md) and [here](https://github.com/stevemao/github-issue-templates/blob/master/conversational/PULL_REQUEST_TEMPLATE.md).

## Description
Can now use multiplication symbol `*` to multiply NativeMeshTag objects

## Motivation and Context
Makes process of multiplying easier for users. No longer have to use method name.

## Changes
feature

## Behavior
See above

## Other Information
Other relevant information to this pull request.

## Changelog file
All pull requests are required to update the [CHANGELOG](https://github.com/pyne/pyne/blob/develop/CHANGELOG.rst) file with the PR.  Your update can take different forms including:

* creating a new entry describing your change, including a reference to this pull request number
* adding a reference to your pull request number to an exist entry if that entry can include your changes
