### PR TITLE
Update version macro to allow for specifying path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ v0.7.6
 **Change**
    * exclude docker related stuff from build_test (#1404 #1408)
    * move changelog test in its own workflow (#1404)
-   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415)
+   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
 
 **Fix**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,9 @@ v0.7.6
 **Change**
    * exclude docker related stuff from build_test (#1404 #1408)
    * move changelog test in its own workflow (#1404)
-   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428)
+   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version 
+     number, cmake will automatically configure proper version files for python and cpp 
+     based on the PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428, #1430)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
 
 **Fix**

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -4,7 +4,7 @@ set(PYNE_MINOR_VERSION 7)
 set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
-MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION}")
+MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}")
 
 # Configure Pyne and cpp version headers
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -7,6 +7,6 @@ set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSIO
 MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}")
 
 # Configure Pyne and cpp version headers
-configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)
-configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}src/pyne_version.h)
+configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
+configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
 

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -5,6 +5,6 @@ set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
 # Configure Pyne and cpp version headers
-configure_file(pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
-configure_file(src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
+configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)
+configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}src/pyne_version.h)
 

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -4,6 +4,8 @@ set(PYNE_MINOR_VERSION 7)
 set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
+MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION}")
+
 # Configure Pyne and cpp version headers
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)
 configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}src/pyne_version.h)


### PR DESCRIPTION
## Description
Introduce an optional path for specifying where the PyNE version substitution should occur.

## Motivation and Context
When PyNE is included as a submodule, it may be necessary to process the PyNE Version substitution without running directly CMake on the PyNE directory.  A new Version macro was introduced in #1428, but it still assumes that CMake is running in the base PyNE source directory.

This change allows the user/developer to specify a path to the PyNE source.

## Changes
This is a new feature from PyNE's point of view, but contributes to a bug fix in downstream packages.


