### PR TITLE
Find dagmc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Next Version
 **Maintenance**
    * update workflow to accommodate security-driven changes (#1445)
    * turn off all fortran (spatial solvers and ENSDF processing) by default (#1444)
+   * update where to look for DAGMC CMake files (#1446)
 
 v0.7.6
 ======

--- a/cmake/FindDAGMC.cmake
+++ b/cmake/FindDAGMC.cmake
@@ -18,7 +18,7 @@ message(STATUS ${DAGMC_ROOT})
 
 find_path(DAGMC_CMAKE_CONFIG NAMES DAGMCConfig.cmake
           HINTS ${DAGMC_ROOT}
-          PATH_SUFFIXES lib Lib cmake lib/cmake/
+          PATH_SUFFIXES lib Lib cmake dagmc lib/cmake/dagmc
           NO_DEFAULT_PATH)
 
 message(STATUS "Found DAGMC in ${DAGMC_CMAKE_CONFIG}")


### PR DESCRIPTION

## Description
Update where PyNE looks for DAGMC 

## Motivation and Context
Recent changes to DAGMC moved where CMake config files are stored.

## Changes
Update


