### PR TITLE
try newer versions of some pip packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Next Version
    * turn off all fortran (spatial solvers and ENSDF processing) by default (#1444)
    * update where to look for DAGMC CMake files (#1446)
    * ensure NUC_DATA_PATH is a string (#1447)
+   * advance versions of packages installed in CI by pip (#1448)
 
 v0.7.6
 ======

--- a/docker/ubuntu_18.04-dev.dockerfile
+++ b/docker/ubuntu_18.04-dev.dockerfile
@@ -46,7 +46,7 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             sphinx \
             cloud_sptheme \
             prettytable \
-            "setuptools<49" \
+            setuptools \
             sphinxcontrib_bibtex \
             numpydoc \
             nbconvert \
@@ -54,7 +54,7 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             nose \
             cython \
             future \
-            "tables<3.7" \
+            tables \
             scipy \
             jinja2 \
             progress; \


### PR DESCRIPTION
## Description
Remove version limits on some python packages installed by pip in CI images.

## Motivation and Context
In order to enable a recent release, we were forced to limit the version of `setuptools` and `pytables` for compatibility. Some recent changes in PyNE have removed the cause (maybe)?

## Changes
This is a build maintenance change.

