### PR TITLE
Update build_test.yml to use new images

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,57 +26,35 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pymoab : [
-          _pymoab,
-          ]
-        dagmc : [
-          '',
-          _dagmc
-        ]
-        openmc : [
-          '',
-        ]
-        hdf5 : [
-          '',
-        ]
+        stage: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
         include:
-          - openmc: ''
-            hdf5: _hdf5-1_12_0
-            dagmc: _dagmc
-            pymoab: _pymoab
-          - openmc: _openmc
-            hdf5: ''
-            dagmc: _dagmc
-            pymoab: _pymoab
-          - openmc: ''
-            hdf5: ''
-            dagmc: ''
-            pymoab: ''
+          - stage: dagmc
+            hdf5: _hdf5
       fail-fast: false
 
-
     container:
-      image: ghcr.io/pyne/ubuntu_20.04_py3${{ matrix.hdf5 }}${{ matrix.dagmc }}${{ matrix.pymoab }}${{ matrix.openmc }}_pyne-deps:stable
+      image: ghcr.io/pyne/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: setup
         shell: bash -l {0}
         run: |
           export ADD_FLAG=" "
-          if [[ "${{ matrix.pymoab }}" == "_pymoab" || "${{ matrix.dagmc }}" == "_dagmc" ]]; then
+          if [[ "${{ matrix.stage }}" == "moab" || "${{ matrix.stage }}" == "dagmc" ]]; then
             export ADD_FLAG="${ADD_FLAG} --moab /root/opt/moab"
           fi
-          if [[ "${{ matrix.dagmc }}" == "_dagmc" ]]; then
+          if [[ "${{ matrix.stage }}" == "dagmc" ]]; then
             export ADD_FLAG="${ADD_FLAG} --dagmc /root/opt/dagmc"
           fi
-          if [[ "${{ matrix.hdf5 }}" == "_hdf5-1_12_0" ]]; then
+          if [[ "${{ matrix.hdf5 }}" == "_hdf5" ]]; then
             export ADD_FLAG="${ADD_FLAG} --hdf5 /root/opt/hdf5/hdf5-1_12_0"
           fi
           export ADD_FLAG="${ADD_FLAG} "
           echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Building PyNE
         shell: bash -l {0}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Next Version
 ============
 
 **Fix**
-   * use multistage docker build action in docker_publish.yml(#1470 #1471 #1473)
+   * use multistage docker build action in docker_publish.yml(#1470 #1471 #1473 #1475)
    * remove setup-QEMU step from composite action(#1461)
    * add composite actions to github workflows(#1459)
    * fixing typos in user warning message (#1456)


### PR DESCRIPTION
## Description
I updated `build_test.yml` to use the new images we build from `docker_publish.yml`. I also changed the `matrix` and the if statements in `build_test.yml` to match the use of the new images.

## Motivation and Context
Requested in #1474. This is a next step after modifying `docker_publish.yml` to build new images using the multistage docker build action. 

## Changes
This is a small update to make sure the workflows that build and test images are testing the ones we most recently built. 

## Behavior
Old behavior was that `build_test.yml` was testing the images built by the pre #1470 `docker_publish.yml` workflow. New behavior is that it tests the images built by the new `docker_publish.yml` workflow. 

## Additional Information
I put this PR under the same entry as #1470, #1471, #1473 in `CHANGELOG.rst` since it seemed like another part of updating the workflows to use the multistage docker build action. 