### PR TITLE
Trying Python version 3.6 in CI.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -60,6 +60,8 @@ jobs:
 
     steps:
       - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
 
       - name: setup
         shell: bash -l {0}
@@ -81,8 +83,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Building PyNE
-        with:
-          python-version: 3.6
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE
@@ -93,8 +93,6 @@ jobs:
           nuc_data_make
 
       - name: Testing PyNE
-        with:
-          python-version: 3.6
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -59,6 +59,8 @@ jobs:
       image: ghcr.io/pyne/ubuntu_18.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:stable
 
     steps:
+      - uses: actions/setup-python@v2
+
       - name: setup
         shell: bash -l {0}
         run: |
@@ -77,8 +79,10 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v2
-        
+
       - name: Building PyNE
+        with:
+          python-version: 3.6
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE
@@ -89,6 +93,8 @@ jobs:
           nuc_data_make
 
       - name: Testing PyNE
+        with:
+          python-version: 3.6
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/tests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Next Version
    * move changelog test in its own workflow (#1404)
    * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
-   * Updating Python versin to 3.6 in CI. (#1437)
+   * Updating Python version to 3.6 in CI. (#1437)
 
 **Fix**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Next Version
    * move changelog test in its own workflow (#1404)
    * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
-   * Updating Python versin to 3.6 in CI.
+   * Updating Python versin to 3.6 in CI. (#1437)
 
 **Fix**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Next Version
    * move changelog test in its own workflow (#1404)
    * Adds 2 templates header files (one for Python one for CPP) to store PYNE version number, cmake will automatically configure proper version files for python and cpp based on the PYNE VERSION number located in the root CMakeFile.txt (#1415)
    * PyNE CI docker container now target DAGMC:'stable' tag instead of develop. (#1415)
+   * Updating Python versin to 3.6 in CI.
 
 **Fix**
 


### PR DESCRIPTION

## Description
Setting Python version to 3.6 in CI.

## Motivation and Context
Checking Python 3.6 as a new minimum version requirement for PyNE (Python 3.5's EOL was in Sept. 2020).
