### PR TITLE
Update run conditions for workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,16 +4,9 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/workflows/build_test.yml'
-      - '.github/actions/build-test/action.yml'
   push:
     branches:
       - 'develop'
-    paths:
-      - '.github/workflows/build_test.yml'
-      - '.github/actions/build-test/action.yml'
-
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,19 +4,13 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - '.github/workflows/docker_publish.yml'
-      - '.github/workflows/changelog_test.yml'
-      - 'docker/**'
-      - 'CHANGELOG.rst'
+    paths:
+      - '.github/workflows/build_test.yml'
+      - '.github/actions/build-test/action.yml'
   push:
-    branches:
-      - develop
-    paths-ignore:
-      - '.github/workflows/docker_publish.yml'
-      - '.github/workflows/changelog_test.yml'
-      - 'docker/**'
-      - 'CHANGELOG.rst'
+    paths:
+      - '.github/workflows/build_test.yml'
+      - '.github/actions/build-test/action.yml'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,6 +8,8 @@ on:
       - '.github/workflows/build_test.yml'
       - '.github/actions/build-test/action.yml'
   push:
+    branches:
+      - 'develop'
     paths:
       - '.github/workflows/build_test.yml'
       - '.github/actions/build-test/action.yml'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -7,6 +7,15 @@ on:
   push:
     branches:
       - 'develop'
+    paths-ignore:
+      - 'docs/*'
+      - 'examples/*'
+      - 'img/*'
+      - 'news/*'
+      - 'tutorial/*'
+      - './*.rst'
+      - 'license.txt'
+      - 'PULL_REQUEST_TEMPLATE.md'
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,9 +4,16 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/*'
+      - 'examples/*'
+      - 'img/*'
+      - 'news/*'
+      - 'tutorial/*'
+      - './*.rst'
+      - 'license.txt'
+      - 'PULL_REQUEST_TEMPLATE.md'
   push:
-    branches:
-      - 'develop'
     paths-ignore:
       - 'docs/*'
       - 'examples/*'

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -3,6 +3,11 @@ name: Build & Publish docker image for PyNE-CI
 on:
   # allows us to run workflows manually
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'docker/*'
+      - '.github/workflows/docker_publish.yml'
+      - '.github/actions/build-test/action.yml'
   push:
     paths:
       - 'docker/*'

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -3,7 +3,12 @@ name: run install script
 on:
   # allows us to run workflows manually
   workflow_dispatch:
+  pull_request:
+    branches:
+      - develop
   push:
+    branches:
+      - develop
     paths:
       - 'scripts/ubuntu.sh'
       - '.github/workflows/install_script.yml'

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -9,9 +9,6 @@ on:
   push:
     branches:
       - develop
-    paths:
-      - 'scripts/ubuntu.sh'
-      - '.github/workflows/install_script.yml'
 
 jobs:
   run_install_script:

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -3,12 +3,18 @@ name: run install script
 on:
   # allows us to run workflows manually
   workflow_dispatch:
-  pull_request:
-    branches:
-      - develop
   push:
     branches:
-      - develop
+      - 'develop'
+    paths-ignore:
+      - 'docs/*'
+      - 'examples/*'
+      - 'img/*'
+      - 'news/*'
+      - 'tutorial/*'
+      - './*.rst'
+      - 'license.txt'
+      - 'PULL_REQUEST_TEMPLATE.md'
 
 jobs:
   run_install_script:
@@ -27,7 +33,3 @@ jobs:
           cd $GITHUB_WORKSPACE/scripts
           chmod +x ubuntu.sh
           ./ubuntu.sh ${{ matrix.branch }} ${{ matrix.build_hdf5 }}
-
-      # use matrix to have 2 jobs [develop, stable]
-      # ./ubuntu.sh stable
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Next Version
    * avoid use of deprecated numpy.bool alias (#1485)
    * Review Tutorial and Bug Fixes (#1486)
    * add composite action for BuildTest job in workflows (#1489)
+   * update run conditions for workflows (#1494)
 
 
 v0.7.7

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \
-            cython<3.0 \
+            cython==2.* \
             nose \
             pytest \
             tables \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \
-            cython \
+            cython < 3.0\
             nose \
             pytest \
             tables \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
             setuptools \
             future \
             progress \
-    pip install cython<3.0
+    pip install Cython<3.0
 
 # make starting directory
 RUN mkdir -p $HOME/opt

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \
+            'cython<3' \
             nose \
             pytest \
             tables \
@@ -35,8 +36,7 @@ RUN apt-get update \
             jinja2 \
             setuptools \
             future \
-            progress \
-    pip install cython==0.*
+            progress
 
 # make starting directory
 RUN mkdir -p $HOME/opt

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \
-            cython==2.* \
             nose \
             pytest \
             tables \
@@ -36,7 +35,8 @@ RUN apt-get update \
             jinja2 \
             setuptools \
             future \
-            progress
+            progress \
+    pip install cython<3.0
 
 # make starting directory
 RUN mkdir -p $HOME/opt

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
             setuptools \
             future \
             progress \
-    pip install Cython<3.0
+    pip install cython==0.*
 
 # make starting directory
 RUN mkdir -p $HOME/opt

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \
-            cython < 3.0\
+            cython<3.0 \
             nose \
             pytest \
             tables \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -20,7 +20,7 @@ apt_package_list="software-properties-common \
 # list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
 pip_package_list="numpy==1.23 \
                   scipy \
-                  Cython<3.0 \
+                  cython==0.* \
                   nose \
                   pytest \
                   tables \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -20,7 +20,7 @@ apt_package_list="software-properties-common \
 # list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
 pip_package_list="numpy==1.23 \
                   scipy \
-                  cython==0.* \
+                  \'cython<3\' \
                   nose \
                   pytest \
                   tables \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -20,7 +20,7 @@ apt_package_list="software-properties-common \
 # list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
 pip_package_list="numpy==1.23 \
                   scipy \
-                  cython < 3.0\
+                  cython<3.0 \
                   nose \
                   pytest \
                   tables \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -20,7 +20,7 @@ apt_package_list="software-properties-common \
 # list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
 pip_package_list="numpy==1.23 \
                   scipy \
-                  cython<3.0 \
+                  cython==2.* \
                   nose \
                   pytest \
                   tables \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -20,7 +20,7 @@ apt_package_list="software-properties-common \
 # list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
 pip_package_list="numpy==1.23 \
                   scipy \
-                  cython \
+                  cython < 3.0\
                   nose \
                   pytest \
                   tables \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -20,7 +20,7 @@ apt_package_list="software-properties-common \
 # list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
 pip_package_list="numpy==1.23 \
                   scipy \
-                  cython<3.0 \
+                  Cython<3.0 \
                   nose \
                   pytest \
                   tables \

--- a/scripts/ubuntu.sh
+++ b/scripts/ubuntu.sh
@@ -20,7 +20,7 @@ apt_package_list="software-properties-common \
 # list of python package required for PyNE and its depedencies (installed using pip3 python package manager)
 pip_package_list="numpy==1.23 \
                   scipy \
-                  cython==2.* \
+                  cython<3.0 \
                   nose \
                   pytest \
                   tables \


### PR DESCRIPTION
## Description
Makes `build_test.yml` run when it or the composite action it uses is updated AND it is a push to the `develop` branch in the main repo (not forks). Also makes `install_script.yml` run on every `push` to `develop` and every `pull_request` to develop. 

## Motivation and Context
Closes #1292 and #1491, which request the two features I mentioned above. 

## Behavior
The previous behavior was that `build_test.yml` ran even though there were no changes to itself or the dockerfile that built the image it tested. This is because it used `paths-ignore:` to filter out files instead of using `paths:` to specify files to check if they have been changed.
The previous behavior of `install_script.yml` was that it only ran when it or the install script `ubuntu.sh` was changed. The current behavior is that it now also runs whenever there is a `push` or `pull` to `develop`. 

## Other Information
One thing I was wondering was if I should add `docker/*` to the `paths:` of `build_test.yml` since it's also in `docker_publish.yml`. I didn't add it because I thought it would be redundant since `docker_publish.yml` has `docker/*` in its `paths:` and `docker_publish.yml` has a job which runs the same job found in `build_test.yml`. 
