### PR TITLE
Fix for compatibility with newer versions of tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next Version
    * update workflow to accommodate security-driven changes (#1445)
    * turn off all fortran (spatial solvers and ENSDF processing) by default (#1444)
    * update where to look for DAGMC CMake files (#1446)
+   * ensure NUC_DATA_PATH is a string (#1447)
 
 v0.7.6
 ======

--- a/tests/xs/test_data_source.py
+++ b/tests/xs/test_data_source.py
@@ -39,7 +39,7 @@ download_file(
     "5349513f196ad594d172bc6ea61dc382",
 )
 
-nuc_data = pyne_conf.NUC_DATA_PATH
+nuc_data = str(pyne_conf.NUC_DATA_PATH,'UTF-8')
 
 # These tests require nuc_data
 if not os.path.isfile(nuc_data):


### PR DESCRIPTION
## Description
Make NUC_DATA_PATH a string

## Motivation and Context
Currently, PyNE must be built with a tables package version lower than 3.7
Using tables package 3.7 or higher makes this variable type byte when it should be a string. 
This change allows for compatibility with newer versions of tables

