### PR TITLE
Adding method to write material library in an OpenMC XML format.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Version
 ============
 
 **New Capabilities**
+   * Adds method to write a MaterialLibrary as an OpenMC XML file.
 
 **Change**
    * exclude docker related stuff from build_test (#1404 #1408)

--- a/pyne/cpp_material.pxd
+++ b/pyne/cpp_material.pxd
@@ -38,7 +38,7 @@ cdef extern from "material.h" namespace "pyne":
 
         # Methods
         void norm_comp() except +
-        std_string openmc(std_string) except +
+        std_string openmc(std_string, int) except +
         std_string mcnp(std_string) except +
         std_string mcnp(std_string, bool) except +
         std_string get_uwuw_name() except +

--- a/pyne/cpp_material_library.pxd
+++ b/pyne/cpp_material_library.pxd
@@ -10,7 +10,7 @@ from libcpp.memory cimport shared_ptr
 
 cimport cpp_jsoncpp
 
-from pyne cimport cpp_material 
+from pyne cimport cpp_material
 
 cdef extern from "material_library.h" namespace "pyne":
 
@@ -22,25 +22,25 @@ cdef extern from "material_library.h" namespace "pyne":
 
         # Methods
         void from_hdf5(std_string, std_string) except +
-        
+
         void load_json(cpp_jsoncpp.Value) except +
         cpp_jsoncpp.Value dump_json() except +
         void from_json(std_string) except +
         void write_json(std_string) except +
-
+        void write_openmc(std_string) except +
         void write_hdf5(std_string, std_string, bool) except +
-        
+
         void add_material(cpp_material.Material) except +
         void add_material(std_string, cpp_material.Material) except +
-        
+
         void del_material(cpp_material.Material) except +
         void del_material(std_string) except +
         void merge(MaterialLibrary*) except +
 
         cpp_material.Material get_material(std_string) except +
         shared_ptr[cpp_material.Material] get_material_ptr( std_string ) except +
-        
-        cpp_umap[std_string, shared_ptr[cpp_material.Material]] get_mat_library() except + 
+
+        cpp_umap[std_string, shared_ptr[cpp_material.Material]] get_mat_library() except +
         std_set[std_string] get_keylist() except +
         std_set[int] get_nuclist() except +
         int size() except +

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -334,7 +334,7 @@ cdef class _Material:
         datapath_bytes = datapath.encode('UTF-8')
         c_datapath = datapath_bytes
         cdef char * c_nucpath
-        
+
         if nucpath != "":
             nucpath_bytes = nucpath.encode('UTF-8')
             c_nucpath = nucpath_bytes
@@ -383,12 +383,12 @@ cdef class _Material:
         uwuw_name = self.mat_pointer.get_uwuw_name()
         return uwuw_name.decode()
 
-    def openmc(self, frac_type='mass'):
+    def openmc(self, frac_type='mass', indent_lvl=1):
         """openmc(frac_type)
         Return an openmc xml element for the material
         """
         cdef std_string mat
-        mat = self.mat_pointer.openmc(frac_type.encode())
+        mat = self.mat_pointer.openmc(frac_type.encode(), indent_lvl)
         return mat.decode()
 
     def fluka(self, fid, frac_type='mass'):
@@ -1782,7 +1782,7 @@ class Material(_Material, collectionsAbc.MutableMapping):
         """
         with open(filename, 'a') as f:
             f.write(self.alara())
-         
+
 
 
 #####################################
@@ -1858,7 +1858,7 @@ def from_atom_frac(atom_fracs, double mass=-1.0, double density=-1.0,
         mat.atoms_per_molecule = atoms_per_molecule
 
     return mat
-    
+
 
 
 def from_activity(activities, double mass=-1.0, double density=-1.0,

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1704,7 +1704,7 @@ class Material(_Material, collectionsAbc.MutableMapping):
         with open(filename, 'a') as f:
             f.write(self.mcnp(frac_type))
 
-    def write_openmc(self, filename, frac_type='mass'):
+    def write_openmc(self, filename, frac_type='mass', indent_lvl=1):
         """write_openmc(self, filename, frac_type='mass')
         The method appends an OpenMC mass fraction definition, with
         attributes to the file with the supplied filename.
@@ -1718,7 +1718,7 @@ class Material(_Material, collectionsAbc.MutableMapping):
             are used to describe material composition.
         """
         with open(filename, 'a') as f:
-            f.write(self.openmc(frac_type))
+            f.write(self.openmc(frac_type, indent_lvl))
 
     def alara(self):
         """alara(self)

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -220,6 +220,20 @@ cdef class _MaterialLibrary:
         filename = filename.encode()
         self._inst.write_json(filename)
 
+    def write_openmc(self, filename):
+        """write_openmc(filename)
+        Writes the material library in an OpenMC XML format.
+
+        Parameters
+        ----------
+        filename : str
+            Path to text file to write the data to.  If the file already
+            exists, it will be overwritten.
+
+        """
+        filename = filename.encode()
+        self._inst.write_openmc(filename)
+
     def __setitem__(self, key, value):
         """Add a Material to this material library, if the material key already exist it will be overwritten.
          Parameters

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -698,7 +698,7 @@ std::string pyne::Material::openmc(std::string frac_type, int indent_lvl) {
   std::string new_quote = "\"";
   std::string end_quote = "\" ";
   std::string indent(indent_lvl * 2, ' ');
-  std::string indent2 = indent + indent;
+  std::string indent2 = indent + std::string(2, ' ');
 
   // open the material element
   oss << indent << "<material id=" ;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -47,7 +47,7 @@ void pyne::Material::norm_comp() {
 void pyne::Material::_load_comp_protocol0(hid_t db, std::string datapath, int row) {
   // Clear current content
   comp.clear();
-  
+
   hid_t matgroup = H5Gopen2(db, datapath.c_str(), H5P_DEFAULT);
   hid_t nucset;
   double nucvalue;
@@ -104,7 +104,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath,
                                           std::string nucpath, int row) {
   // Clear current content
   comp.clear();
-  
+
   if (!h5wrap::path_exists(db, nucpath))
     throw std::runtime_error("No path found at the location: " + nucpath);
 
@@ -688,7 +688,7 @@ void pyne::Material::deprecated_write_hdf5(hid_t db, std::string datapath,
 }
 
 
-std::string pyne::Material::openmc(std::string frac_type) {
+std::string pyne::Material::openmc(std::string frac_type, int indent_lvl) {
   std::ostringstream oss;
 
   std::set<int> carbon_set; carbon_set.insert(nucname::id("C"));
@@ -697,10 +697,11 @@ std::string pyne::Material::openmc(std::string frac_type) {
   // vars for consistency
   std::string new_quote = "\"";
   std::string end_quote = "\" ";
-  std::string indent = "  ";
+  std::string indent(indent_lvl * 2, ' ');
+  std::string indent2 = indent + indent;
 
   // open the material element
-  oss << "<material id=" ;
+  oss << indent << "<material id=" ;
 
   // add the mat number
   if (temp_mat.metadata.isMember("mat_number")) {
@@ -723,7 +724,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   oss << std::endl;
 
   //indent
-  oss << indent;
+  oss << indent2;
 
   // specify density
   oss << "<density ";
@@ -753,8 +754,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   // add nuclides
   for(comp_map::iterator f = fracs.begin(); f != fracs.end(); f++) {
     if (f->second == 0.0) { continue; }
-    //indent
-    oss << "  ";
+    oss << indent2;
     // start a new nuclide element
     oss << "<nuclide name=" << new_quote;
     oss << pyne::nucname::openmc(f->first);
@@ -768,7 +768,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
 
   // other OpenMC material properties
   if(temp_mat.metadata.isMember("sab")) {
-    oss << indent;
+    oss << indent2;
     oss << "<sab name=";
     oss << new_quote << temp_mat.metadata["sab"].asString() << end_quote;
     oss << "/>";
@@ -776,7 +776,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   if(temp_mat.metadata.isMember("temperature")) {
-    oss << indent;
+    oss << indent2;
     oss << "<temperature>";
     oss << new_quote << temp_mat.metadata["temperature"].asString() << end_quote;
     oss << "</temperature>";
@@ -784,7 +784,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   if(temp_mat.metadata.isMember("macroscopic")) {
-    oss << indent;
+    oss << indent2;
     oss << "<macroscopic name=";
     oss << new_quote << temp_mat.metadata["macroscropic"].asString() << end_quote;
     oss << "/>";
@@ -792,7 +792,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   if(temp_mat.metadata.isMember("isotropic")) {
-    oss << indent;
+    oss << indent2;
     oss << "<isotropic>";
     oss << new_quote << temp_mat.metadata["isotropic"].asString() << end_quote;
     oss << "</isotropic>";
@@ -800,7 +800,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   // close the material node
-  oss << "</material>" << std::endl;
+  oss << indent << "</material>" << std::endl;
 
   return oss.str();
 }

--- a/src/material.h
+++ b/src/material.h
@@ -185,7 +185,7 @@ namespace pyne
     ///            appended to the end of the dataset.
     /// \param chunksize The chunksize for all material data on disk.
     /// New write_hdf5 which fallback on the old one when required
-    void write_hdf5(std::string filename, std::string datapath="/mat_name", 
+    void write_hdf5(std::string filename, std::string datapath="/mat_name",
         float row=-0.0, int chunksize=DEFAULT_MAT_CHUNKSIZE);
 
     /// Writes this nucpath to an HDF5 file.
@@ -251,7 +251,7 @@ namespace pyne
     void deprecated_write_hdf5(std::string filename, std::string datapath,
                     std::string nucpath, float row=-0.0, int chunksize=DEFAULT_MAT_CHUNKSIZE);
     /// Return an openmc xml material element as a string
-    std::string openmc(std::string fact_type = "mass");
+    std::string openmc(std::string frac_type = "mass", int indent_lvl=1);
 
     /// Return an mcnp input deck record as a string
     std::string mcnp(std::string frac_type = "mass", bool mult_den = true);

--- a/src/material_library.cpp
+++ b/src/material_library.cpp
@@ -1,6 +1,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #endif
+#include <fstream>
 #include <iostream>
 
 #ifndef PYNE_IS_AMALGAMATED
@@ -132,6 +133,23 @@ void pyne::MaterialLibrary::write_json(const std::string& filename) {
   std::string s = writer.write(json);
   std::ofstream f(filename.c_str(), std::ios_base::trunc);
   f << s << "\n";
+  f.close();
+}
+
+void pyne::MaterialLibrary::write_openmc(const std::string& filename) const
+{
+  std::ofstream f(filename.c_str());
+  // write header
+  f << "<?xml version=\"1.0\"?>\n";
+  f << "<materials>\n";
+  // write materials
+  for (auto& mat : material_library) {
+    f << mat.second->openmc("atom");
+  }
+  // write footer
+  f << "</materials>";
+
+  // close file
   f.close();
 }
 

--- a/src/material_library.h
+++ b/src/material_library.h
@@ -54,6 +54,9 @@ class MaterialLibrary {
   void load_json(Json::Value json);
   Json::Value dump_json();
   void write_json(const std::string& filename);
+  //! Writes the materials in an OpenMC XML format
+  void write_openmc(const std::string& filename) const;
+
   /**
    * \brief Writes MaterialLibrary out to an HDF5 file.
             This happens according to protocol 1.

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -210,7 +210,7 @@ def test_hdf5_protocol_1_old():
     assert_equal(m.metadata['comment'], 'hitting the dancefloor')
 
     os.remove('proto1.h5')
-    
+
     leu = Material({'U235': 0.02, 'U238': 0.98}, 6.34, 2.72, 1.0)
     leu.metadata['comment'] = 'hitting the dancefloor'
     leu.write_hdf5('proto1.h5', datapath="/new_mat", nucpath="/nucid", chunksize=10)
@@ -234,9 +234,9 @@ def test_hdf5_protocol_1_old():
     assert_equal(m.mass, 4.2)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'first light')
-    
+
     os.remove('proto1.h5')
-    
+
 def test_hdf5_protocol_1():
     if 'proto1.h5' in os.listdir('.'):
         os.remove('proto1.h5')
@@ -245,7 +245,7 @@ def test_hdf5_protocol_1():
     leu = Material({'U235': 0.04, 'U238': 0.96}, 4.2, 2.72, 1.0)
     leu.metadata['comment'] = 'first light'
     leu.write_hdf5('proto1.h5')
-    
+
     for i in range(2, 11):
         leu = Material({'U235': 0.04, 'U238': 0.96}, i*4.2, 2.72, 1.0*i)
         leu.metadata['comment'] = 'fire in the disco - {0}'.format(i)
@@ -260,7 +260,7 @@ def test_hdf5_protocol_1():
         assert_equal(m.mass, i*4.2)
         assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
         assert_equal(m.metadata['comment'], 'fire in the disco - {0}'.format(i))
-    
+
     m = from_hdf5('proto1.h5', '/mat_name', -1, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 10.0)
@@ -271,7 +271,7 @@ def test_hdf5_protocol_1():
     m = from_hdf5('proto1.h5', '/mat_name', 0, 1)
     assert_equal(m.density, 2.72)
     assert_equal(m.atoms_per_molecule, 1.0)
-    assert_equal(m.mass, 4.2) 
+    assert_equal(m.mass, 4.2)
     assert_equal(m.comp, {922350000: 0.04, 922380000: 0.96})
     assert_equal(m.metadata['comment'], 'first light')
     os.remove('proto1.h5')
@@ -326,7 +326,7 @@ class TestMaterialMethods(TestCase):
         assert_equal(set(obs), set(exp))
         for key in exp:
             assert_almost_equal(obs[key], exp[key])
-    
+
 
     def test_decay_heat_metastable(self):
         mat = Material({471080001: 0.5, 551340001: 0.5}, 2)
@@ -397,7 +397,7 @@ def test_expand_elements3():
     expmat = natmat.expand_elements(exception_ids)
     afrac = expmat.to_atom_frac()
     assert_almost_equal(natmat[60000000], afrac[60000000])
-    
+
 def test_collapse_elements1():
     """ Very simple test to combine nucids"""
     nucvec = {10010000:  1.0,
@@ -1255,7 +1255,7 @@ def test_openmc():
                           'name':'LEU'},
                    density=19.1)
 
-    mass = leu.openmc()
+    mass = leu.openmc(indent_lvl=0)
     mass_exp = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
@@ -1263,7 +1263,7 @@ def test_openmc():
                 '</material>\n')
     assert_equal(mass, mass_exp)
 
-    atom = leu.openmc(frac_type='atom')
+    atom = leu.openmc(frac_type='atom', indent_lvl=0)
     atom_exp = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" ao="4.0491e-02" />\n'
@@ -1277,10 +1277,10 @@ def test_openmc():
     leu_read = Material()
     leu_read.from_hdf5('leu.h5', '/mat_name')
 
-    mass = leu.openmc()
+    mass = leu.openmc(indent_lvl=0)
     assert_equal(mass, mass_exp)
 
-    atom = leu.openmc(frac_type='atom')
+    atom = leu.openmc(frac_type='atom', indent_lvl=0)
     assert_equal(atom, atom_exp)
 
 def test_openmc_mat0():
@@ -1294,7 +1294,7 @@ def test_openmc_mat0():
                           'name':'LEU'},
                    density=19.1)
 
-    mass = leu.openmc()
+    mass = leu.openmc(indent_lvl=0)
     mass_exp = ('<material id="2" name="LEU" >\n'
                 '  <density value="19.1" units="g/cc" />\n'
                 '  <nuclide name="U235" wo="4.0000e-02" />\n'
@@ -1313,7 +1313,7 @@ def test_openmc_sab():
                           'name':'Water'},
                    density=1.001)
 
-    mass = leu.openmc()
+    mass = leu.openmc(indent_lvl=0)
     mass_exp = ('<material id="2" name="Water" >\n'
                 '  <density value="1.001" units="g/cc" />\n'
                 '  <nuclide name="H1" wo="6.6667e-01" />\n'
@@ -1330,10 +1330,10 @@ def test_openmc_c():
                    'name':'silicon carbide'}
     csi.density = 3.16
 
-    atom = csi.openmc(frac_type='atom')
+    atom = csi.openmc(frac_type='atom', indent_lvl=0)
     atom_exp = ('<material id="2" name="silicon carbide" >\n'
                 '  <density value="3.16" units="g/cc" />\n'
-                '  <nuclide name="C0" ao="5.0000e-01" />\n'                
+                '  <nuclide name="C0" ao="5.0000e-01" />\n'
                 '  <nuclide name="Si28" ao="4.6111e-01" />\n'
                 '  <nuclide name="Si29" ao="2.3425e-02" />\n'
                 '  <nuclide name="Si30" ao="1.5460e-02" />\n'
@@ -1358,7 +1358,7 @@ def test_phits():
                 '     92235.15c -4.0000e-02\n'
                 '     92238.25c -9.6000e-01\n')
     assert_equal(mass, mass_exp)
-    
+
     atom = leu.phits(frac_type='atom')
     atom_exp = ('C name: leu\n'
                 'C comments: this is a long comment that will definitly go over the 80 character\n'
@@ -1517,7 +1517,7 @@ def test_uwuw():
     name_exp = ('mat:leu')
     assert_equal(uwuw_name, name_exp)
 
-    
+
     no_name = Material(nucvec={'U235': 0.04, 'U238': 0.96},
                    metadata={'mat_number': 2,
                           'table_ids': {'92235':'15c', '92238':'25c'},
@@ -1577,11 +1577,9 @@ def test_write_openmc():
                           'name':'LEU'},
                    density=19.1)
 
-    leu.write_openmc('openmc_mass_fracs.txt')
-    leu.write_openmc('openmc_mass_fracs.txt', frac_type='atom')
+    leu.write_openmc('openmc_mass_fracs.txt', indent_lvl=0)
+    leu.write_openmc('openmc_mass_fracs.txt', frac_type='atom', indent_lvl=0)
 
-
-    
     with open('openmc_mass_fracs.txt') as f:
         written = f.read()
     expected = ('<material id="2" name="LEU" >\n'
@@ -1596,7 +1594,7 @@ def test_write_openmc():
                 '</material>\n')
     assert_equal(written, expected)
     os.remove('openmc_mass_fracs.txt')
-    
+
 def test_write_mcnp():
     if 'mcnp_mass_fracs.txt' in os.listdir('.'):
         os.remove('mcnp_mass_fracs.txt')


### PR DESCRIPTION
## Description
These changes add a method to `MaterialLibrary` that allow one to write the materials in an XML format for use with OpenMC.

## Motivation and Context
For verification, it is sometimes easier to have the materials in a format that OpenMC can read. This is also useful when looking to apply material definitions from a PyNE material library to OpenMC models.