### PR TITLE
Fix multistage action image tag problem

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -38,8 +38,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo $DOCKER_IMAGE_TAG
-
       # build base python, moab, dagmc, openmc using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
         with:
@@ -65,7 +63,6 @@ jobs:
       - id: output_tag
         run: |
           echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "$DOCKER_IMAGE_TAG"
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
@@ -100,8 +97,6 @@ jobs:
           fi
           export ADD_FLAG="${ADD_FLAG} "
           echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
-
-      - run: echo "$needs.multistage_image_build.outputs.image_tag"
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -38,9 +38,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: echo $env.DOCKER_IMAGE_TAG
+
       - if: github.ref_name == 'develop'
         run: |
-          echo $DOCKER_IMAGE_TAG
           echo "" >> $DOCKER_IMAGE_TAG
           echo $DOCKER_IMAGE_TAG
 
@@ -68,7 +69,7 @@ jobs:
 
       - id: output_tag
         run: |
-          echo "$env.DOCKER_IMAGE_TAG" >> "$github.output"
+          echo "test=$env.DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "$env.DOCKER_IMAGE_TAG"
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -67,7 +67,9 @@ jobs:
           build-args: py_version=3.8, build_hdf5=hdf5-1_12_0
 
       - id: output_tag
-        run: echo $DOCKER_IMAGE_TAG >> $github.output
+        run: |
+          echo $env.DOCKER_IMAGE_TAG >> $github.output
+          echo $env.DOCKER_IMAGE_TAG
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
@@ -103,7 +105,7 @@ jobs:
           export ADD_FLAG="${ADD_FLAG} "
           echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
 
-      - run: echo ${{ needs.multistage_image_build.outputs.image_tag }}
+      - run: echo $needs.multistage_image_build.outputs.image_tag
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -25,7 +25,7 @@ jobs:
           20.04,
         ]
     outputs:
-      image_tag: ${{ steps.output_tag.outputs.test }}
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
     steps:
       - name: Checkout repository
@@ -39,11 +39,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: echo $DOCKER_IMAGE_TAG
-
-      - if: github.ref_name == 'develop'
-        run: |
-          echo "" >> $DOCKER_IMAGE_TAG
-          echo $DOCKER_IMAGE_TAG
 
       # build base python, moab, dagmc, openmc using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
@@ -69,7 +64,7 @@ jobs:
 
       - id: output_tag
         run: |
-          echo "test=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "$DOCKER_IMAGE_TAG"
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -24,6 +24,8 @@ jobs:
         ubuntu_versions : [
           20.04,
         ]
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.test }}
 
     steps:
       - name: Checkout repository
@@ -36,7 +38,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: GITHUB_REF_NAME == "develop"
+      - if: github.ref_name == "develop"
         run: |
           echo $DOCKER_IMAGE_TAG
           echo "" >> $DOCKER_IMAGE_TAG
@@ -64,6 +66,9 @@ jobs:
           dockerfile: docker/ubuntu_20.04-dev.dockerfile
           build-args: py_version=3.8, build_hdf5=hdf5-1_12_0
 
+      - id: output_tag
+        run: echo $DOCKER_IMAGE_TAG >> $GITHUB_OUTPUT
+
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
   BuildTest:
@@ -79,10 +84,8 @@ jobs:
             hdf5: _hdf5
       fail-fast: false
 
-
     container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
-
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
     steps:
       - name: setup
         shell: bash -l {0}
@@ -134,7 +137,7 @@ jobs:
           - stage: dagmc
             hdf5: _hdf5
 
-    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}: latest -> stable"
+    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
 
     steps:
       - name: Log in to the Container registry

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -103,6 +103,8 @@ jobs:
           export ADD_FLAG="${ADD_FLAG} "
           echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
 
+      - run: echo ${{ needs.multistage_image_build.outputs.image_tag }}
+
       - name: Checkout repository
         uses: actions/checkout@v3
         

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -38,7 +38,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: github.ref_name == "develop"
+      - if: github.ref_name == 'develop'
         run: |
           echo $DOCKER_IMAGE_TAG
           echo "" >> $DOCKER_IMAGE_TAG

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3
-  DOCKER_IMAGE_TAG: :refs_heads_${{ GITHUB_REF_NAME }}-bk0
+  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -68,8 +68,8 @@ jobs:
 
       - id: output_tag
         run: |
-          echo $env.DOCKER_IMAGE_TAG >> $github.output
-          echo $env.DOCKER_IMAGE_TAG
+          echo "$env.DOCKER_IMAGE_TAG" >> "$github.output"
+          echo "$env.DOCKER_IMAGE_TAG"
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
@@ -105,7 +105,7 @@ jobs:
           export ADD_FLAG="${ADD_FLAG} "
           echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
 
-      - run: echo $needs.multistage_image_build.outputs.image_tag
+      - run: echo "$needs.multistage_image_build.outputs.image_tag"
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3
+  DOCKER_IMAGE_TAG: :refs_heads_${{ GITHUB_REF_NAME }}-bk0
 
 jobs:
 
@@ -35,6 +36,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - if: GITHUB_REF_NAME == "develop"
+        run: |
+          echo $DOCKER_IMAGE_TAG
+          echo "" >> $DOCKER_IMAGE_TAG
+          echo $DOCKER_IMAGE_TAG
+
       # build base python, moab, dagmc, openmc using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
         with:
@@ -42,6 +49,7 @@ jobs:
           stages: base_python, moab, dagmc
           server-stage: openmc
           quiet: false
+          tag-latest-on-default: false
           dockerfile: docker/ubuntu_20.04-dev.dockerfile
           build-args: py_version=3.8
 
@@ -52,6 +60,7 @@ jobs:
           stages: base_python, moab
           server-stage: dagmc
           quiet: false
+          tag-latest-on-default: false
           dockerfile: docker/ubuntu_20.04-dev.dockerfile
           build-args: py_version=3.8, build_hdf5=hdf5-1_12_0
 
@@ -72,7 +81,7 @@ jobs:
 
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:refs_heads_multistage-docker-bk0
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
 
     steps:
       - name: setup
@@ -125,7 +134,7 @@ jobs:
           - stage: dagmc
             hdf5: _hdf5
 
-    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:refs_heads_multistage-docker-bk0: latest -> stable"
+    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}: latest -> stable"
 
     steps:
       - name: Log in to the Container registry
@@ -138,11 +147,11 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:refs_heads_multistage-docker-bk0
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
       - name: Push Image to latest img
         uses: akhilerm/tag-push-action@v2
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:refs_heads_multistage-docker-bk0
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -67,7 +67,7 @@ jobs:
           build-args: py_version=3.8, build_hdf5=hdf5-1_12_0
 
       - id: output_tag
-        run: echo $DOCKER_IMAGE_TAG >> $GITHUB_OUTPUT
+        run: echo $DOCKER_IMAGE_TAG >> $github.output
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -38,7 +38,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo $env.DOCKER_IMAGE_TAG
+      - run: echo $DOCKER_IMAGE_TAG
 
       - if: github.ref_name == 'develop'
         run: |
@@ -69,8 +69,8 @@ jobs:
 
       - id: output_tag
         run: |
-          echo "test=$env.DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "$env.DOCKER_IMAGE_TAG"
+          echo "test=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "$DOCKER_IMAGE_TAG"
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Next Version
 ============
 
 **Fix**
-   * fix image tag issue with different branches caused by #1470 (#1471)
+   * fix BuildTest job not finding images problem caused by #1470 (#1471)
    * use multistage docker build action in docker_publish.yml(#1470)
    * remove setup-QEMU step from composite action(#1461)
    * add composite actions to github workflows(#1459)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Version
 ============
 
 **Fix**
+   * fix image tag issue with different branches caused by #1470 (#1471)
    * use multistage docker build action in docker_publish.yml(#1470)
    * remove setup-QEMU step from composite action(#1461)
    * add composite actions to github workflows(#1459)

--- a/docker/ubuntu_20.04-dev.dockerfile
+++ b/docker/ubuntu_20.04-dev.dockerfile
@@ -128,8 +128,19 @@ RUN cd /root \
     && cd ../.. \
     && rm -rf DAGMC
 
+FROM dagmc AS openmc
+ARG build_hdf5
+# build/install OpenMC Python API
+RUN if [ "$build_hdf5" != "NO" ]; then \
+            export HDF5_ROOT="$HDF5_INSTALL_PATH" ; \
+    fi ;\
+    git clone https://github.com/openmc-dev/openmc.git $HOME/opt/openmc \
+    && cd  $HOME/opt/openmc \
+    && git checkout tags/v0.13.0 \
+    && pip install . 
+
 # Build/Install PyNE
-FROM dagmc AS pyne
+FROM openmc AS pyne
 ARG build_hdf5
 
 RUN export PYNE_HDF5_ARGS="" ;\
@@ -148,15 +159,3 @@ RUN if [ "$build_pyne" = "YES" ]; then \
         cd $HOME \
         && nuc_data_make ; \
     fi
-
-FROM dagmc AS openmc
-ARG build_hdf5
-# build/install OpenMC Python API
-RUN if [ "$build_hdf5" != "NO" ]; then \
-            export HDF5_ROOT="$HDF5_INSTALL_PATH" ; \
-    fi ;\
-    git clone https://github.com/openmc-dev/openmc.git $HOME/opt/openmc \
-    && cd  $HOME/opt/openmc \
-    && git checkout tags/v0.13.0 \
-    && pip install . 
-


### PR DESCRIPTION
## Description
- added an env variable that stores the tag of the docker image to be built by the multistage build action. This tag is based off the current branch's name
- added an if statement to set the env variable to "" if the branch is `develop`, the default branch
- added an output to the first job to send this env variable to the `BuildTest` job so it can use it to pull the correct image. (this is because you can't use env variables in the `image:` declaration of a job)
- made the multistage build actions NOT tag latest on the default branch (this is because in the `pushing_test_stable_img` job, we push the built images to other images with `latest` tags, so having the `latest` tag on the image when it's built would cause naming conflicts)
- switched the order of the pyne and openmc stage in `docker_publish.yml`
- made the pyne stage be based off the openmc stage

## Motivation and Context
Pull request #1470 was merged, but the Build Tests weren't able to run because they couldn't find the docker images. 

In the workflow file, the image names to be searched for have a tag of `refs_heads_multistage-docker-bk0`. This worked on the `multistage-docker` branch because the multistage build action applies a tag with the branch's name to the docker images it builds when the workflow is run on a branch that is not on the default branch of a repository. However, when the multistage build action is run on the default branch (in this case, `develop`), it tags the docker images with `latest` or nothing if the `tag-latest-on-default` option is made false. 

## Changes
This PR is a bug fix to allow the Build Tests to run properly in the main repository on the default `develop` branch. 

## Behavior
What is the current behavior? What is the new behavior?
The current behavior is that the Build Tests don't run at all because they can't find the correct images. The new expected behavior is that in non-default branches, the workflow will use images tagged with the branch name, and in the default branch `develop`, it will use images tagged with `latest` or nothing. 

However, the code in this PR currently isn't working as intended because the Build Tests are using the images tagged with latest and not tagged with the branch name, which means they aren't testing on the newly built images (newly built images are tagged with the branch name). 

The error has something to do with the fact that I'm not using `echo` correctly or I'm not referencing the env variables correctly to transfer the env variable for the tag to the `BuildTest` job via the output system from Github Actions. 