### PR TITLE
Avoid use of the deprecated alias np.int in dagmc.pyx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Next Version
    * fix reorder error in member variables (#1466)
    * remove unusable C-linkage with std::vector (#1468)
    * fixed compatibility issue with Python 3.10 in endf.py (#1472)
+   * avoid use of deprecated numpy.int alias (#1479)
 
 v0.7.7
 ======
@@ -24,7 +25,7 @@ v0.7.7
    * turn off all fortran (spatial solvers and ENSDF processing) by default (#1444)
    * update where to look for DAGMC CMake files (#1446)
    * ensure NUC_DATA_PATH is a string (#1447)
-   * update CI to Ubuntu 20.04 (#1449) 
+   * update CI to Ubuntu 20.04 (#1449)
 
 v0.7.6
 ======

--- a/pyne/dagmc.pyx
+++ b/pyne/dagmc.pyx
@@ -48,7 +48,7 @@ def get_entity_handle_type():
     return type(str("EntityHandle"), (eh_t,), {})
 
 EntityHandle = get_entity_handle_type()
-_ErrorCode = type(str("ErrorCode"), (np.int,), {})
+_ErrorCode = type(str("ErrorCode"), (np.intc,), {})
 
 class DagmcError(Exception):
     pass


### PR DESCRIPTION
## Description

Make a one-line change in dagmc.pyx to avoid using the deprecated alias `numpy.int`

## Motivation and Context

NumPy 1.20 [deprecated the use of aliases](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) like `np.int` and `np.float`, and NumPy 1.24 [removed](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) the aliases altogether, so if you are using 1.24+, using np.int will result in an AttributeError, as experienced by a [user recently](https://groups.google.com/g/pyne-dev/c/wpqI6PcNm-M).

## Changes

Bug fix changing `np.int` to `np.intc` (equivalent to C int)

## Behavior

No behavior should change other than PyNE working with NumPy 1.24+.