### PR TITLE
Improving ability to invoke PyNE Version CMake macro when submodule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ v0.7.6
 **Change**
    * exclude docker related stuff from build_test (#1404 #1408)
    * move changelog test in its own workflow (#1404)
-   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415)
+   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
 
 **Fix**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,9 @@ v0.7.6
 **Change**
    * exclude docker related stuff from build_test (#1404 #1408)
    * move changelog test in its own workflow (#1404)
-   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version 
-     number, cmake will automatically configure proper version files for python and cpp 
-     based on the PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428, #1430)
+   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, 
+     cmake will automatically configure proper version files for python and cpp based on the 
+     PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
 
 **Fix**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ v0.7.6
    * move changelog test in its own workflow (#1404)
    * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, 
      cmake will automatically configure proper version files for python and cpp based on the 
-     PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428)
+     PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428, #1431)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
 
 **Fix**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,9 @@ v0.7.6
 **Change**
    * exclude docker related stuff from build_test (#1404 #1408)
    * move changelog test in its own workflow (#1404)
-   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428)
+   * Adds 2 templates header files (one for Python one for CPP) to store PYNE version 
+     number, cmake will automatically configure proper version files for python and cpp 
+     based on the PYNE VERSION number located in the root CMakeFile.txt (#1415, #1428, #1430)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
 
 **Fix**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,6 @@ project(pyne)
 
 include(PyneVersion)
 
-IF (PYNE_VERSION_ONLY)
-  RETURN()
-ENDIF()
-
 # check for and enable c++11 support
 INCLUDE(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ project(pyne)
 
 include(PyneVersion)
 
+IF (PYNE_VERSION_ONLY)
+  RETURN()
+ENDIF()
+
 # check for and enable c++11 support
 INCLUDE(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/amalgamate.py
+++ b/amalgamate.py
@@ -20,7 +20,7 @@ HEADER_EXTS |= {e.upper() for e in HEADER_EXTS}
 
 DEFAULT_FILES = [
     'license.txt',
-    'src/version.h',
+    'src/pyne_version.h',
     'src/utils.h',
     'src/utils.cpp',
     'src/extra_types.h',

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -5,7 +5,7 @@ set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
 # Configure Pyne and cpp version headers
-configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
-configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
+configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py)
+configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/src/pyne_version.h)
 
 MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -4,6 +4,11 @@ set(PYNE_MINOR_VERSION 7)
 set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
+if( NOT (PYNE_SUBMODULE_PATH) )
+   MESSAGE(STATUS "PyNE not used as submodule, using current directory")
+   set(PYNE_SUBMODULE_PATH "./")
+endif(PYNE_SUBMODULE_PATH)
+
 # Configure Pyne and cpp version headers
 configure_file(${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py)
 configure_file(${PYNE_SUBMODULE_PATH}/src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/src/pyne_version.h)

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -4,7 +4,7 @@ set(PYNE_MINOR_VERSION 7)
 set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
-MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION}")
+MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}")
 
 # Configure Pyne and cpp version headers
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -4,10 +4,8 @@ set(PYNE_MINOR_VERSION 7)
 set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
-MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}")
-
 # Configure Pyne and cpp version headers
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
 configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
 
-MESSAGE(STATUS "Set PyNE Version to ${PYNE_VERSION} in ${CMAKE_CURRENT_SOURCE_DIR}/pyne and ${CMAKE_CURRENT_SOURCE_DIR}/src")
+MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -7,6 +7,6 @@ set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSIO
 MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}")
 
 # Configure Pyne and cpp version headers
-configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)
-configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}src/pyne_version.h)
+configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
+configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
 

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -10,3 +10,4 @@ MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${P
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
 configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
 
+MESSAGE(STATUS "Set PyNE Version to ${PYNE_VERSION}")

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -10,4 +10,4 @@ MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${P
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
 configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
 
-MESSAGE(STATUS "Set PyNE Version to ${PYNE_VERSION}")
+MESSAGE(STATUS "Set PyNE Version to ${PYNE_VERSION} in ${CMAKE_CURRENT_SOURCE_DIR}/pyne and ${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -7,7 +7,7 @@ set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSIO
 if( NOT (PYNE_SUBMODULE_PATH) )
    MESSAGE(STATUS "PyNE not used as submodule, using current directory")
    set(PYNE_SUBMODULE_PATH "./")
-endif(PYNE_SUBMODULE_PATH)
+endif(NOT (PYNE_SUBMODULE_PATH))
 
 # Configure Pyne and cpp version headers
 configure_file(${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py)

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -5,6 +5,6 @@ set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
 # Configure Pyne and cpp version headers
-configure_file(pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/pyne/pyne_version.py)
-configure_file(src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/pyne_version.h)
+configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)
+configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}src/pyne_version.h)
 

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -8,4 +8,4 @@ set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSIO
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py)
 configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/src/pyne_version.h)
 
-MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${PYNE_SUBMODULE_PATH}${CMAKE_CURRENT_SOURCE_DIR}")
+MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}")

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -4,6 +4,8 @@ set(PYNE_MINOR_VERSION 7)
 set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
+MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION}")
+
 # Configure Pyne and cpp version headers
 configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${PYNE_SUBMODULE_PATH}pyne/pyne_version.py)
 configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${PYNE_SUBMODULE_PATH}src/pyne_version.h)

--- a/cmake/PyneVersion.cmake
+++ b/cmake/PyneVersion.cmake
@@ -5,7 +5,7 @@ set(PYNE_PATCH_VERSION 6)
 set(PYNE_VERSION ${PYNE_MAJOR_VERSION}.${PYNE_MINOR_VERSION}.${PYNE_PATCH_VERSION})
 
 # Configure Pyne and cpp version headers
-configure_file(${PYNE_SUBMODULE_PATH}pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py)
-configure_file(${PYNE_SUBMODULE_PATH}src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/src/pyne_version.h)
+configure_file(${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/pyne/pyne_version.py)
+configure_file(${PYNE_SUBMODULE_PATH}/src/pyne_version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}/src/pyne_version.h)
 
 MESSAGE(STATUS "Setting PyNE Version to ${PYNE_VERSION} by changing files in ${CMAKE_CURRENT_SOURCE_DIR}/${PYNE_SUBMODULE_PATH}")


### PR DESCRIPTION
## Description
Introduce features and variables that allow the PyNE Version CMake macro to be called from a different path location

## Motivation and Context
The PyNE Version macro works for build from within PyNE, but needs more support when PyNE is a submodule in a different path.

## Changes
This can be considered a feature enhancement with changes in the PyNE Version macro.
