### PR TITLE
Move installation script to main repo

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -105,12 +105,11 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           python setup.py install --user --clean ${{ env.ADD_FLAG}}
-          export PATH="/root/opt"
-          export PYTHONPATH="/root/opt/moab/lib/python3.10/site-packages/"
+          export PATH="$PATH:/github/home/.local/bin"
+          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
           cd ../
           nuc_data_make
-      # export PATH="$PATH:/github/home/.local/bin"
-      # export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
+
       - name: Testing PyNE
         shell: bash -l {0}
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/docker_publish.yml'
 
 env:
-  DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3
+  DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
           server-stage: openmc
           quiet: false
           tag-latest-on-default: false
-          dockerfile: docker/ubuntu_20.04-dev.dockerfile
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: py_version=3.8
 
       # build HDF5 using multistage docker build action 
@@ -57,7 +57,7 @@ jobs:
           server-stage: dagmc
           quiet: false
           tag-latest-on-default: false
-          dockerfile: docker/ubuntu_20.04-dev.dockerfile
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: py_version=3.8, build_hdf5=hdf5-1_12_0
 
       - id: output_tag

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -115,7 +115,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/tests
-          ./travis-run-tests.sh python3
+          ./ci-run-tests.sh python3
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -47,7 +47,6 @@ jobs:
           quiet: false
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: py_version=3.8
 
       # build HDF5 using multistage docker build action 
       - uses: firehed/multistage-docker-build-action@v1
@@ -58,7 +57,7 @@ jobs:
           quiet: false
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: py_version=3.8, build_hdf5=hdf5-1_12_0
+          build-args: build_hdf5=hdf5-1_12_0
 
       - id: output_tag
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -40,6 +40,7 @@ jobs:
 
       # build base python, moab, dagmc, openmc using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
+        id: build1
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}
           stages: base_python, moab, dagmc
@@ -50,6 +51,7 @@ jobs:
 
       # build HDF5 using multistage docker build action 
       - uses: firehed/multistage-docker-build-action@v1
+        id: build2
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}_hdf5
           stages: base_python, moab
@@ -58,6 +60,11 @@ jobs:
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_hdf5=hdf5-1_12_0
+
+      # print out server-tags
+      - run: |
+          echo ${{ steps.build1.outputs.server-tag }}
+          echo ${{ steps.build2.outputs.server-tag }}
 
       - id: output_tag
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         ubuntu_versions : [
-          20.04,
+          22.04,
         ]
     outputs:
       image_tag: ${{ steps.output_tag.outputs.image_tag }}
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
     steps:
       - name: setup
         shell: bash -l {0}
@@ -132,7 +132,7 @@ jobs:
           - stage: dagmc
             hdf5: _hdf5
 
-    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
+    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
 
     steps:
       - name: Log in to the Container registry

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -106,7 +106,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           python setup.py install --user --clean ${{ env.ADD_FLAG}}
           export PATH="$PATH:/github/home/.local/bin"
-          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.8/site-packages/"
+          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
           cd ../
           nuc_data_make
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -105,10 +105,11 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           python setup.py install --user --clean ${{ env.ADD_FLAG}}
-          export PATH="$PATH:/github/home/.local/bin"
+          export PATH="/root/opt"
           export PYTHONPATH="/root/opt/moab/lib/python3.10/site-packages/"
           cd ../
           nuc_data_make
+      # export PATH="$PATH:/github/home/.local/bin"
       # export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
       - name: Testing PyNE
         shell: bash -l {0}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -106,10 +106,10 @@ jobs:
           cd $GITHUB_WORKSPACE
           python setup.py install --user --clean ${{ env.ADD_FLAG}}
           export PATH="$PATH:/github/home/.local/bin"
-          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
+          export PYTHONPATH="/root/opt/moab/lib/python3.10/site-packages/"
           cd ../
           nuc_data_make
-
+      # export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
       - name: Testing PyNE
         shell: bash -l {0}
         run: |

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -1,0 +1,20 @@
+name: run install script
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  push:
+    paths:
+      - 'scripts/ubuntu.sh'
+      - '.github/workflows/docker_publish.yml'
+
+jobs:
+  run_install_script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: run install script
+        shell: bash -l {0}
+        run: |
+          cd $GITHUB_WORKSPACE/scripts
+          chmod +x ubuntu.sh
+          ./ubuntu.sh

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -4,18 +4,20 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   push:
-    # paths:
-    #   - 'scripts/ubuntu.sh'
-    #   - '.github/workflows/docker_publish.yml'
+    paths:
+      - 'scripts/ubuntu.sh'
+      - '.github/workflows/docker_publish.yml'
 
 jobs:
   run_install_script:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: run install script
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/scripts
           chmod +x ubuntu.sh
           ./ubuntu.sh
-# comment to trigger workflow run

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   run_install_script:
-  runs-on: ubuntu-latest
-  strategy: 
-    matrix:
-      branch: ['develop', 'stable'] # 'develop' can be anything that's not 'stable'. This triggers an if statement in ubuntu.sh
+    runs-on: ubuntu-latest
+    strategy: 
+      matrix:
+        branch: ['develop', 'stable'] # 'develop' can be anything that's not 'stable'. This triggers an if statement in ubuntu.sh
       
     steps:
       - name: Checkout repository

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/scripts
           chmod +x ubuntu.sh
-          ./ubuntu.sh ${{ matrix.branch }} ${{ build_hdf5 }}
+          ./ubuntu.sh ${{ matrix.branch }} ${{ matrix.build_hdf5 }}
 
       # use matrix to have 2 jobs [develop, stable]
       # ./ubuntu.sh stable

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -10,6 +10,11 @@ on:
 
 jobs:
   run_install_script:
+  strategy: 
+    matrix:
+      branch: ['develop', 'stable'] # 'develop' can be anything that's not 'stable'
+                                    # this triggers an if statement in ubuntu.sh
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -20,4 +25,8 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/scripts
           chmod +x ubuntu.sh
-          ./ubuntu.sh
+          ./ubuntu.sh ${{ matrix.branch }}
+
+      # use matrix to have 2 jobs [develop, stable]
+      # ./ubuntu.sh stable
+

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -10,12 +10,11 @@ on:
 
 jobs:
   run_install_script:
+  runs-on: ubuntu-latest
   strategy: 
     matrix:
-      branch: ['develop', 'stable'] # 'develop' can be anything that's not 'stable'
-                                    # this triggers an if statement in ubuntu.sh
-
-    runs-on: ubuntu-latest
+      branch: ['develop', 'stable'] # 'develop' can be anything that's not 'stable'. This triggers an if statement in ubuntu.sh
+      
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -4,9 +4,9 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   push:
-    paths:
-      - 'scripts/ubuntu.sh'
-      - '.github/workflows/docker_publish.yml'
+    # paths:
+    #   - 'scripts/ubuntu.sh'
+    #   - '.github/workflows/docker_publish.yml'
 
 jobs:
   run_install_script:

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -6,7 +6,7 @@ on:
   push:
     paths:
       - 'scripts/ubuntu.sh'
-      - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/install_script.yml'
 
 jobs:
   run_install_script:

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -18,3 +18,4 @@ jobs:
           cd $GITHUB_WORKSPACE/scripts
           chmod +x ubuntu.sh
           ./ubuntu.sh
+# comment to trigger workflow run

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -14,7 +14,7 @@ jobs:
     strategy: 
       matrix:
         branch: ['develop', 'stable'] # 'develop' can be anything that's not 'stable'. This triggers an if statement in ubuntu.sh
-      
+        build_hdf5: ['NO', 'hdf5-1_12_0']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/scripts
           chmod +x ubuntu.sh
-          ./ubuntu.sh ${{ matrix.branch }}
+          ./ubuntu.sh ${{ matrix.branch }} ${{ build_hdf5 }}
 
       # use matrix to have 2 jobs [develop, stable]
       # ./ubuntu.sh stable

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Next Version
    * move tests from nose to pytest (#1478)
 
 **Fix**
+   * move install script to main repo(#1477)
    * use multistage docker build action in docker_publish.yml(#1470 #1471 #1473 #1475)
    * remove setup-QEMU step from composite action(#1461)
    * add composite actions to github workflows(#1459)

--- a/docker/ubuntu_20.04-dev.dockerfile
+++ b/docker/ubuntu_20.04-dev.dockerfile
@@ -9,10 +9,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ARG py_version
 
 ENV HOME /root
-RUN if [ "${py_version%.?}" -eq 3 ] ; \
-    then \ 
-            export PY_SUFIX=${py_version%.?}; \
-    fi;\
+RUN export PY_SUFIX=${py_version%.?}; \
     apt-get update \
     && apt-get install -y --fix-missing \
             software-properties-common \
@@ -28,11 +25,8 @@ RUN if [ "${py_version%.?}" -eq 3 ] ; \
             libhdf5-dev \
             hdf5-tools \
     && apt-get clean -y; \
-    if [ "${py_version%.?}" -eq 3 ] ; \
-       then \ 
-            update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
-            update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
-    fi;\
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,7 +1,7 @@
 ARG py_version=3.8
 ARG build_hdf5="NO"
 
-FROM ubuntu:20.04 AS base_python
+FROM ubuntu:22.04 AS base_python
 
 # Ubuntu Setup
 ENV TZ=America/Chicago

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -100,7 +100,7 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
 # put MOAB on the path
 ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
-ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/
+# ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/
 
 FROM moab AS dagmc
 # build/install DAGMC

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -69,7 +69,7 @@ ENV INSTALL_PATH=$HOME/opt/moab
 RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
     echo $PYMOAB_FLAG ;\
     export MOAB_HDF5_ARGS=""; \
-    if [ "$build_hdf5" != "NO" ] ; \ 
+    if [ "$build_hdf5" != "NO" ] ; \
     then \
             export MOAB_HDF5_ARGS="-DHDF5_ROOT=$HDF5_INSTALL_PATH"; \
     fi \
@@ -90,6 +90,9 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
             -DENABLE_BLASLAPACK=OFF \
             -DENABLE_FORTRAN=OFF \
     && make -j 3 \
+    && cd pymoab \
+    && pip install . --user \
+    && cd ..
     && make install \
     && cd .. \
     && rm -rf moab ;
@@ -129,7 +132,7 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
     git clone https://github.com/openmc-dev/openmc.git $HOME/opt/openmc \
     && cd  $HOME/opt/openmc \
     && git checkout tags/v0.13.0 \
-    && pip install . 
+    && pip install .
 
 # Build/Install PyNE
 FROM openmc AS pyne
@@ -145,7 +148,7 @@ RUN export PYNE_HDF5_ARGS="" ;\
     && python setup.py install --user \
                                 --moab $HOME/opt/moab --dagmc $HOME/opt/dagmc \
                                 $PYNE_HDF5_ARGS \
-                                --clean -j 3; 
+                                --clean -j 3;
 ENV PATH $HOME/.local/bin:$PATH
 RUN if [ "$build_pyne" = "YES" ]; then \
         cd $HOME \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -92,7 +92,7 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
     && make -j 3 \
     && cd pymoab \
     && pip install . --user \
-    && cd ..
+    && cd .. \
     && make install \
     && cd .. \
     && rm -rf moab ;

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -10,11 +10,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ARG py_version
 
 ENV HOME /root
-RUN export PY_SUFIX=${py_version%.?}; \
-    apt-get update \
+RUN apt-get update \
     && apt-get install -y --fix-missing \
             software-properties-common \
-            python${PY_SUFIX}-pip \
+            python3-pip \
             wget \
             build-essential \
             git \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -98,7 +98,7 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
 # put MOAB on the path
 ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
-ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/
+ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/:$PYTHONPATH
 
 FROM moab AS dagmc
 # build/install DAGMC

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,7 +1,8 @@
 ARG py_version=3.8
 ARG build_hdf5="NO"
+ARG ubuntu_version=22.04
 
-FROM ubuntu:22.04 AS base_python
+FROM ubuntu:${ubuntu_version} AS base_python
 
 # Ubuntu Setup
 ENV TZ=America/Chicago

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -69,7 +69,7 @@ ENV INSTALL_PATH=$HOME/opt/moab
 RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
     echo $PYMOAB_FLAG ;\
     export MOAB_HDF5_ARGS=""; \
-    if [ "$build_hdf5" != "NO" ] ; \ 
+    if [ "$build_hdf5" != "NO" ] ; \
     then \
             export MOAB_HDF5_ARGS="-DHDF5_ROOT=$HDF5_INSTALL_PATH"; \
     fi \
@@ -90,6 +90,9 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
             -DENABLE_BLASLAPACK=OFF \
             -DENABLE_FORTRAN=OFF \
     && make -j 3 \
+    && cd pymoab \
+    && pip install . \
+    && cd .. \
     && make install \
     && cd .. \
     && rm -rf moab ;
@@ -129,7 +132,7 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
     git clone https://github.com/openmc-dev/openmc.git $HOME/opt/openmc \
     && cd  $HOME/opt/openmc \
     && git checkout tags/v0.13.0 \
-    && pip install . 
+    && pip install .
 
 # Build/Install PyNE
 FROM openmc AS pyne
@@ -145,7 +148,7 @@ RUN export PYNE_HDF5_ARGS="" ;\
     && python setup.py install --user \
                                 --moab $HOME/opt/moab --dagmc $HOME/opt/dagmc \
                                 $PYNE_HDF5_ARGS \
-                                --clean -j 3; 
+                                --clean -j 3;
 ENV PATH $HOME/.local/bin:$PATH
 RUN if [ "$build_pyne" = "YES" ]; then \
         cd $HOME \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,4 +1,3 @@
-ARG py_version=3.8
 ARG build_hdf5="NO"
 ARG ubuntu_version=22.04
 
@@ -7,7 +6,6 @@ FROM ubuntu:${ubuntu_version} AS base_python
 # Ubuntu Setup
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-ARG py_version
 
 ENV HOME /root
 RUN apt-get update \
@@ -63,7 +61,6 @@ ENV LD_LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LIBRARY_PATH
 
 FROM base_python AS moab
-ARG py_version
 ARG build_hdf5
 ENV INSTALL_PATH=$HOME/opt/moab
 
@@ -99,7 +96,7 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
 # put MOAB on the path
 ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
-ENV PYTHONPATH=$HOME/opt/moab/lib/python${py_version}/site-packages/
+ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/
 
 FROM moab AS dagmc
 # build/install DAGMC

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -83,12 +83,13 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
     && ls ..\
     # build/install shared lib
     && cmake .. \
-            ${PYMOAB_FLAG} \
+            -DENABLE_PYMOAB=ON \
             -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
             -DENABLE_HDF5=ON $MOAB_HDF5_ARGS \
             -DBUILD_SHARED_LIBS=ON \
             -DENABLE_BLASLAPACK=OFF \
             -DENABLE_FORTRAN=OFF \
+    && echo ${PYMOAB_FLAG} \
     && make -j 3 \
     && make install \
     && cd .. \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -83,13 +83,12 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
     && ls ..\
     # build/install shared lib
     && cmake .. \
-            -DENABLE_PYMOAB=ON \
+            ${PYMOAB_FLAG} \
             -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
             -DENABLE_HDF5=ON $MOAB_HDF5_ARGS \
             -DBUILD_SHARED_LIBS=ON \
             -DENABLE_BLASLAPACK=OFF \
             -DENABLE_FORTRAN=OFF \
-    && echo ${PYMOAB_FLAG} \
     && make -j 3 \
     && make install \
     && cd .. \
@@ -98,7 +97,7 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
 # put MOAB on the path
 ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
-ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/:$PYTHONPATH
+ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/
 
 FROM moab AS dagmc
 # build/install DAGMC

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
             scipy \
             cython \
             nose \
+            pytest \
             tables \
             matplotlib \
             jinja2 \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -66,9 +66,7 @@ ARG build_hdf5
 ENV INSTALL_PATH=$HOME/opt/moab
 
 # build MOAB
-RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
-    echo $PYMOAB_FLAG ;\
-    export MOAB_HDF5_ARGS=""; \
+RUN export MOAB_HDF5_ARGS=""; \
     if [ "$build_hdf5" != "NO" ] ; \
     then \
             export MOAB_HDF5_ARGS="-DHDF5_ROOT=$HDF5_INSTALL_PATH"; \
@@ -83,7 +81,7 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
     && ls ..\
     # build/install shared lib
     && cmake .. \
-            ${PYMOAB_FLAG} \
+            -DENABLE_PYMOAB=ON \
             -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH \
             -DENABLE_HDF5=ON $MOAB_HDF5_ARGS \
             -DBUILD_SHARED_LIBS=ON \
@@ -100,7 +98,6 @@ RUN export PYMOAB_FLAG="-DENABLE_PYMOAB=ON"; \
 # put MOAB on the path
 ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
-# ENV PYTHONPATH=$HOME/opt/moab/lib/python3.10/site-packages/
 
 FROM moab AS dagmc
 # build/install DAGMC

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -29,10 +29,6 @@ pip_package_list="numpy==1.23 \
                   future \
                   progress"
 
-
-# hdf5 std directory
-hdf5_libdir=/usr/lib/x86_64-linux-gnu/hdf5/serial
-
 # function to check if build folder already exists
 function check_repo() {
 
@@ -59,6 +55,9 @@ pip3 install ${pip_package_list}
 install_dir=${HOME}/opt
 mkdir -p ${install_dir}
 
+# hdf5 std directory
+hdf5_libdir=$HOME/opt/hdf5/$build_hdf5
+
 # need to put libhdf5.so on LD_LIBRARY_PATH (Making sure that LD_LIBRARY_PATH is defined first)
 if [ -z $LD_LIBRARY_PATH ]; then
   export LD_LIBRARY_PATH="${hdf5_libdir}"
@@ -77,20 +76,22 @@ mkdir -p moab
 cd moab
 
 # clone and version
-git clone --depth 1 --single-branch -b 5.3.0 https://bitbucket.org/fathomteam/moab 
+git clone --depth 1 --single-branch -b 5.3.0 https://bitbucket.org/fathomteam/moab moab-repo
 cd moab-repo
 mkdir -p build
 cd build
 
 # cmake, build and install
-cmake ../ -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_libdir} \
+cmake ../ -DENABLE_PYMOAB=ON \
+          -DCMAKE_INSTALL_PREFIX=${install_dir}/moab \
+          -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_libdir} \
           -DBUILD_SHARED_LIBS=ON \
-          -DENABLE_PYMOAB=ON \
           -DENABLE_BLASLAPACK=OFF \
-          -DENABLE_FORTRAN=OFF \
-          -DCMAKE_INSTALL_PREFIX=${install_dir}/moab
-make
+          -DENABLE_FORTRAN=OFF    
+make -j 3 
 make install
+cd ..
+rm -rf moab-repo
 
 # Adding MOAB/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
 export LD_LIBRARY_PATH="${install_dir}/moab/lib:$LD_LIBRARY_PATH"
@@ -114,7 +115,7 @@ mkdir -p dagmc
 cd dagmc
 
 # clone and version
-git clone https://github.com/svalinn/DAGMC.git dagmc-repo
+git clone --depth 1 --branch stable https://github.com/svalinn/DAGMC.git dagmc-repo
 cd dagmc-repo
 git checkout develop
 mkdir build
@@ -122,10 +123,17 @@ cd build
 
 # cmake, build and install
 cmake .. -DMOAB_DIR=${install_dir}/moab \
+         -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
          -DBUILD_STATIC_LIBS=OFF \
-         -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc
-make
+         -DBUILD_UWUW=OFF \
+         -DBUILD_TALLY=OFF \
+         -DBUILD_MAKE_WATERTIGHT=OFF \
+         -DBUILD_OVERLAP_CHECK=OFF \
+         -DBUILD_TESTS=OFF 
+make -j 3
 make install
+cd ../..
+rm -rf dagmc-repo
 
 # Adding DAGMC/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
 export LD_LIBRARY_PATH="${install_dir}/dagmc/lib:$LD_LIBRARY_PATH"
@@ -140,7 +148,7 @@ export PATH="${install_dir}/dagmc/bin:$PATH"
 cd ${install_dir}
 git clone https://github.com/openmc-dev/openmc.git
 cd openmc
-git checkout develop
+git checkout tags/v0.13.0
 mkdir bld
 cd bld
 cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local
@@ -154,12 +162,13 @@ pip3 install .
 ############
 
 # pre-setup
+export PYNE_HDF5_ARGS="--hdf5 ${hdf5_libdir}"
 cd ${install_dir}
 check_repo pyne
 mkdir -p pyne
 cd pyne
 # clone and version
-git clone https://github.com/pyne/pyne.git pyne-repo
+git clone -b develop --single-branch https://github.com/pyne/pyne.git pyne-repo
 cd pyne-repo
 if [ $1 == 'stable' ] ; then
   TAG=$(git describe --abbrev=0 --tags)
@@ -169,7 +178,8 @@ fi
 python setup.py install --user \
                         --moab ${install_dir}/moab \
                         --dagmc ${install_dir}/dagmc \
-                        --clean
+                        ${PYNE_HDF5_ARGS} \
+                        --clean -j 3
 
 # Adding .local/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
 export LD_LIBRARY_PATH="${HOME}/.local/lib:$LD_LIBRARY_PATH"

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+TZ=America/Chicago
+ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# list of package installed through apt-get 
+# (required to run this scripts and/or as dependancies for PyNE and its depedancies)
+apt_package_list="software-properties-common \
+                  python3-pip \
+                  wget \
+                  build-essential \
+                  git \
+                  cmake \
+                  gfortran \
+                  libblas-dev \
+                  liblapack-dev \
+                  libeigen3-dev \
+                  libhdf5-dev \
+                  hdf5-tools"
+
+# list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
+pip_package_list="numpy==1.23 \
+                  scipy \
+                  cython \
+                  nose \
+                  tables \
+                  matplotlib \
+                  jinja2 \
+                  setuptools \
+                  future \
+                  progress"
+
+
+# hdf5 std directory
+hdf5_libdir=/usr/lib/x86_64-linux-gnu/hdf5/serial
+
+# function to check if build folder already exists
+function check_repo() {
+
+    repo_name=$1
+
+    if [ -d ${repo_name} ] ; then
+        read -p "Delete the existing ${repo_name} directory and all contents? (y/n) " -n 1 -r
+        if [[ $REPLY =~ ^[Yy]$ ]] ; then
+            rm -rf ${repo_name}
+        fi
+    fi
+
+}
+
+# system update
+sudo apt-get -y update
+sudo apt-get install -y --fix-missing ${apt_package_list}
+apt-get clean -y;
+update-alternatives --install /usr/bin/python python /usr/bin/python3 10;
+update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
+pip install --upgrade pip;
+pip3 install ${pip_package_list}
+
+install_dir=${HOME}/opt
+mkdir -p ${install_dir}
+
+# need to put libhdf5.so on LD_LIBRARY_PATH (Making sure that LD_LIBRARY_PATH is defined first)
+if [ -z $LD_LIBRARY_PATH ]; then
+  export LD_LIBRARY_PATH="${hdf5_libdir}"
+else
+  export LD_LIBRARY_PATH="${hdf5_libdir}:$LD_LIBRARY_PATH"
+fi
+
+
+############
+### MOAB ###
+############
+# pre-setup
+cd ${install_dir}
+check_repo moab
+mkdir -p moab
+cd moab
+
+# clone and version
+git clone --depth 1 --single-branch -b 5.3.0 https://bitbucket.org/fathomteam/moab 
+cd moab-repo
+mkdir -p build
+cd build
+
+# cmake, build and install
+cmake ../ -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_libdir} \
+          -DBUILD_SHARED_LIBS=ON \
+          -DENABLE_PYMOAB=ON \
+          -DENABLE_BLASLAPACK=OFF \
+          -DENABLE_FORTRAN=OFF \
+          -DCMAKE_INSTALL_PREFIX=${install_dir}/moab
+make
+make install
+
+# Adding MOAB/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
+export LD_LIBRARY_PATH="${install_dir}/moab/lib:$LD_LIBRARY_PATH"
+
+# Adding pymoab to $PYTHONPATH
+PYTHON_VERSION=$(python -c 'import sys; print(sys.version.split('')[0][0:3])')
+if [ -z $PYTHONPATH ]; then
+  export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages"
+else
+  export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH"
+fi
+
+
+#############
+### DAGMC ###
+#############
+# pre-setup check that the directory we need are in place
+cd ${install_dir}
+check_repo dagmc
+mkdir -p dagmc
+cd dagmc
+
+# clone and version
+git clone https://github.com/svalinn/DAGMC.git dagmc-repo
+cd dagmc-repo
+git checkout develop
+mkdir build
+cd build
+
+# cmake, build and install
+cmake .. -DMOAB_DIR=${install_dir}/moab \
+         -DBUILD_STATIC_LIBS=OFF \
+         -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc
+make
+make install
+
+# Adding DAGMC/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
+export LD_LIBRARY_PATH="${install_dir}/dagmc/lib:$LD_LIBRARY_PATH"
+
+# Adding dagmc/bin to $PATH
+export PATH="${install_dir}/dagmc/bin:$PATH"
+
+####################
+### OpenMC API #####
+####################
+
+cd ${install_dir}
+git clone https://github.com/openmc-dev/openmc.git
+cd openmc
+git checkout develop
+mkdir bld
+cd bld
+cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local
+make
+make install
+cd ..
+pip3 install .
+
+############
+### PyNE ###
+############
+
+# pre-setup
+cd ${install_dir}
+check_repo pyne
+mkdir -p pyne
+cd pyne
+# clone and version
+git clone https://github.com/pyne/pyne.git pyne-repo
+cd pyne-repo
+if [ $1 == 'stable' ] ; then
+  TAG=$(git describe --abbrev=0 --tags)
+  git checkout tags/`echo ${TAG}` -b `echo ${TAG}`
+fi
+
+python setup.py install --user \
+                        --moab ${install_dir}/moab \
+                        --dagmc ${install_dir}/dagmc \
+                        --clean
+
+# Adding .local/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
+export LD_LIBRARY_PATH="${HOME}/.local/lib:$LD_LIBRARY_PATH"
+# Adding .local//bin to $PATH
+export PATH="${HOME}/.local/bin:$PATH"
+
+# Make Pyne Nuclear Data
+cd  # cd without argument will take you back to your $HOME directory
+nuc_data_make
+
+# Run tests
+cd ${install_dir}/pyne/pyne-repo/tests
+./travis-run-tests.sh
+
+
+echo " \
+# Add HDF5 
+if [ -z \$LD_LIBRARY_PATH ]; then 
+  export LD_LIBRARY_PATH=\"${hdf5_libdir}\"
+else 
+  export LD_LIBRARY_PATH=\"${hdf5_libdir}:\$LD_LIBRARY_PATH\" 
+fi 
+# Adding MOAB/lib to \$LD_LIBRARY_PATH and \$LIBRARY_PATH
+export LD_LIBRARY_PATH=\"${install_dir}/moab/lib:\$LD_LIBRARY_PATH\"
+
+# Adding pymoab to \$PYTHONPATH
+PYTHON_VERSION=\$(python -c 'import sys; print(sys.version.split('')[0][0:3])')
+if [ -z \$PYTHONPATH ]; then
+  export PYTHONPATH=\"${install_dir}/moab/lib/python\${PYTHON_VERSION}/site-packages\"
+else
+  export PYTHONPATH=\"${install_dir}/moab/lib/python\${PYTHON_VERSION}/site-packages:\$PYTHONPATH\"
+fi
+
+export LD_LIBRARY_PATH=\"${install_dir}/dagmc/lib:\$LD_LIBRARY_PATH\" 
+# Adding dagmc/bin to \$PATH 
+export PATH=\"${install_dir}/dagmc/bin:\$PATH\" 
+" >> .bashrc
+echo "Run 'source ~/.bashrc' to update environment variables. PyNE may not function correctly without doing so."

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -192,7 +192,7 @@ nuc_data_make
 
 # Run tests
 cd ${install_dir}/pyne/pyne-repo/tests
-./travis-run-tests.sh
+./ci-run-tests.sh
 
 
 echo " \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -100,15 +100,6 @@ rm -rf moab-repo
 # Adding MOAB/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
 export LD_LIBRARY_PATH="${install_dir}/moab/lib:$LD_LIBRARY_PATH"
 
-# # Adding pymoab to $PYTHONPATH
-# PYTHON_VERSION=$(python -c 'import sys; print(sys.version.split('')[0][0:3])')
-# if [ -z $PYTHONPATH ]; then
-#   export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages"
-# else
-#   export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH"
-# fi
-
-
 #############
 ### DAGMC ###
 #############

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -50,7 +50,7 @@ apt-get clean -y;
 update-alternatives --install /usr/bin/python python /usr/bin/python3 10;
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
 pip install --upgrade pip;
-pip3 install ${pip_package_list}
+pip install ${pip_package_list}
 
 install_dir=${HOME}/opt
 mkdir -p ${install_dir}
@@ -149,16 +149,15 @@ export PATH="${install_dir}/dagmc/bin:$PATH"
 ####################
 
 cd ${install_dir}
-git clone https://github.com/openmc-dev/openmc.git
+git clone --depth 1 --branch v0.13.0 https://github.com/openmc-dev/openmc.git
 cd openmc
-git checkout tags/v0.13.0
 mkdir bld
 cd bld
 cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local
 make
 make install
 cd ..
-pip3 install .
+pip install .
 
 ############
 ### PyNE ###

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -22,6 +22,7 @@ pip_package_list="numpy==1.23 \
                   scipy \
                   cython \
                   nose \
+                  pytest \
                   tables \
                   matplotlib \
                   jinja2 \
@@ -99,13 +100,13 @@ rm -rf moab-repo
 # Adding MOAB/lib to $LD_LIBRARY_PATH and $LIBRARY_PATH
 export LD_LIBRARY_PATH="${install_dir}/moab/lib:$LD_LIBRARY_PATH"
 
-# Adding pymoab to $PYTHONPATH
-PYTHON_VERSION=$(python -c 'import sys; print(sys.version.split('')[0][0:3])')
-if [ -z $PYTHONPATH ]; then
-  export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages"
-else
-  export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH"
-fi
+# # Adding pymoab to $PYTHONPATH
+# PYTHON_VERSION=$(python -c 'import sys; print(sys.version.split('')[0][0:3])')
+# if [ -z $PYTHONPATH ]; then
+#   export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages"
+# else
+#   export PYTHONPATH="$install_dir/moab/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPATH"
+# fi
 
 
 #############

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -49,8 +49,8 @@ sudo apt-get install -y --fix-missing ${apt_package_list}
 apt-get clean -y;
 update-alternatives --install /usr/bin/python python /usr/bin/python3 10;
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
-pip install --upgrade pip;
-pip install ${pip_package_list}
+pip install --user --upgrade pip;
+pip install --user ${pip_package_list}
 
 install_dir=${HOME}/opt
 mkdir -p ${install_dir}
@@ -90,7 +90,7 @@ cmake ../ -DENABLE_PYMOAB=ON \
           -DENABLE_FORTRAN=OFF    
 make -j 3 
 cd pymoab
-pip install .
+pip install --user .
 cd ..
 make install
 cd ..
@@ -157,7 +157,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local
 make
 make install
 cd ..
-pip install .
+pip install --user .
 
 ############
 ### PyNE ###

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -89,6 +89,9 @@ cmake ../ -DENABLE_PYMOAB=ON \
           -DENABLE_BLASLAPACK=OFF \
           -DENABLE_FORTRAN=OFF    
 make -j 3 
+cd pymoab
+pip install .
+cd ..
 make install
 cd ..
 rm -rf moab-repo

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -208,7 +208,12 @@ nuc_data_make
 
 # Run tests
 cd ${install_dir}/pyne/pyne-repo/tests
-./ci-run-tests.sh
+if [ $1 == 'stable' ] ; then
+  ./travis-run-tests.sh
+else
+  ./ci-run-tests.sh
+fi
+
 
 
 echo " \


### PR DESCRIPTION
## Description
I added the `ubuntu.sh` bash install script from the [install_scripts repo](https://github.com/pyne/install_scripts) to the `scripts` folder of this repo. I also edited it slightly to match the commands in `ubuntu_22.04-dev.dockerfile`. 

## Motivation and Context
This change was requested in #1462.

## Changes
Along with adding the install script and updating it to match the dockerfile, I also updated `ubuntu_22.04-dev.dockerfile` to not check for python versions (since we only use version 3.x now) and updated it from ubuntu 20.04 to 22.04, which were two changes requested by @gonuke.

## Behavior
The current behavior is that the install script is in a separate repo and isn't getting tested/updated when the code in this repo is updated. The new behavior should be that the install script is in this repo along with the other code and it will be tested and updated whenever code in this repo is updated. 

## Other Information
There are probably some things yet to be updated/polished in `ubuntu.sh`. When I was editing it, I only updated parts where `ubuntu.sh` had something different or missing compared to the dockerfile. I left the commands that were only in `ubuntu.sh` but not in the dockerfile intact . 
Also, I'm not sure how to go about testing this bash install script.