### PR TITLE
Add missing rxname offsets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next Version
    * update MOAB dead link and add PyNE logo to readme file (#1481)
 
 **Fix**
+   * Add missing rxname offsets (#1482)
    * move install script to main repo(#1477)
    * use multistage docker build action in docker_publish.yml(#1470 #1471 #1473 #1475)
    * remove setup-QEMU step from composite action(#1461)

--- a/src/rxname.cpp
+++ b/src/rxname.cpp
@@ -2399,8 +2399,15 @@ void * pyne::rxname::_fill_maps() {
   // offset_id mapping may be ambiquious so they must come before the id_offsets!
   // the following should be sorted by (dz, da, ds)
   // neutrons:
+  offset_id[make_pair("n", offset(-6, -12))] = name_id["n3a"];
+  offset_id[make_pair("n", offset(-6, -11))] = name_id["z_3a"];
+  offset_id[make_pair("n", offset(-5, -10))] = name_id["t2a"];
+  offset_id[make_pair("n", offset(-4, -9))] = name_id["z_2n2a"];
   offset_id[make_pair("n", offset(-4, -8))] = name_id["n2a"];
   offset_id[make_pair("n", offset(-4, -7))] = name_id["z_2a"];
+  offset_id[make_pair("n", offset(-3, -5))] = name_id["da"];
+  offset_id[make_pair("n", offset(-3, -4))] = name_id["pa"];
+  offset_id[make_pair("n", offset(-2, -6))] = name_id["z_3na"];
   offset_id[make_pair("n", offset(-2, -5))] = name_id["z_2na"];
   offset_id[make_pair("n", offset(-2, -4))] = name_id["na"];
   offset_id[make_pair("n", offset(-2, -4, 1))] = name_id["na_1"];
@@ -2544,10 +2551,16 @@ void * pyne::rxname::_fill_maps() {
     id_offset[make_pair(ioffid->first.first, ioffid->second)] = ioffid->first.second;
   }
   // neutrons:
+  id_offset[make_pair("n", name_id["npa"])] = offset(-3, -5);
+  id_offset[make_pair("n", name_id["pt"])] = offset(-2, -3);
   id_offset[make_pair("n", name_id["nHe3"])] = offset(-2, -3);
   id_offset[make_pair("n", name_id["nHe3_1"])] = offset(-2, -3, 2);
   id_offset[make_pair("n", name_id["nHe3_2"])] = offset(-2, -3, 2);
+  id_offset[make_pair("n", name_id["pd"])] = offset(-2, -2);
+  id_offset[make_pair("n", name_id["n2p"])] = offset(-2, -2);
   id_offset[make_pair("n", name_id["z_3np"])] = offset(-1, -3);
+  id_offset[make_pair("n", name_id["z_2nd"])] = offset(-1, -3);
+  id_offset[make_pair("n", name_id["z_2np"])] = offset(-1, -2);
   id_offset[make_pair("n", name_id["nd"])] = offset(-1, -2);
   id_offset[make_pair("n", name_id["nd_1"])] = offset(-1, -2, 1);
   id_offset[make_pair("n", name_id["nd_2"])] = offset(-1, -2, 2);


### PR DESCRIPTION
Please follow these guidelines when making a Pull Request.
This template was adapted from [here](https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md) and [here](https://github.com/stevemao/github-issue-templates/blob/master/conversational/PULL_REQUEST_TEMPLATE.md).

## Description
Add missing rxname offsets to map.

--Please verify the offsets. I am simply a developer and nuclear is not my field...

## Motivation and Context
When parsing ENDFBVIII (https://www.nndc.bnl.gov/endf-b8.0/zips/ENDF-B-VIII.0.zip) I get a RuntimeError when using functions rxname.parent and rxname.child from python.

## Changes
What kind of change does this PR introduce? (Bug fix, feature, documentation update...)
Bug fix

## Behavior
What is the current behavior? What is the new behavior?
RuntimeError when calling from python with certain rx ids.

## Other Information
Other relevant information to this pull request.

## Changelog file
All pull requests are required to update the [CHANGELOG](https://github.com/pyne/pyne/blob/develop/CHANGELOG.rst) file with the PR.  Your update can take different forms including:

* creating a new entry describing your change, including a reference to this pull request number
* adding a reference to your pull request number to an exist entry if that entry can include your changes
