### PR TITLE
Update version strings for new release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ PyNE Change Log
 Next Version
 ============
 
+
+
+v0.7.6
+======
+
 **New Capabilities**
    * Adds method to write a MaterialLibrary as an OpenMC XML file.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(pyne)
 # Set PYNE version
 set(PYNE_MAJOR_VERSION 0)
 set(PYNE_MINOR_VERSION 7)
-set(PYNE_PATCH_VERSION 5)
+set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
 # Configure Pyne and cpp version headers


### PR DESCRIPTION
Updating the two places that refer to the version number of a release in preparation for a microrelease.