### PR TITLE
Specify version for tag-push-action

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -143,13 +143,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image to stable img
-        uses: akhilerm/tag-push-action@v2
+        uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
       - name: Push Image to latest img
-        uses: akhilerm/tag-push-action@v2
+        uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Version
 ============
 
 **Fix**
+   * specify version of akhilerm/tag-push-action to be v2.1.0 so the pushing_test_stable_img job can run(#1473)
    * fix BuildTest job not finding images problem caused by #1470 (#1471)
    * use multistage docker build action in docker_publish.yml(#1470)
    * remove setup-QEMU step from composite action(#1461)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,7 @@ Next Version
 ============
 
 **Fix**
-   * specify version of akhilerm/tag-push-action to be v2.1.0 so the pushing_test_stable_img job can run(#1473)
-   * fix BuildTest job not finding images problem caused by #1470 (#1471)
-   * use multistage docker build action in docker_publish.yml(#1470)
+   * use multistage docker build action in docker_publish.yml(#1470 #1471 #1473)
    * remove setup-QEMU step from composite action(#1461)
    * add composite actions to github workflows(#1459)
    * fixing typos in user warning message (#1456)


### PR DESCRIPTION
## Description
I specified the version of the `akhilerm/tag-push-action` in the `pushing_test_stable_img` job to be `v2.1.0` instead of just `v2`.

## Motivation and Context
When the #1471 was merged, the [workflow](https://github.com/pyne/pyne/actions/runs/4151686671/jobs/7182330432) ran into errors in the `pushing_test_stable_img` job because it couldn't find `v2` of the `akhilerm/tag-push-action`. 

## Changes
This PR is a small bug fix that will allow the last job of the workflow to run.

## Behavior
Current behavior is that the workflow runs into errors in the `pushing_test_stable_img` job with finding the version of the marketplace action. The new behavior should be that the job can find the action. (However, there is no way to test this before merging because the `pushing_test_stable_img` job only runs if the repository owner is `pyne`)

## Other Information
The action used to be specified with version `v2.0.0`, and it was changed to be `v2` in #1470. 