### PR TITLE
Fixing the docker build action

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -83,27 +83,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pymoab : [
-          _pymoab,
-          ]
-        dagmc : [
-          _dagmc
-        ]
-        openmc : [
-          '',
-        ]
         hdf5 : [
           '',
         ]
+        dagmc : [
+          _dagmc
+        ]
+        pymoab : [
+          _pymoab,
+          ]
+        openmc : [
+          '',
+        ]
         include:
-          - openmc: ''
-            hdf5: _hdf5-1_12_0
+          - hdf5: _hdf5-1_12_0
             dagmc: _dagmc
             pymoab: _pymoab
-          - openmc: _openmc
-            hdf5: ''
+            openmc: ''
+          - hdf5: ''
             dagmc: _dagmc
             pymoab: _pymoab
+            openmc: _openmc
 
       fail-fast: false
     
@@ -196,32 +196,32 @@ jobs:
       
     strategy:
       matrix:
-        pymoab : [
-          _pymoab,
-          ]
+        hdf5 : [
+          '',
+        ]
         dagmc : [
           '',
           _dagmc
         ]
+        pymoab : [
+          _pymoab,
+          ]
         openmc : [
           '',
         ]
-        hdf5 : [
-          '',
-        ]
         include:
-          - openmc: ''
-            hdf5: _hdf5-1_12_0
+          - hdf5: _hdf5-1_12_0
             dagmc: _dagmc
             pymoab: _pymoab
-          - openmc: _openmc
-            hdf5: ''
+            openmc: ''
+          - hdf5: ''
             dagmc: _dagmc
             pymoab: _pymoab
-          - openmc: ''
-            hdf5: ''
+            openmc: _openmc
+          - hdf5: ''
             dagmc: ''
             pymoab: ''
+            openmc: ''
       fail-fast: false
 
 
@@ -274,29 +274,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pymoab : [
-          # '', commented out as this combination is not built
-          _pymoab,
-          ]
+        hdf5 : [
+          '',
+        ]
         dagmc : [
           # '', commented out as this combination is not built
           _dagmc
         ]
+        pymoab : [
+          # '', commented out as this combination is not built
+          _pymoab,
+          ]
         openmc : [
           '',
         ]
-        hdf5 : [
-          '',
-        ]
         include:
-          - openmc: ''
-            hdf5: _hdf5-1_12_0
+          - hdf5: _hdf5-1_12_0
             dagmc: _dagmc
             pymoab: _pymoab
-          - openmc: _openmc
-            hdf5: ''
+            openmc: ''
+          - hdf5: ''
             dagmc: _dagmc
             pymoab: _pymoab
+            openmc: _openmc
 
     name: "${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}: latest -> stable"
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -299,7 +299,7 @@ jobs:
             openmc: _openmc
         exclude:
           - hdf5: ''
-            dagmc: ''
+            dagmc: '_dagmc'
             pymoab: ''
             openmc: ''
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -282,7 +282,6 @@ jobs:
           _dagmc
         ]
         pymoab : [
-          '',
           _pymoab,
           ]
         openmc : [
@@ -297,9 +296,8 @@ jobs:
             dagmc: _dagmc
             pymoab: _pymoab
             openmc: _openmc
-        exclude:
           - hdf5: ''
-            dagmc: '_dagmc'
+            dagmc: ''
             pymoab: ''
             openmc: ''
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -299,13 +299,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image to stable img
-        uses: akhilerm/tag-push-action@v1.0.0
+        uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:ci_testing
           dst: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:stable
 
-      - name: Push Image to stable img
-        uses: akhilerm/tag-push-action@v1.0.0
+      - name: Push Image to latest img
+        uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:ci_testing
           dst: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -268,7 +268,8 @@ jobs:
   # can be copied from the ghcr where they are saved using :ci_testing tags to
   # :latest and :stable tags.
   pushing_test_stable_img:
-    if: ${{ github.repository_owner == 'pyne' }}
+    # if: ${{ github.repository_owner == 'pyne' }}
+    if: ${{ github.repository_owner == 'shimwell' }}
     needs: [BuildTest]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -278,11 +278,11 @@ jobs:
           '',
         ]
         dagmc : [
-          # '', commented out as this combination is not built
+          '',
           _dagmc
         ]
         pymoab : [
-          # '', commented out as this combination is not built
+          '',
           _pymoab,
           ]
         openmc : [
@@ -297,6 +297,12 @@ jobs:
             dagmc: _dagmc
             pymoab: _pymoab
             openmc: _openmc
+        exclude:
+          - hdf5: ''
+            dagmc: ''
+            pymoab: ''
+            openmc: ''
+
 
     name: "${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}: latest -> stable"
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -268,8 +268,7 @@ jobs:
   # can be copied from the ghcr where they are saved using :ci_testing tags to
   # :latest and :stable tags.
   pushing_test_stable_img:
-    # if: ${{ github.repository_owner == 'pyne' }}
-    if: ${{ github.repository_owner == 'shimwell' }}
+    if: ${{ github.repository_owner == 'pyne' }}
     needs: [BuildTest]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
 
+  # builds and pushes two docker images to ghcr.
+  # These docker images are also cached locally so that they can be efficiently
+  # accessed by the subsequent stage (build_and_push_dagmc).
   build_and_push_python3_pymoab:
     runs-on: ubuntu-latest
     strategy:
@@ -72,18 +75,18 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3_pymoab_pyne-deps:ci_testing
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-${{ github.sha }}
 
-
+  # builds on the previous cached images adding extra layers to the base docker
+  # images created in the previous step. The resulting images include various
+  # combinations of pymoab dagmc, openmc and hdf5.
   build_and_push_dagmc:
     needs: build_and_push_python3_pymoab
     runs-on: ubuntu-latest
     strategy:
       matrix:
         pymoab : [
-          '',
           _pymoab,
           ]
         dagmc : [
-          '',
           _dagmc
         ]
         openmc : [
@@ -173,6 +176,8 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache-${{ github.sha }}
           tags: ghcr.io/${{ github.repository_owner }}/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:ci_testing
 
+  # Once the previous two steps have finished the docker images are uploaded
+  # to ghcr and therefore the local cached images are removed. 
   cleanup_cache:
     if: always()
     needs: [build_and_push_python3_pymoab, build_and_push_dagmc]
@@ -182,6 +187,8 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache-${{ github.sha }}
 
+  # Downloads the images uploaded to ghcr in previous stages and runs pyne
+  # tests to check that they work.
   BuildTest:
     needs: [build_and_push_python3_pymoab, build_and_push_dagmc]
     runs-on: ubuntu-latest
@@ -257,6 +264,9 @@ jobs:
           cd $GITHUB_WORKSPACE/tests
           ./travis-run-tests.sh python3
 
+  # if the previous step that tests the docker images passes then the images
+  # can be copied from the ghcr where they are saved using :ci_testing tags to
+  # :latest and :stable tags.
   pushing_test_stable_img:
     if: ${{ github.repository_owner == 'pyne' }}
     needs: [BuildTest]
@@ -264,11 +274,11 @@ jobs:
     strategy:
       matrix:
         pymoab : [
-          '',
+          # '', commented out as this combination is not built
           _pymoab,
           ]
         dagmc : [
-          '',
+          # '', commented out as this combination is not built
           _dagmc
         ]
         openmc : [

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -79,9 +79,11 @@ jobs:
     strategy:
       matrix:
         pymoab : [
+          '',
           _pymoab,
           ]
         dagmc : [
+          '',
           _dagmc
         ]
         openmc : [

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Next Version
 
    * fixing VR test (#1399)
    * fixing output from MaterialLibrary warning. (#1414)
+   * fixing docker publish CI Github Action (#1426)
 
 **Maintenance**
    * removing old circle-ci related stuff (#1405)


### PR DESCRIPTION
## Description
Tiny change to the docker building ci that:
-updates to use the latest tag-push-action from v1 to v2
-we had two steps with the same name so I've renamed the second one so that it better describes what is happening.
-added some comments to the steps that helps with issue #1425 

## Motivation and Context


## Changes
Updated docker build CI

## Behavior
failing CI
https://github.com/pyne/pyne/actions/workflows/docker_publish.yml

## Other Information
Currently a blocking issue for the next DAGMC release

## Changelog file
All pull requests are required to update the [CHANGELOG](https://github.com/pyne/pyne/blob/develop/CHANGELOG.rst) file with the PR.  Your update can take different forms including:

* creating a new entry describing your change, including a reference to this pull request number
* adding a reference to your pull request number to an exist entry if that entry can include your changes
