### PR TITLE
Add workflow to create virtual machine from Dockerfile

### DIFF
--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build VirtualBox image using d2vm
         run: |
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -81,7 +81,15 @@ jobs:
       - name: Build VirtualBox image using d2vm
         run: |
           sudo apt-get update
-          sudo apt-get install qemu-utils
+          sudo apt-get install -y --fix-missing \
+            util-linux \
+            udev \
+            parted \
+            e2fsprogs \
+            mount \
+            tar \
+            extlinux \
+            qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -80,7 +80,8 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
-          sudo apt-get qemu-utils
+          sudo apt-get update
+          sudo apt-get install qemu-utils
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -20,9 +20,7 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
-          git clone https://github.com/linka-cloud/d2vm && cd d2vm
-          make install
-          cd ..
+          curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_arm64.tar.gz" | tar -xvz d2vm
+          sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          which d2vm
-          sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build PyNE docker image
-        ses: firehed/multistage-docker-build-action@v1
+        uses: firehed/multistage-docker-build-action@v1
         id: build_pyne
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
-          which d2vm
+          cd ..
           echo "make worked"
+          which d2vm
           sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,6 +14,15 @@ env:
 jobs:
   virtualbox_image_build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
+        include:
+          - stage: dagmc
+            hdf5: _hdf5
+      fail-fast: false
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -23,4 +32,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -10,19 +10,60 @@ on:
 
 env:
   VM_PASSWORD: temppwd
+  DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
+  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  virtualbox_image_build:
+  pyne_image_build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        stage: [base_python, moab, dagmc, openmc]
-        hdf5: ['']
-        include:
-          - stage: dagmc
-            hdf5: _hdf5
-      fail-fast: false
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build PyNE docker image
+        ses: firehed/multistage-docker-build-action@v1
+        id: build_pyne
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          stages: base_python, moab, dagmc, openmc
+          server-stage: pyne
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+
+      - id: output_tag
+        run: |
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  BuildTest:
+    needs: [pyne_image_build]
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
+      
+  virtualbox_image_build:
+    needs: [BuildTest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -39,5 +80,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -23,4 +23,5 @@ jobs:
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
           which d2vm
+          echo "make worked"
           sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,55 +14,55 @@ env:
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  pyne_image_build:
-    runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+  # pyne_image_build:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build PyNE docker image
-        uses: firehed/multistage-docker-build-action@v1
-        id: build_pyne
-        with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-          stages: base_python, moab, dagmc, openmc
-          server-stage: pyne
-          quiet: false
-          tag-latest-on-default: false
-          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+  #     - name: Build PyNE docker image
+  #       uses: firehed/multistage-docker-build-action@v1
+  #       id: build_pyne
+  #       with:
+  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+  #         stages: base_python, moab, dagmc, openmc
+  #         server-stage: pyne
+  #         quiet: false
+  #         tag-latest-on-default: false
+  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
-      - id: output_tag
-        run: |
-          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+  #     - id: output_tag
+  #       run: |
+  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  BuildTest:
-    needs: [pyne_image_build]
-    runs-on: ubuntu-latest
+  # BuildTest:
+  #   needs: [pyne_image_build]
+  #   runs-on: ubuntu-latest
 
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   container:
+  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: use BuildTest composite action
-        uses: ./.github/actions/build-test
-        with:
-          stage: ${{ matrix.stage }}
-          hdf5: ${{ matrix.hdf5 }}
+  #     - name: use BuildTest composite action
+  #       uses: ./.github/actions/build-test
+  #       with:
+  #         stage: ${{ matrix.stage }}
+  #         hdf5: ${{ matrix.hdf5 }}
 
   virtualbox_image_build:
-    needs: [BuildTest]
+    # needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -89,8 +89,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -13,64 +13,13 @@ env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
-jobs:
-  # pyne_image_build:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
-
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Build PyNE docker image
-  #       uses: firehed/multistage-docker-build-action@v1
-  #       id: build_pyne
-  #       with:
-  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-  #         stages: base_python, moab, dagmc, openmc
-  #         server-stage: pyne
-  #         quiet: false
-  #         tag-latest-on-default: false
-  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
-
-  #     - id: output_tag
-  #       run: |
-  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
-
-  # BuildTest:
-  #   needs: [pyne_image_build]
-  #   runs-on: ubuntu-latest
-
-  #   container:
-  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: use BuildTest composite action
-  #       uses: ./.github/actions/build-test
-  #       with:
-  #         stage: ${{ matrix.stage }}
-  #         hdf5: ${{ matrix.hdf5 }}
-      
+jobs:      
   virtualbox_image_build:
-    # needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v2
-
+        
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -93,13 +42,11 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/bquan0/pyne_ubuntu_22.04_py3/openmc:df359b744263d9869f345ad0f374f7338b920c0d -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/openmc:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v2
         with:
           name: virtualbox_image
           path: pyne.vdi
-
-      # ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }}
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -39,5 +39,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -42,7 +42,7 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/openmc:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3/openmc:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
-          curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_arm64.tar.gz" | tar -xvz d2vm
+          curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
           sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -22,5 +22,5 @@ jobs:
         run: |
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
-          cd ..
-          sudo d2vm/go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          which d2vm
+          sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -23,4 +23,4 @@ jobs:
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
           cd ..
-          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          sudo d2vm/go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -13,8 +13,56 @@ env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
-jobs:      
+jobs:
+  pyne_image_build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build PyNE docker image
+        uses: firehed/multistage-docker-build-action@v1
+        id: build_pyne
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          stages: base_python, moab, dagmc, openmc
+          server-stage: pyne
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+
+      - id: output_tag
+        run: |
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  BuildTest:
+    needs: [pyne_image_build]
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
+
   virtualbox_image_build:
+    needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
   push:
     paths:
-      -'docker/*'
-      -'.github/workflows/virtualbox_image.yml'
+      - 'docker/*'
+      - '.github/workflows/virtualbox_image.yml'
 
 env:
   VM_PASSWORD: temppwd

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,55 +14,55 @@ env:
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  # pyne_image_build:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
+  pyne_image_build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Build PyNE docker image
-  #       uses: firehed/multistage-docker-build-action@v1
-  #       id: build_pyne
-  #       with:
-  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-  #         stages: base_python, moab, dagmc, openmc
-  #         server-stage: pyne
-  #         quiet: false
-  #         tag-latest-on-default: false
-  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
+      - name: Build PyNE docker image
+        uses: firehed/multistage-docker-build-action@v1
+        id: build_pyne
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          stages: base_python, moab, dagmc, openmc
+          server-stage: pyne
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
-  #     - id: output_tag
-  #       run: |
-  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+      - id: output_tag
+        run: |
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  # BuildTest:
-  #   needs: [pyne_image_build]
-  #   runs-on: ubuntu-latest
+  BuildTest:
+    needs: [pyne_image_build]
+    runs-on: ubuntu-latest
 
-  #   container:
-  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-  #     - name: use BuildTest composite action
-  #       uses: ./.github/actions/build-test
-  #       with:
-  #         stage: ${{ matrix.stage }}
-  #         hdf5: ${{ matrix.hdf5 }}
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
 
   virtualbox_image_build:
-    # needs: [BuildTest]
+    needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -1,0 +1,25 @@
+name: Create VirtualBox disk image from Dockerfile
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      -'docker/*'
+      -'.github/workflows/virtualbox_image.yml'
+
+env:
+  VM_PASSWORD: temppwd
+
+jobs:
+  virtualbox_image_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build VirtualBox image using d2vm
+        run: |
+          git clone https://github.com/linka-cloud/d2vm && cd d2vm
+          make install
+          cd ..
+          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -80,6 +80,7 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
+          sudo apt-get qemu-utils
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
@@ -91,7 +92,5 @@ jobs:
           name: virtualbox_image
           path: pyne.vdi
 
-
-      # 
       # ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }}
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,55 +14,55 @@ env:
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  pyne_image_build:
-    runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+  # pyne_image_build:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build PyNE docker image
-        uses: firehed/multistage-docker-build-action@v1
-        id: build_pyne
-        with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-          stages: base_python, moab, dagmc, openmc
-          server-stage: pyne
-          quiet: false
-          tag-latest-on-default: false
-          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+  #     - name: Build PyNE docker image
+  #       uses: firehed/multistage-docker-build-action@v1
+  #       id: build_pyne
+  #       with:
+  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+  #         stages: base_python, moab, dagmc, openmc
+  #         server-stage: pyne
+  #         quiet: false
+  #         tag-latest-on-default: false
+  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
-      - id: output_tag
-        run: |
-          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+  #     - id: output_tag
+  #       run: |
+  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  BuildTest:
-    needs: [pyne_image_build]
-    runs-on: ubuntu-latest
+  # BuildTest:
+  #   needs: [pyne_image_build]
+  #   runs-on: ubuntu-latest
 
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   container:
+  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: use BuildTest composite action
-        uses: ./.github/actions/build-test
-        with:
-          stage: ${{ matrix.stage }}
-          hdf5: ${{ matrix.hdf5 }}
+  #     - name: use BuildTest composite action
+  #       uses: ./.github/actions/build-test
+  #       with:
+  #         stage: ${{ matrix.stage }}
+  #         hdf5: ${{ matrix.hdf5 }}
       
   virtualbox_image_build:
-    needs: [BuildTest]
+    # needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build VirtualBox image using d2vm
@@ -80,5 +80,15 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/bquan0/pyne_ubuntu_22.04_py3/openmc:df359b744263d9869f345ad0f374f7338b920c0d -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+
+      - name: Upload VirtualBox image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: virtualbox_image
+          path: pyne.vdi
+
+
+      # 
+      # ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }}
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -90,10 +90,10 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3/openmc:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: virtualbox_image
           path: pyne.vdi

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -39,5 +39,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -1,6 +1,7 @@
 name: Create VirtualBox disk image from Dockerfile
 
 on:
+  # allows us to run workflows manually
   workflow_dispatch:
   push:
     paths:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Next Version
    * Review Tutorial and Bug Fixes (#1486)
    * add composite action for BuildTest job in workflows (#1489)
    * update run conditions for workflows (#1494)
-
+   * add workflow to build virtual machines based on Dockerfile (#1490)
 
 v0.7.7
 ======


### PR DESCRIPTION
## Description
Adds the workflow `virtualbox_image.yml` to create a virtual box disk image using the [d2vm](https://github.com/linka-cloud/d2vm) command. 

## Motivation and Context
Requested by @gonuke. This will allow us to distribute virtual machines that are based on our Docker images. 

## Behavior
The new behavior is that the workflow generates virtual machines based on `ubuntu_22.04-dev.dockerfile`. However, I ran into some errors while the d2vm command was building the virtual machines, as can be seen in this [workflow run](https://github.com/bquan0/pyne/actions/runs/5624454309). I'm not sure how to fix these errors as it seems like it's an issue with the contents of the dockerfile instead of an issue with the d2vm command. 