### PR TITLE
Update MOAB link and add logo of PyNE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Version
 ============
 **Change**
    * move tests from nose to pytest (#1478)
+   * update MOAB dead link and add PyNE logo to readme file (#1481)
 
 **Fix**
    * use multistage docker build action in docker_publish.yml(#1470 #1471 #1473 #1475)

--- a/readme.rst
+++ b/readme.rst
@@ -1,4 +1,8 @@
-PyNE: The Nuclear Engineering Toolkit 
+.. |image| image:: https://github.com/pyne/pyne/blob/develop/img/pyne_icon_small.png
+   :class: centered
+   :width: 42px
+
+|image| PyNE: The Nuclear Engineering Toolkit
 =====================================
 The PyNE project aims to provide a common set of tools for nuclear
 science and engineering needs.
@@ -12,10 +16,6 @@ Examples, documentation, and more can be found at
 https://pyne.io, the official PyNE project site.
 
 .. _github: https://github.com/pyne/pyne
-
-.. install-start
-
-.. _install:
 
 ============
 Installation

--- a/readme.rst
+++ b/readme.rst
@@ -1,4 +1,4 @@
-PyNE: The Nuclear Engineering Toolkit
+PyNE: The Nuclear Engineering Toolkit 
 =====================================
 The PyNE project aims to provide a common set of tools for nuclear
 science and engineering needs.
@@ -9,7 +9,7 @@ and contribute, please let us know either on the mailing list
 pyne-dev@googlegroups.com) or `github`_.
 
 Examples, documentation, and more can be found at
-http://pyne.io/, the official PyNE project site.
+https://pyne.io, the official PyNE project site.
 
 .. _github: https://github.com/pyne/pyne
 
@@ -39,7 +39,7 @@ PyNE has the following dependencies:
    #. `Jinja2 <http://jinja.pocoo.org/>`_
 
 Optional Depenendencies:
-   #. `MOAB <https://press3.mcs.anl.gov/sigma/moab-library>`_
+   #. `MOAB <https://sigma.mcs.anl.gov/moab-library/>`_
    #. `DAGMC <https://svalinn.github.io/DAGMC/install/index.html>`__
    #. `OpenMC <https://docs.openmc.org/en/stable/quickinstall.html>`_
    
@@ -63,6 +63,6 @@ Contributing
 ============
 We highly encourage contributions to PyNE! If you would like to contribute,
 it is as easy as forking the repository on GitHub, making your changes, and
-issuing a pull request. If you have any questions about this process don't
-hesitate to ask the mailing list (https://groups.google.com/forum/#!forum/pyne-dev,
+issuing a pull request. If you have any questions or need assistance during this process,
+don't hesitate to reach out to the PyNE mailing list (https://groups.google.com/forum/#!forum/pyne-dev,
 pyne-dev@googlegroups.com).


### PR DESCRIPTION
## Description
I have made some changes to the PyNE documentation. Specifically, I updated the dead link to MOAB and added the PyNE logo at the title for visual enhancement.

## Motivation and Context
The change is required to fix the dead link to MOAB, which was leading to an outdated resource. By updating the link, users will have access to the correct and up-to-date information. Additionally, adding the PyNE logo improves the visual representation of the documentation.

## Changes
This PR introduces a documentation update. It includes the following changes:

- Updated the dead link to MOAB.
- Added the PyNE logo at the title.

## Behavior
Prior to this change, the link to MOAB in the documentation was no longer valid. The documentation lacked the PyNE logo, resulting in a less visually appealing title.

After applying this change, users will be directed to the correct MOAB resource when accessing the link in the documentation. The PyNE logo will also be displayed at the title, improving the overall visual presentation.