### PR TITLE
Quick fix - material number being added to warning message as integer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Next Version
 **Fix**
 
    * fixing VR test (#1399)
+   * fixing output from MaterialLibrary warning. (#1414)
 
 **Maintenance**
    * removing old circle-ci related stuff (#1405)
@@ -62,7 +63,7 @@ v0.7.4
    * Add multiplication operator for NativeMeshTag and corresponding tests (#1376)
    * Incorporate native use of multiplication symbol for NativeMeshTag (#1411)
    * Addition, subtraction, and division symbols are now available to manipulate NativeMeshTags (#1412)
-     
+
 **Fix**
 
    * An e_bounds reading problem when old sampler is used without e_bounds text file (#1353)

--- a/src/material_library.cpp
+++ b/src/material_library.cpp
@@ -149,7 +149,7 @@ int pyne::MaterialLibrary::ensure_material_number(pyne::Material& mat) const {
     mat_numb_it = mat_number_set.find(mat_number);
     if (mat_numb_it != mat_number_set.end()) {
       std::string msg = "Material number ";
-      msg += mat_number;
+      msg += std::to_string(mat_number);
       msg += " is already in the library.";
       warning(msg);
     }


### PR DESCRIPTION
Ran into this today as I was preparing some models using the UWUW workflow. I had some duplicate materials in my material library and PyNE was trying to let me know, but the message I got looked something like this. 

```shell
 WARNING: Material number � is already in the library.
 WARNING: Material number � is already in the library.
 WARNING: Material number  is already in the library.
 WARNING: Material number  is already in the library.
 WARNING: Material number   is already in the library.
 WARNING: Material number   is already in the library.
 WARNING: Material number ! is already in the library.
 WARNING: Material number ! is already in the library.
 WARNING: Material number # is already in the library.
 WARNING: Material number # is already in the library.
 WARNING: Material number $ is already in the library.
 WARNING: Material number $ is already in the library.
 WARNING: Material number % is already in the library.
 WARNING: Material number % is already in the library.

```

I tracked it down to the material number (an `int`) being added to the string without conversion to a string. This one-line change should take care of the problem.