### PR TITLE
Make Pyne Version actions into a CMake include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,17 +11,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 # Setup the project
 project(pyne)
 
-
-# Set PYNE version
-set(PYNE_MAJOR_VERSION 0)
-set(PYNE_MINOR_VERSION 7)
-set(PYNE_PATCH_VERSION 6)
-set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
-
-# Configure Pyne and cpp version headers
-configure_file(pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
-configure_file(src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
-
+include(PyneVersion)
 
 # check for and enable c++11 support
 INCLUDE(CheckCXXCompilerFlag)

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -1,0 +1,10 @@
+# Set PYNE version
+set(PYNE_MAJOR_VERSION 0)
+set(PYNE_MINOR_VERSION 7)
+set(PYNE_PATCH_VERSION 6)
+set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
+
+# Configure Pyne and cpp version headers
+configure_file(pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
+configure_file(src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
+


### PR DESCRIPTION
To make the action available to other CMake workflows, the actions to set and invoke the version number is moved to a file that can be included.

This is driven by the need to invoke these actions when PyNE is being amalgamated from a SubModule