### PR TITLE
Add composite action for BuildTest job

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -29,18 +29,18 @@ runs:
         export ADD_FLAG="${ADD_FLAG} "
         echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
         
-      - name: Building PyNE
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE
-          python setup.py install --user --clean ${{ env.ADD_FLAG}}
-          export PATH="$PATH:/github/home/.local/bin"
-          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
-          cd ../
-          nuc_data_make
+    - name: Building PyNE
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE
+        python setup.py install --user --clean ${{ env.ADD_FLAG}}
+        export PATH="$PATH:/github/home/.local/bin"
+        export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
+        cd ../
+        nuc_data_make
 
-      - name: Testing PyNE
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE/tests
-          ./ci-run-tests.sh python3
+    - name: Testing PyNE
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE/tests
+        ./ci-run-tests.sh python3

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -20,8 +20,7 @@ inputs:
 
 runs:
   using: "composite"
-  container:
-    image: ghcr.io/${{ inputs.owner }}/pyne_ubuntu_22.04_py3${{ inputs.hdf5 }}/${{ inputs.stage }}${{ inputs.tag }}
+  image: ghcr.io/${{ inputs.owner }}/pyne_ubuntu_22.04_py3${{ inputs.hdf5 }}/${{ inputs.stage }}${{ inputs.tag }}
   steps: 
     - name: setup
       shell: bash -l {0}

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -1,13 +1,12 @@
 name: BuildTest
-description: tests one docker image built in docker_publish.yml. Used to keep 
-    the build test procedure consistent in docker_publish.yml and build_test.yml
+description: Builds and tests an installation of PyNE in a single docker image.  This action is used for bootstrap testing when building the docker images as well as testing of each PR using those docker images.
 inputs:
   stage:
-    description: matrix variable
+    description: The docker stage that will be used as the docker image for testing.
     required: true
     default: ''
   hdf5:
-    description: matrix variable
+    description: Information about which version of HDF5 will be used for testing.
     required: true
     default: ''
 runs:

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -9,6 +9,16 @@ inputs:
     description: Information about which version of HDF5 will be used for testing.
     required: true
     default: ''
+  tag:
+    description: The tag for the docker image used to run the tests
+    required: true
+    default: ''
+  owner:
+    description: The owner of the repository
+    required: true
+    default: 'pyne'
+container:
+  image: ghcr.io/${{ inputs.owner }}/pyne_ubuntu_22.04_py3${{ inputs.hdf5 }}/${{ inputs.stage }}${{ inputs.tag }}
 runs:
   using: "composite"
   steps: 
@@ -34,7 +44,6 @@ runs:
         cd $GITHUB_WORKSPACE
         python setup.py install --user --clean ${{ env.ADD_FLAG}}
         export PATH="$PATH:/github/home/.local/bin"
-        export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
         cd ../
         nuc_data_make
 

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -9,18 +9,8 @@ inputs:
     description: Information about which version of HDF5 will be used for testing.
     required: true
     default: ''
-  tag:
-    description: The tag for the docker image used to run the tests
-    required: true
-    default: ''
-  owner:
-    description: The owner of the repository
-    required: true
-    default: 'pyne'
-
 runs:
   using: "composite"
-  image: ghcr.io/${{ inputs.owner }}/pyne_ubuntu_22.04_py3${{ inputs.hdf5 }}/${{ inputs.stage }}${{ inputs.tag }}
   steps: 
     - name: setup
       shell: bash -l {0}

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -14,20 +14,20 @@ runs:
   using: "composite"
   steps: 
     - name: setup
-        shell: bash -l {0}
-        run: |
-          export ADD_FLAG=" "
-          if [[ "${{ inputs.stage }}" == "moab" || "${{ inputs.stage }}" == "dagmc" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --moab /root/opt/moab"
-          fi
-          if [[ "${{ inputs.stage }}" == "dagmc" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --dagmc /root/opt/dagmc"
-          fi
-          if [[ "${{ inputs.hdf5 }}" == "_hdf5" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --hdf5 /root/opt/hdf5/hdf5-1_12_0"
-          fi
-          export ADD_FLAG="${ADD_FLAG} "
-          echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
+      shell: bash -l {0}
+      run: |
+        export ADD_FLAG=" "
+        if [[ "${{ inputs.stage }}" == "moab" || "${{ inputs.stage }}" == "dagmc" ]]; then
+          export ADD_FLAG="${ADD_FLAG} --moab /root/opt/moab"
+        fi
+        if [[ "${{ inputs.stage }}" == "dagmc" ]]; then
+          export ADD_FLAG="${ADD_FLAG} --dagmc /root/opt/dagmc"
+        fi
+        if [[ "${{ inputs.hdf5 }}" == "_hdf5" ]]; then
+          export ADD_FLAG="${ADD_FLAG} --hdf5 /root/opt/hdf5/hdf5-1_12_0"
+        fi
+        export ADD_FLAG="${ADD_FLAG} "
+        echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -1,0 +1,49 @@
+name: BuildTest
+description: tests one docker image built in docker_publish.yml. Used to keep 
+    the build test procedure consistent in docker_publish.yml and build_test.yml
+inputs:
+  stage:
+    description: matrix variable
+    required: true
+    default: ''
+  hdf5:
+    description: matrix variable
+    required: true
+    default: ''
+runs:
+  using: "composite"
+  steps: 
+    - name: setup
+        shell: bash -l {0}
+        run: |
+          export ADD_FLAG=" "
+          if [[ "${{ inputs.stage }}" == "moab" || "${{ inputs.stage }}" == "dagmc" ]]; then
+            export ADD_FLAG="${ADD_FLAG} --moab /root/opt/moab"
+          fi
+          if [[ "${{ inputs.stage }}" == "dagmc" ]]; then
+            export ADD_FLAG="${ADD_FLAG} --dagmc /root/opt/dagmc"
+          fi
+          if [[ "${{ inputs.hdf5 }}" == "_hdf5" ]]; then
+            export ADD_FLAG="${ADD_FLAG} --hdf5 /root/opt/hdf5/hdf5-1_12_0"
+          fi
+          export ADD_FLAG="${ADD_FLAG} "
+          echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Building PyNE
+        shell: bash -l {0}
+        run: |
+          cd $GITHUB_WORKSPACE
+          python setup.py install --user --clean ${{ env.ADD_FLAG}}
+          export PATH="$PATH:/github/home/.local/bin"
+          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
+          cd ../
+          nuc_data_make
+
+      - name: Testing PyNE
+        shell: bash -l {0}
+        run: |
+          cd $GITHUB_WORKSPACE/tests
+          ./ci-run-tests.sh python3

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -28,9 +28,6 @@ runs:
         fi
         export ADD_FLAG="${ADD_FLAG} "
         echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
         
       - name: Building PyNE
         shell: bash -l {0}

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -17,10 +17,11 @@ inputs:
     description: The owner of the repository
     required: true
     default: 'pyne'
-container:
-  image: ghcr.io/${{ inputs.owner }}/pyne_ubuntu_22.04_py3${{ inputs.hdf5 }}/${{ inputs.stage }}${{ inputs.tag }}
+
 runs:
   using: "composite"
+  container:
+    image: ghcr.io/${{ inputs.owner }}/pyne_ubuntu_22.04_py3${{ inputs.hdf5 }}/${{ inputs.stage }}${{ inputs.tag }}
   steps: 
     - name: setup
       shell: bash -l {0}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -37,6 +37,7 @@ jobs:
       image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
+      - uses: actions/checkout@v3
       - name: use BuildTest composite action
         uses: ./.github/actions/build-test
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,6 +45,4 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           hdf5: ${{ matrix.hdf5 }}
-          tag: ':stable'
-          owner: 'pyne'
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -37,7 +37,9 @@ jobs:
       image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: use BuildTest composite action
         uses: ./.github/actions/build-test
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -33,8 +33,8 @@ jobs:
             hdf5: _hdf5
       fail-fast: false
 
-    # container:
-    #   image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+    container:
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,41 +34,12 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/pyne/pyne_ubuntu_20.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
-      - name: setup
-        shell: bash -l {0}
-        run: |
-          export ADD_FLAG=" "
-          if [[ "${{ matrix.stage }}" == "moab" || "${{ matrix.stage }}" == "dagmc" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --moab /root/opt/moab"
-          fi
-          if [[ "${{ matrix.stage }}" == "dagmc" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --dagmc /root/opt/dagmc"
-          fi
-          if [[ "${{ matrix.hdf5 }}" == "_hdf5" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --hdf5 /root/opt/hdf5/hdf5-1_12_0"
-          fi
-          export ADD_FLAG="${ADD_FLAG} "
-          echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
-          pip install pytest
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - name: Building PyNE
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE
-          python setup.py install --user --clean ${{ env.ADD_FLAG}}
-          export PATH="$PATH:/github/home/.local/bin"
-          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.8/site-packages/"
-          cd ../
-          nuc_data_make
-
-      - name: Testing PyNE
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE/tests
-          ./ci-run-tests.sh

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -33,8 +33,8 @@ jobs:
             hdf5: _hdf5
       fail-fast: false
 
-    container:
-      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+    # container:
+    #   image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository
@@ -45,4 +45,6 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           hdf5: ${{ matrix.hdf5 }}
+          tag: ':stable'
+          owner: 'pyne'
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -89,7 +89,9 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: use BuildTest composite action
         uses: ./.github/actions/build-test
         with:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -20,11 +20,6 @@ jobs:
   # to be built upon by the subsequent stage.
   multistage_image_build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ubuntu_versions : [
-          22.04,
-        ]
     outputs:
       image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
@@ -41,7 +36,7 @@ jobs:
 
       # build base python, moab, dagmc, openmc using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
-        id: build1
+        id: build_all_stages
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}
           stages: base_python, moab, dagmc
@@ -52,7 +47,7 @@ jobs:
 
       # build HDF5 using multistage docker build action 
       - uses: firehed/multistage-docker-build-action@v1
-        id: build2
+        id: build_dagmc_with_hdf5
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}_hdf5
           stages: base_python, moab
@@ -61,11 +56,6 @@ jobs:
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_hdf5=hdf5-1_12_0
-
-      # print out server-tags
-      - run: |
-          echo ${{ steps.build1.outputs.server-tag }}
-          echo ${{ steps.build2.outputs.server-tag }}
 
       - id: output_tag
         run: |
@@ -86,8 +76,8 @@ jobs:
             hdf5: _hdf5
       fail-fast: false
 
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
+    # container:
+    #   image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -97,6 +87,8 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           hdf5: ${{ matrix.hdf5 }}
+          owner: ${{ github.repository_owner }}
+          tag: ${{ env.DOCKER_IMAGE_TAG }}
 
 
   # if the previous step that tests the docker images passes then the images

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'docker/*'
       - '.github/workflows/docker_publish.yml'
+      - '.github/actions/build-test/action.yml'
 
 env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -88,6 +88,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
     steps:
+      - uses: actions/checkout@v3
       - name: use BuildTest composite action
         uses: ./.github/actions/build-test
         with:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -87,8 +87,6 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           hdf5: ${{ matrix.hdf5 }}
-          tag: ${{ env.DOCKER_IMAGE_TAG }}
-          owner: ${{ github.repository_owner }}
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -76,8 +76,8 @@ jobs:
             hdf5: _hdf5
       fail-fast: false
 
-    # container:
-    #   image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -87,9 +87,8 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           hdf5: ${{ matrix.hdf5 }}
-          owner: ${{ github.repository_owner }}
           tag: ${{ env.DOCKER_IMAGE_TAG }}
-
+          owner: ${{ github.repository_owner }}
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -88,40 +88,12 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
     steps:
-      - name: setup
-        shell: bash -l {0}
-        run: |
-          export ADD_FLAG=" "
-          if [[ "${{ matrix.stage }}" == "moab" || "${{ matrix.stage }}" == "dagmc" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --moab /root/opt/moab"
-          fi
-          if [[ "${{ matrix.stage }}" == "dagmc" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --dagmc /root/opt/dagmc"
-          fi
-          if [[ "${{ matrix.hdf5 }}" == "_hdf5" ]]; then
-            export ADD_FLAG="${ADD_FLAG} --hdf5 /root/opt/hdf5/hdf5-1_12_0"
-          fi
-          export ADD_FLAG="${ADD_FLAG} "
-          echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - name: Building PyNE
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE
-          python setup.py install --user --clean ${{ env.ADD_FLAG}}
-          export PATH="$PATH:/github/home/.local/bin"
-          export PYTHONPATH="$PYTHONPATH:/github/home/.local/lib/python3.10/site-packages/"
-          cd ../
-          nuc_data_make
-
-      - name: Testing PyNE
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE/tests
-          ./ci-run-tests.sh python3
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Next Version
    * fixed compatibility issue with Python 3.10 in endf.py (#1472)
    * avoid use of deprecated numpy.int alias (#1479)
    * avoid use of deprecated numpy.bool alias (#1485)
+   * add composite action for BuildTest job in workflows (#1489)
 
 v0.7.7
 ======


### PR DESCRIPTION
## Description
Adds a composite action to replace the BuildTest job used in `docker_publish.yml` and `build_test.yml`.

## Motivation and Context
Requested by @gonuke. This change will keep the BuildTest jobs in the two workflows consistent and requires less effort to maintain the consistency.

## Behavior
Current behavior is that the BuildTest jobs in `docker_publish.yml` and `build_test.yml` have become inconsistent with each other due to previous pull requests I made where I only updated the BuildTest job in `docker_publish.yml`. Now, I have put the BuildTest job from `docker_publish.yml` (the most updated version) into the composite action and it is being used in both workflows. 

## Other Information
The composite action can only include the `steps` of the BuildTest job, which means that the `matrix` and the `container` of the BuildTest job still need to be updated in their respective workflow files. However, the `container` of the BuildTest job already had differences between the two workflow files in terms of their tag, so this issue wouldn't have been fixed with the composite action anyway. 
Here's a [workflow run](https://github.com/bquan0/pyne/actions/runs/5509596417) to show that the BuildTest job still functions as intended with the composite action.