### PR TITLE
Add option to turn off last FORTRAN code (ENSDF) and default to no fortran

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Next Version
 
 **Maintenance**
    * update workflow to accommodate security-driven changes (#1445)
+   * turn off all fortran (spatial solvers and ENSDF processing) by default (#1444)
 
 v0.7.6
 ======

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ ELSE()
 ENDIF()
 
 option ( ENABLE_SPATIAL_SOLVERS     "Should build AHOT spatial solvers?"                 OFF )
+option ( ENABLE_ENSDF_PROCESSIONG   "Should build ENSDF processing tools?"               OFF )
 
 include(PyneMacros)
 pyne_print_logo()  # Beware of dragons

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ ELSE()
     MESSAGE(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 ENDIF()
 
-option ( ENABLE_SPATIAL_SOLVERS     "Should build AHOT spatial solvers?"                 ON )
+option ( ENABLE_SPATIAL_SOLVERS     "Should build AHOT spatial solvers?"                 OFF )
 
 include(PyneMacros)
 pyne_print_logo()  # Beware of dragons

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,23 +103,25 @@ if(DAGMC_FOUND)
     target_link_libraries(pyne dagmc MOAB)
 endif(DAGMC_FOUND)
 
-add_executable(alphad ${PROJECT_SOURCE_DIR}/src/ensdf_processing/ALPHAD/alphad.f
+if(ENABLE_ENSDF_PROCESSIONG)
+  add_executable(alphad ${PROJECT_SOURCE_DIR}/src/ensdf_processing/ALPHAD/alphad.f
+                        ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
+  add_executable(delta ${PROJECT_SOURCE_DIR}/src/ensdf_processing/DELTA/delta.for)
+  add_executable(gtol ${PROJECT_SOURCE_DIR}/src/ensdf_processing/GTOL/gtol.f
                       ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
-add_executable(delta ${PROJECT_SOURCE_DIR}/src/ensdf_processing/DELTA/delta.for)
-add_executable(gtol ${PROJECT_SOURCE_DIR}/src/ensdf_processing/GTOL/gtol.f
-                    ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
-add_executable(bldhst ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/bldhst.for)
-add_executable(hsicc ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/hsicc.for
-                     ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
-add_executable(hsmrg ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/hsmrg.for
-                     ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
-add_executable(seqhst ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/seqhst.for
-                      ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
-add_executable(logft ${PROJECT_SOURCE_DIR}/src/ensdf_processing/LOGFT/logft.for
-                     ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
-add_executable(radd ${PROJECT_SOURCE_DIR}/src/ensdf_processing/RADD/RadD.for)
-add_executable(ruler ${PROJECT_SOURCE_DIR}/src/ensdf_processing/RULER/ruler.f
-                     ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
+  add_executable(bldhst ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/bldhst.for)
+  add_executable(hsicc ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/hsicc.for
+                       ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
+  add_executable(hsmrg ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/hsmrg.for
+                       ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
+  add_executable(seqhst ${PROJECT_SOURCE_DIR}/src/ensdf_processing/HSICC/seqhst.for
+                        ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
+  add_executable(logft ${PROJECT_SOURCE_DIR}/src/ensdf_processing/LOGFT/logft.for
+                       ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
+  add_executable(radd ${PROJECT_SOURCE_DIR}/src/ensdf_processing/RADD/RadD.for)
+  add_executable(ruler ${PROJECT_SOURCE_DIR}/src/ensdf_processing/RULER/ruler.f
+                       ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)
+endif(ENABLE_ENSDF_PROCESSIONG)
 
 # Print include dir
 get_property(inc_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)


### PR DESCRIPTION
## Description
Add a CMake option to turn off the building of ENSDF processing and turn off that and spatial solvers by default.

## Motivation and Context
ENSDF Fortran code is and has features no longer supported by newer compilers.  To avoid updating the FORTRAN and avoid being stuck with old compilers, these are being turned off by default.

## Changes
Change in build process/options.
