### PR TITLE
Add workflow to create virtual machine from PyNE docker image in ghcr.io

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Information about which version of HDF5 will be used for testing.
     required: true
     default: ''
+  build_pyne:
+    description: Condition which enables or disables the Building PyNE step.
+    required: false
+    default: 'NO'
 runs:
   using: "composite"
   steps: 
@@ -29,6 +33,7 @@ runs:
         echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
         
     - name: Building PyNE
+      if: inputs.build_pyne == 'NO'
       shell: bash -l {0}
       run: |
         cd $GITHUB_WORKSPACE

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: Information about which version of HDF5 will be used for testing.
     required: true
     default: ''
-  build_pyne:
-    description: Condition which enables or disables the Building PyNE step.
-    required: false
-    default: 'NO'
 runs:
   using: "composite"
   steps: 
@@ -33,7 +29,6 @@ runs:
         echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
         
     - name: Building PyNE
-      if: inputs.build_pyne == 'NO'
       shell: bash -l {0}
       run: |
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -110,7 +110,7 @@ jobs:
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}, build_pyne=YES
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -60,7 +60,7 @@ jobs:
           quiet: false
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=hdf5-1_12_0, build_pyne=YES
+          build-args: build_hdf5=hdf5-1_12_0
 
       - id: output_tag
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -24,7 +24,19 @@ jobs:
   # to be built upon by the subsequent stage.
   multistage_image_build:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
+    strategy:
+      matrix: 
+        pyne_test_base: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
+        hdf5_build_arg: ['']
+        include:
+          - stage: dagmc
+            hdf5: _hdf5
+            hdf5_build_arg: hdf5-1_12_0
+      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -35,84 +47,116 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: modify DOCKER_IMAGE_BASENAME if _hdf5 will be built
+        if: matrix.hdf5 != ''
+        run: echo "DOCKER_IMAGE_BASENAME=${env.DOCKER_IMAGE_BASENAME}${matrix.hdf5}" >> $GITHUB_ENV
 
       # build base python, moab, dagmc, openmc using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
-        id: build_all_stages
+        id: multistage_build_and_test
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-          stages: base_python, moab, dagmc
-          server-stage: openmc
+          stages: ${{ matrix.pyne_test_base }}
+          testenv-stage: ${{ matrix.pyne_test_base }}
+          server-stage: pyne
           quiet: false
-          tag-latest-on-default: true
+          tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-
-      # build HDF5 using multistage docker build action 
-      - uses: firehed/multistage-docker-build-action@v1
-        id: build_dagmc_with_hdf5
-        with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_hdf5
-          stages: base_python, moab
-          server-stage: dagmc
-          quiet: false
-          tag-latest-on-default: true
-          dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=hdf5-1_12_0
-
-  # Downloads the images uploaded to ghcr in previous stages and runs pyne
-  # tests to check that they work.
-  BuildTest:
-    needs: [multistage_image_build]
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        stage: [base_python, moab, dagmc, openmc]
-        hdf5: ['']
-        include:
-          - stage: dagmc
-            hdf5: _hdf5
-      fail-fast: false
-
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: use BuildTest composite action
-        uses: ./.github/actions/build-test
-        with:
-          stage: ${{ matrix.stage }}
-          hdf5: ${{ matrix.hdf5 }}
-
-  # if the previous step that tests the docker images passes then the images
-  # can be copied from the ghcr where they are saved using :ci_testing tags to
-  # :latest and :stable tags.
-  pushing_test_stable_img:
-    if: ${{ github.repository_owner == 'pyne' }}
-    needs: [BuildTest]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        stage: [base_python, moab, dagmc, openmc]
-        hdf5: ['']
-        include:
-          - stage: dagmc
-            hdf5: _hdf5
-
-    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
-
-    steps:
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ env.pyne_test_base }}
 
       - name: Push Image to stable img
+        if: github.repository_owner == 'pyne'
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ steps.multistage_build_and_test.outputs.testenv-tag }}
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+
+
+  #     # build HDF5 using multistage docker build action 
+  #     - uses: firehed/multistage-docker-build-action@v1
+  #       id: build_dagmc_with_hdf5
+  #       with:
+  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}_hdf5
+  #         stages: base_python, moab
+  #         server-stage: dagmc
+  #         quiet: false
+  #         tag-latest-on-default: false
+  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
+  #         build-args: build_hdf5=hdf5-1_12_0
+
+  #     - name: Check event for DOCKER_IMAGE_TAG change
+  #       if: github.event_name == 'pull_request'
+  #       run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
+
+  #     - id: output_tag
+  #       run: |
+  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  # # Downloads the images uploaded to ghcr in previous stages and runs pyne
+  # # tests to check that they work.
+  # BuildTest:
+  #   needs: [multistage_image_build]
+  #   runs-on: ubuntu-latest
+
+  #   strategy:
+  #     matrix:
+  #       stage: [base_python, moab, dagmc, openmc]
+  #       hdf5: ['']
+  #       include:
+  #         - stage: dagmc
+  #           hdf5: _hdf5
+  #     fail-fast: false
+
+  #   container:
+  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
+
+  #     - name: use BuildTest composite action
+  #       uses: ./.github/actions/build-test
+  #       with:
+  #         stage: ${{ matrix.stage }}
+  #         hdf5: ${{ matrix.hdf5 }}
+
+  # # if the previous step that tests the docker images passes then the images
+  # # can be copied from the ghcr where they are saved using :ci_testing tags to
+  # # :latest and :stable tags.
+  # pushing_test_stable_img:
+  #   if: ${{ github.repository_owner == 'pyne' }}
+  #   needs: [BuildTest]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       stage: [base_python, moab, dagmc, openmc]
+  #       hdf5: ['']
+  #       include:
+  #         - stage: dagmc
+  #           hdf5: _hdf5
+
+  #   name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
+
+  #   steps:
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+          
+  #     - name: Check event for DOCKER_IMAGE_TAG change
+  #       if: github.event_name == 'pull_request'
+  #       run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
+
+  #     - name: Push Image to stable img
+  #       uses: akhilerm/tag-push-action@v2.1.0
+  #       with:
+  #         src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
+  #         dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+
+  #     - name: Push Image to latest img
+  #       uses: akhilerm/tag-push-action@v2.1.0
+  #       with:
+  #         src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
+  #         dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -60,7 +60,7 @@ jobs:
           quiet: false
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=hdf5-1_12_0
+          build-args: build_hdf5=hdf5-1_12_0, build_pyne=YES
 
       - id: output_tag
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
-  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
 
@@ -25,8 +24,6 @@ jobs:
   # to be built upon by the subsequent stage.
   multistage_image_build:
     runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
     steps:
       - name: Checkout repository
@@ -47,7 +44,7 @@ jobs:
           stages: base_python, moab, dagmc
           server-stage: openmc
           quiet: false
-          tag-latest-on-default: false
+          tag-latest-on-default: true
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
       # build HDF5 using multistage docker build action 
@@ -58,17 +55,9 @@ jobs:
           stages: base_python, moab
           server-stage: dagmc
           quiet: false
-          tag-latest-on-default: false
+          tag-latest-on-default: true
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_hdf5=hdf5-1_12_0
-
-      - name: Check event for DOCKER_IMAGE_TAG change
-        if: github.event_name == 'pull_request'
-        run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
-
-      - id: output_tag
-        run: |
-          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
@@ -86,7 +75,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -121,19 +110,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Check event for DOCKER_IMAGE_TAG change
-        if: github.event_name == 'pull_request'
-        run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
 
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
-
-      - name: Push Image to latest img
-        uses: akhilerm/tag-push-action@v2.1.0
-        with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -16,9 +16,9 @@ on:
 
 env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
+  USE_LATEST_TAG: false
 
 jobs:
-
   # builds and pushes docker images of various stages to ghcr.
   # These docker images are also stored in ghcr and can be pulled
   # to be built upon by the subsequent stage.
@@ -27,16 +27,6 @@ jobs:
     outputs:
       image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
-    strategy:
-      matrix: 
-        pyne_test_base: [base_python, moab, dagmc, openmc]
-        hdf5: ['']
-        hdf5_build_arg: ['']
-        include:
-          - stage: dagmc
-            hdf5: _hdf5
-            hdf5_build_arg: hdf5-1_12_0
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -48,115 +38,100 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: modify DOCKER_IMAGE_BASENAME if _hdf5 will be built
-        if: matrix.hdf5 != ''
-        run: echo "DOCKER_IMAGE_BASENAME=${env.DOCKER_IMAGE_BASENAME}${matrix.hdf5}" >> $GITHUB_ENV
+      - name: Tag images with latest if on the main repo's develop branch
+        if: github.repository_owner == 'pyne' && github.ref_name == 'develop'
+        run: echo "USE_LATEST_TAG=true" >> $GITHUB_ENV
 
       # build base python, moab, dagmc, openmc using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
-        id: multistage_build_and_test
+        id: build_all_stages
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-          stages: ${{ matrix.pyne_test_base }}
-          testenv-stage: ${{ matrix.pyne_test_base }}
-          server-stage: pyne
+          stages: base_python, moab, dagmc
+          server-stage: openmc
           quiet: false
-          tag-latest-on-default: false
+          parallel: true
+          tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+
+      # build HDF5 using multistage docker build action 
+      - uses: firehed/multistage-docker-build-action@v1
+        id: build_dagmc_with_hdf5
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_hdf5
+          stages: base_python, moab
+          server-stage: dagmc
+          quiet: false
+          parallel: true
+          tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+          build-args: build_hdf5=hdf5-1_12_0
+
+  # Downloads the images uploaded to ghcr in previous stages and runs pyne
+  # tests to check that they work.
+  BuildTest:
+    needs: [multistage_image_build]
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix: 
+        pyne_test_base: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
+        hdf5_build_arg: ['']
+        include:
+          - stage: dagmc
+            hdf5: _hdf5
+            hdf5_build_arg: hdf5-1_12_0
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Tag images with latest if on the main repo's develop branch
+        if: github.repository_owner == 'pyne' && github.ref_name == 'develop'
+        run: echo "USE_LATEST_TAG=true" >> $GITHUB_ENV
+
+      # build test stage and pyne-dev stage using multistage docker build action
+      - uses: firehed/multistage-docker-build-action@v1
+        id: multistage_build_and_test
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
+          stages: ${{ matrix.pyne_test_base }}
+          server-stage: pyne-dev
+          quiet: false
+          parallel: true
+          tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ env.pyne_test_base }}
 
+  # if the previous step that tests the docker images passes then the images
+  # can be copied from the ghcr where they are saved using :ci_testing tags to
+  # :latest and :stable tags.
+  pushing_test_stable_img:
+    if: ${{ github.repository_owner == 'pyne' }}
+    needs: [BuildTest]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
+        include:
+          - stage: dagmc
+            hdf5: _hdf5
+
+    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push Image to stable img
-        if: github.repository_owner == 'pyne'
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ steps.multistage_build_and_test.outputs.testenv-tag }}
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
-
-
-  #     # build HDF5 using multistage docker build action 
-  #     - uses: firehed/multistage-docker-build-action@v1
-  #       id: build_dagmc_with_hdf5
-  #       with:
-  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}_hdf5
-  #         stages: base_python, moab
-  #         server-stage: dagmc
-  #         quiet: false
-  #         tag-latest-on-default: false
-  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
-  #         build-args: build_hdf5=hdf5-1_12_0
-
-  #     - name: Check event for DOCKER_IMAGE_TAG change
-  #       if: github.event_name == 'pull_request'
-  #       run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
-
-  #     - id: output_tag
-  #       run: |
-  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
-
-  # # Downloads the images uploaded to ghcr in previous stages and runs pyne
-  # # tests to check that they work.
-  # BuildTest:
-  #   needs: [multistage_image_build]
-  #   runs-on: ubuntu-latest
-
-  #   strategy:
-  #     matrix:
-  #       stage: [base_python, moab, dagmc, openmc]
-  #       hdf5: ['']
-  #       include:
-  #         - stage: dagmc
-  #           hdf5: _hdf5
-  #     fail-fast: false
-
-  #   container:
-  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}${{ needs.multistage_image_build.outputs.image_tag }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: use BuildTest composite action
-  #       uses: ./.github/actions/build-test
-  #       with:
-  #         stage: ${{ matrix.stage }}
-  #         hdf5: ${{ matrix.hdf5 }}
-
-  # # if the previous step that tests the docker images passes then the images
-  # # can be copied from the ghcr where they are saved using :ci_testing tags to
-  # # :latest and :stable tags.
-  # pushing_test_stable_img:
-  #   if: ${{ github.repository_owner == 'pyne' }}
-  #   needs: [BuildTest]
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       stage: [base_python, moab, dagmc, openmc]
-  #       hdf5: ['']
-  #       include:
-  #         - stage: dagmc
-  #           hdf5: _hdf5
-
-  #   name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
-
-  #   steps:
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-          
-  #     - name: Check event for DOCKER_IMAGE_TAG change
-  #       if: github.event_name == 'pull_request'
-  #       run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
-
-  #     - name: Push Image to stable img
-  #       uses: akhilerm/tag-push-action@v2.1.0
-  #       with:
-  #         src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
-  #         dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
-
-  #     - name: Push Image to latest img
-  #       uses: akhilerm/tag-push-action@v2.1.0
-  #       with:
-  #         src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}${{ env.DOCKER_IMAGE_TAG }}
-  #         dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -62,6 +62,10 @@ jobs:
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_hdf5=hdf5-1_12_0
 
+      - name: Check event for DOCKER_IMAGE_TAG change
+        if: github.event_name == 'pull_request'
+        run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
+
       - id: output_tag
         run: |
           echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
@@ -117,6 +121,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Check event for DOCKER_IMAGE_TAG change
+        if: github.event_name == 'pull_request'
+        run: echo "DOCKER_IMAGE_TAG=:refs_heads_${GITHUB_HEAD_REF}-bk0" >> $GITHUB_ENV
 
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -77,9 +77,9 @@ jobs:
       matrix: 
         pyne_test_base: [base_python, moab, dagmc, openmc]
         hdf5: ['']
-        hdf5_build_arg: ['']
+        hdf5_build_arg: ['NO']
         include:
-          - stage: dagmc
+          - pyne_test_base: dagmc
             hdf5: _hdf5
             hdf5_build_arg: hdf5-1_12_0
       fail-fast: false

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -87,6 +87,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Tag images with latest if on the main repo's develop branch
         if: github.repository_owner == 'pyne' && github.ref_name == 'develop'

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -24,8 +24,14 @@ jobs:
   # to be built upon by the subsequent stage.
   multistage_image_build:
     runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+    strategy:
+      matrix: 
+        hdf5: ['']
+        hdf5_build_arg: ['NO']
+        include:
+          - hdf5: _hdf5
+            hdf5_build_arg: hdf5-1_12_0
+      fail-fast: false
 
     steps:
       - name: Checkout repository
@@ -46,26 +52,14 @@ jobs:
       - uses: firehed/multistage-docker-build-action@v1
         id: build_all_stages
         with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
           stages: base_python, moab, dagmc
           server-stage: openmc
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-
-      # build HDF5 using multistage docker build action 
-      - uses: firehed/multistage-docker-build-action@v1
-        id: build_dagmc_with_hdf5
-        with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_hdf5
-          stages: base_python, moab
-          server-stage: dagmc
-          quiet: false
-          parallel: true
-          tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
-          dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=hdf5-1_12_0
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=openmc
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
@@ -110,7 +104,7 @@ jobs:
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}, build_pyne=YES
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -103,13 +103,13 @@ jobs:
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ env.pyne_test_base }}
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to
   # :latest and :stable tags.
   pushing_test_stable_img:
-    if: ${{ github.repository_owner == 'pyne' }}
+    if: github.repository_owner == 'pyne' && github.ref_name == 'develop'
     needs: [BuildTest]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -62,6 +62,7 @@ jobs:
           server-stage: pyne
           quiet: false
           tag-latest-on-default: false
+          parallel: true
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ env.pyne_test_base }}
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -62,7 +62,6 @@ jobs:
           server-stage: pyne
           quiet: false
           tag-latest-on-default: false
-          parallel: true
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ env.pyne_test_base }}
 

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,7 +14,7 @@ on:
 env:
   VM_PASSWORD: temppwd
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
-  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
+
 
 jobs:
   pyne_image_build:
@@ -33,21 +33,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # before merging, change tag-latest-on-default to true
       - name: Build PyNE docker image
         uses: firehed/multistage-docker-build-action@v1
         id: build_pyne
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-          stages: base_python, moab, dagmc, openmc
+          stages: openmc
           server-stage: pyne
           quiet: false
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_pyne=YES
-
-      - id: output_tag
-        run: |
-          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
   pushing_test_stable_img:
     needs: [pyne_image_build]
@@ -63,14 +59,8 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable
-
-      - name: Push Image to latest img
-        uses: akhilerm/tag-push-action@v2.1.0
-        with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build VirtualBox image using d2vm
         run: |
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -81,7 +81,15 @@ jobs:
       - name: Build VirtualBox image using d2vm
         run: |
           sudo apt-get update
-          sudo apt-get install qemu-utils
+          sudo apt-get install -y --fix-missing \
+            util-linux \
+            udev \
+            parted \
+            e2fsprogs \
+            mount \
+            tar \
+            extlinux \
+            qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -80,7 +80,8 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
-          sudo apt-get qemu-utils
+          sudo apt-get update
+          sudo apt-get install qemu-utils
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -83,7 +83,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner  }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build VirtualBox image using d2vm

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -43,7 +43,7 @@ jobs:
           quiet: false
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=hdf5-1_12_0, build_pyne=YES
+          build-args: build_pyne=YES
 
       - id: output_tag
         run: |

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -3,6 +3,9 @@ name: Create VirtualBox disk image from Dockerfile
 on:
   # allows us to run workflows manually
   workflow_dispatch:
+  release:
+    types:
+      - published
   push:
     paths:
       - 'docker/*'
@@ -58,8 +61,32 @@ jobs:
       - name: use BuildTest composite action
         uses: ./.github/actions/build-test
         with:
-          stage: ${{ matrix.stage }}
-          hdf5: ${{ matrix.hdf5 }}
+          stage: ''
+          hdf5: ''
+          build_pyne: 'YES'
+
+  pushing_test_stable_img:
+    needs: [BuildTest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Image to stable img
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable
+
+      - name: Push Image to latest img
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
 
   virtualbox_image_build:
     needs: [BuildTest]
@@ -89,7 +116,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -20,9 +20,7 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
-          git clone https://github.com/linka-cloud/d2vm && cd d2vm
-          make install
-          cd ..
+          curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_arm64.tar.gz" | tar -xvz d2vm
+          sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          which d2vm
-          sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build PyNE docker image
-        ses: firehed/multistage-docker-build-action@v1
+        uses: firehed/multistage-docker-build-action@v1
         id: build_pyne
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
-          which d2vm
+          cd ..
           echo "make worked"
+          which d2vm
           sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,6 +14,15 @@ env:
 jobs:
   virtualbox_image_build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
+        include:
+          - stage: dagmc
+            hdf5: _hdf5
+      fail-fast: false
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -23,4 +32,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -48,23 +48,6 @@ jobs:
         run: |
           echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  BuildTest:
-    needs: [pyne_image_build]
-    runs-on: ubuntu-latest
-
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: use BuildTest composite action
-        uses: ./.github/actions/build-test
-        with:
-          stage: ''
-          hdf5: ''
-          build_pyne: 'YES'
-
   pushing_test_stable_img:
     needs: [BuildTest]
     runs-on: ubuntu-latest

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -10,19 +10,60 @@ on:
 
 env:
   VM_PASSWORD: temppwd
+  DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
+  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  virtualbox_image_build:
+  pyne_image_build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        stage: [base_python, moab, dagmc, openmc]
-        hdf5: ['']
-        include:
-          - stage: dagmc
-            hdf5: _hdf5
-      fail-fast: false
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build PyNE docker image
+        ses: firehed/multistage-docker-build-action@v1
+        id: build_pyne
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          stages: base_python, moab, dagmc, openmc
+          server-stage: pyne
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+
+      - id: output_tag
+        run: |
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  BuildTest:
+    needs: [pyne_image_build]
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
+      
+  virtualbox_image_build:
+    needs: [BuildTest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -39,5 +80,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -23,4 +23,5 @@ jobs:
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
           which d2vm
+          echo "make worked"
           sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -43,6 +43,7 @@ jobs:
           quiet: false
           tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
+          build-args: build_hdf5=hdf5-1_12_0, build_pyne=YES
 
       - id: output_tag
         run: |

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,55 +14,55 @@ env:
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  pyne_image_build:
-    runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+  # pyne_image_build:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build PyNE docker image
-        uses: firehed/multistage-docker-build-action@v1
-        id: build_pyne
-        with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-          stages: base_python, moab, dagmc, openmc
-          server-stage: pyne
-          quiet: false
-          tag-latest-on-default: false
-          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+  #     - name: Build PyNE docker image
+  #       uses: firehed/multistage-docker-build-action@v1
+  #       id: build_pyne
+  #       with:
+  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+  #         stages: base_python, moab, dagmc, openmc
+  #         server-stage: pyne
+  #         quiet: false
+  #         tag-latest-on-default: false
+  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
-      - id: output_tag
-        run: |
-          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+  #     - id: output_tag
+  #       run: |
+  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  BuildTest:
-    needs: [pyne_image_build]
-    runs-on: ubuntu-latest
+  # BuildTest:
+  #   needs: [pyne_image_build]
+  #   runs-on: ubuntu-latest
 
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   container:
+  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: use BuildTest composite action
-        uses: ./.github/actions/build-test
-        with:
-          stage: ${{ matrix.stage }}
-          hdf5: ${{ matrix.hdf5 }}
+  #     - name: use BuildTest composite action
+  #       uses: ./.github/actions/build-test
+  #       with:
+  #         stage: ${{ matrix.stage }}
+  #         hdf5: ${{ matrix.hdf5 }}
 
   virtualbox_image_build:
-    needs: [BuildTest]
+    # needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -89,8 +89,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -6,10 +6,6 @@ on:
   release:
     types:
       - published
-  push:
-    paths:
-      - 'docker/*'
-      - '.github/workflows/virtualbox_image.yml'
 
 env:
   VM_PASSWORD: temppwd
@@ -19,8 +15,6 @@ env:
 jobs:
   pyne_image_build:
     runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
     steps:
       - name: Checkout repository
@@ -42,7 +36,7 @@ jobs:
           stages: openmc
           server-stage: pyne
           quiet: false
-          tag-latest-on-default: false
+          tag-latest-on-default: true
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
   pushing_test_stable_img:
@@ -60,7 +54,7 @@ jobs:
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable_${{ github.ref }}
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]
@@ -90,7 +84,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:stable_${{ github.ref }} -p ${{ env.VM_PASSWORD }} -o pyne_${{ github.ref }}.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -13,64 +13,13 @@ env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
-jobs:
-  # pyne_image_build:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
-
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Build PyNE docker image
-  #       uses: firehed/multistage-docker-build-action@v1
-  #       id: build_pyne
-  #       with:
-  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-  #         stages: base_python, moab, dagmc, openmc
-  #         server-stage: pyne
-  #         quiet: false
-  #         tag-latest-on-default: false
-  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
-
-  #     - id: output_tag
-  #       run: |
-  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
-
-  # BuildTest:
-  #   needs: [pyne_image_build]
-  #   runs-on: ubuntu-latest
-
-  #   container:
-  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: use BuildTest composite action
-  #       uses: ./.github/actions/build-test
-  #       with:
-  #         stage: ${{ matrix.stage }}
-  #         hdf5: ${{ matrix.hdf5 }}
-      
+jobs:      
   virtualbox_image_build:
-    # needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v2
-
+        
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -93,13 +42,11 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/bquan0/pyne_ubuntu_22.04_py3/openmc:df359b744263d9869f345ad0f374f7338b920c0d -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/openmc:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v2
         with:
           name: virtualbox_image
           path: pyne.vdi
-
-      # ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }}
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -39,5 +39,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -42,7 +42,7 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/openmc:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3/openmc:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
-          curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_arm64.tar.gz" | tar -xvz d2vm
+          curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
           sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -22,5 +22,5 @@ jobs:
         run: |
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
-          cd ..
-          sudo d2vm/go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          which d2vm
+          sudo ./go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -23,4 +23,4 @@ jobs:
           git clone https://github.com/linka-cloud/d2vm && cd d2vm
           make install
           cd ..
-          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .
+          sudo d2vm/go/bin/d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -5,7 +5,8 @@ on:
   workflow_dispatch:
   release:
     types:
-      - published
+      - created
+      - edited
 
 env:
   VM_PASSWORD: temppwd
@@ -60,7 +61,7 @@ jobs:
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:${{ github.ref }}
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:${{ github.ref_name }}
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]
@@ -90,11 +91,11 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:stable_${{ github.ref }} -p ${{ env.VM_PASSWORD }} -o pyne_${{ github.ref }}.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:stable_${{ github.ref_name }} -p ${{ env.VM_PASSWORD }} -o pyne_${{ github.ref_name }}.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: virtualbox_image
-          path: pyne_${{ github.ref }}.vdi
+          path: pyne_${{ github.ref_name }}.vdi
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -13,8 +13,56 @@ env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
-jobs:      
+jobs:
+  pyne_image_build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build PyNE docker image
+        uses: firehed/multistage-docker-build-action@v1
+        id: build_pyne
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          stages: base_python, moab, dagmc, openmc
+          server-stage: pyne
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+
+      - id: output_tag
+        run: |
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+  BuildTest:
+    needs: [pyne_image_build]
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
+
   virtualbox_image_build:
+    needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
   push:
     paths:
-      -'docker/*'
-      -'.github/workflows/virtualbox_image.yml'
+      - 'docker/*'
+      - '.github/workflows/virtualbox_image.yml'
 
 env:
   VM_PASSWORD: temppwd

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,55 +14,55 @@ env:
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  # pyne_image_build:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
+  pyne_image_build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Build PyNE docker image
-  #       uses: firehed/multistage-docker-build-action@v1
-  #       id: build_pyne
-  #       with:
-  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-  #         stages: base_python, moab, dagmc, openmc
-  #         server-stage: pyne
-  #         quiet: false
-  #         tag-latest-on-default: false
-  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
+      - name: Build PyNE docker image
+        uses: firehed/multistage-docker-build-action@v1
+        id: build_pyne
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          stages: base_python, moab, dagmc, openmc
+          server-stage: pyne
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
-  #     - id: output_tag
-  #       run: |
-  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+      - id: output_tag
+        run: |
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  # BuildTest:
-  #   needs: [pyne_image_build]
-  #   runs-on: ubuntu-latest
+  BuildTest:
+    needs: [pyne_image_build]
+    runs-on: ubuntu-latest
 
-  #   container:
-  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.pyne_image_build.outputs.image_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-  #     - name: use BuildTest composite action
-  #       uses: ./.github/actions/build-test
-  #       with:
-  #         stage: ${{ matrix.stage }}
-  #         hdf5: ${{ matrix.hdf5 }}
+      - name: use BuildTest composite action
+        uses: ./.github/actions/build-test
+        with:
+          stage: ${{ matrix.stage }}
+          hdf5: ${{ matrix.hdf5 }}
 
   virtualbox_image_build:
-    # needs: [BuildTest]
+    needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -1,0 +1,25 @@
+name: Create VirtualBox disk image from Dockerfile
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      -'docker/*'
+      -'.github/workflows/virtualbox_image.yml'
+
+env:
+  VM_PASSWORD: temppwd
+
+jobs:
+  virtualbox_image_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build VirtualBox image using d2vm
+        run: |
+          git clone https://github.com/linka-cloud/d2vm && cd d2vm
+          make install
+          cd ..
+          sudo d2vm build -p ${{ env.VM_PASSWORD }} -f ./docker/ubuntu_22.04-dev.dockerfile -o pyne.vdi .

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -80,6 +80,7 @@ jobs:
 
       - name: Build VirtualBox image using d2vm
         run: |
+          sudo apt-get qemu-utils
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
@@ -91,7 +92,5 @@ jobs:
           name: virtualbox_image
           path: pyne.vdi
 
-
-      # 
       # ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }}
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,10 +14,13 @@ on:
 env:
   VM_PASSWORD: temppwd
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
+  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
   pyne_image_build:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
     steps:
       - name: Checkout repository
@@ -38,9 +41,13 @@ jobs:
           stages: base_python, moab, dagmc, openmc
           server-stage: pyne
           quiet: false
-          tag-latest-on-default: true
+          tag-latest-on-default: false
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_pyne=YES
+
+      - id: output_tag
+        run: |
+          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
   pushing_test_stable_img:
     needs: [pyne_image_build]
@@ -56,8 +63,14 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable
+
+      - name: Push Image to latest img
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]
@@ -87,7 +100,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,55 +14,55 @@ env:
   DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
-  pyne_image_build:
-    runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
+  # pyne_image_build:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build PyNE docker image
-        uses: firehed/multistage-docker-build-action@v1
-        id: build_pyne
-        with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
-          stages: base_python, moab, dagmc, openmc
-          server-stage: pyne
-          quiet: false
-          tag-latest-on-default: false
-          dockerfile: docker/ubuntu_22.04-dev.dockerfile
+  #     - name: Build PyNE docker image
+  #       uses: firehed/multistage-docker-build-action@v1
+  #       id: build_pyne
+  #       with:
+  #         repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+  #         stages: base_python, moab, dagmc, openmc
+  #         server-stage: pyne
+  #         quiet: false
+  #         tag-latest-on-default: false
+  #         dockerfile: docker/ubuntu_22.04-dev.dockerfile
 
-      - id: output_tag
-        run: |
-          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+  #     - id: output_tag
+  #       run: |
+  #         echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
-  BuildTest:
-    needs: [pyne_image_build]
-    runs-on: ubuntu-latest
+  # BuildTest:
+  #   needs: [pyne_image_build]
+  #   runs-on: ubuntu-latest
 
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #   container:
+  #     image: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ needs.multistage_image_build.outputs.image_tag }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: use BuildTest composite action
-        uses: ./.github/actions/build-test
-        with:
-          stage: ${{ matrix.stage }}
-          hdf5: ${{ matrix.hdf5 }}
+  #     - name: use BuildTest composite action
+  #       uses: ./.github/actions/build-test
+  #       with:
+  #         stage: ${{ matrix.stage }}
+  #         hdf5: ${{ matrix.hdf5 }}
       
   virtualbox_image_build:
-    needs: [BuildTest]
+    # needs: [BuildTest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build VirtualBox image using d2vm
@@ -80,5 +80,15 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/bquan0/pyne_ubuntu_22.04_py3/openmc:df359b744263d9869f345ad0f374f7338b920c0d -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+
+      - name: Upload VirtualBox image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: virtualbox_image
+          path: pyne.vdi
+
+
+      # 
+      # ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne${{ env.DOCKER_IMAGE_TAG }}
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -89,7 +89,7 @@ jobs:
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
 
   virtualbox_image_build:
-    needs: [BuildTest]
+    needs: [pushing_test_stable_img]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -90,10 +90,10 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/pyne/pyne_ubuntu_22.04_py3/openmc:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne:${{ env.DOCKER_IMAGE_TAG }} -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: virtualbox_image
           path: pyne.vdi

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -39,5 +39,5 @@ jobs:
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
           echo "make worked"
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
           

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -83,7 +83,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner  }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build VirtualBox image using d2vm
@@ -100,7 +100,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.actor }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -1,6 +1,7 @@
 name: Create VirtualBox disk image from Dockerfile
 
 on:
+  # allows us to run workflows manually
   workflow_dispatch:
   push:
     paths:

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -14,13 +14,10 @@ on:
 env:
   VM_PASSWORD: temppwd
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3
-  DOCKER_IMAGE_TAG: :refs_heads_${{ github.ref_name }}-bk0
 
 jobs:
   pyne_image_build:
     runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.output_tag.outputs.image_tag }}
 
     steps:
       - name: Checkout repository
@@ -41,13 +38,9 @@ jobs:
           stages: base_python, moab, dagmc, openmc
           server-stage: pyne
           quiet: false
-          tag-latest-on-default: false
+          tag-latest-on-default: true
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
           build-args: build_pyne=YES
-
-      - id: output_tag
-        run: |
-          echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
   pushing_test_stable_img:
     needs: [pyne_image_build]
@@ -63,14 +56,8 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
           dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable
-
-      - name: Push Image to latest img
-        uses: akhilerm/tag-push-action@v2.1.0
-        with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne${{ env.DOCKER_IMAGE_TAG }}
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]
@@ -100,7 +87,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3/pyne:latest -p ${{ env.VM_PASSWORD }} -o pyne.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -49,7 +49,7 @@ jobs:
           echo "image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
 
   pushing_test_stable_img:
-    needs: [BuildTest]
+    needs: [pyne_image_build]
     runs-on: ubuntu-latest
     steps:
       - name: Log in to the Container registry

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -54,7 +54,13 @@ jobs:
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable_${{ github.ref }}
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable
+
+      - name: Push Image to release tag img
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:${{ github.ref }}
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]
@@ -90,5 +96,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: virtualbox_image
-          path: pyne.vdi
+          path: pyne_${{ github.ref }}.vdi
           

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,7 @@ Next Version
    * Add composite action for BuildTest job in workflows (#1489)
    * Update run conditions for workflows (#1494)
    * Fix gamma intensity calculation (#1496)
-
-
+   * Add workflow to build virtual machines based on Dockerfile (#1490)
 
 v0.7.7
 ======

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,5 +1,6 @@
 ARG build_hdf5="NO"
 ARG build_pyne="NO"
+ARG pyne_test_base=openmc
 ARG ubuntu_version=22.04
 
 FROM ubuntu:${ubuntu_version} AS base_python
@@ -133,7 +134,7 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
     && pip install .
 
 # Build/Install PyNE from develop branch
-FROM openmc AS pyne-dev
+FROM ${pyne_test_base} AS pyne-dev
 ARG build_hdf5
 ARG build_pyne
 
@@ -157,7 +158,7 @@ RUN if [ "$build_pyne" = "YES" ]; then \
     && ./ci-run-tests.sh python3
 
 # Build/Install PyNE from release branch
-FROM openmc AS pyne
+FROM ${pyne_test_base} AS pyne
 ARG build_hdf5
 ARG build_pyne
 

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -134,6 +134,7 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
     && pip install .
 
 # Build/Install PyNE from develop branch
+ARG pyne_test_base
 FROM ${pyne_test_base} AS pyne-dev
 ARG build_hdf5
 ARG build_pyne
@@ -158,6 +159,7 @@ RUN if [ "$build_pyne" = "YES" ]; then \
     && ./ci-run-tests.sh python3
 
 # Build/Install PyNE from release branch
+ARG pyne_test_base
 FROM ${pyne_test_base} AS pyne
 ARG build_hdf5
 ARG build_pyne

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -151,7 +151,7 @@ RUN export PYNE_HDF5_ARGS="" ;\
                                 --clean -j 3;
 ENV PATH $HOME/.local/bin:$PATH
 RUN cd $HOME \
-    && nuc_data_make ; \
+    && nuc_data_make \
     && cd $HOME/opt/pyne/tests \
     && ./ci-run-tests.sh python3
 
@@ -171,6 +171,6 @@ RUN cd $HOME/opt/pyne \
                                 --clean -j 3;
 ENV PATH $HOME/.local/bin:$PATH
 RUN cd $HOME \
-    && nuc_data_make ; \
+    && nuc_data_make \
     && cd $HOME/opt/pyne/tests \
     && ./ci-run-tests.sh python3

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,7 +1,6 @@
 ARG build_hdf5="NO"
 ARG build_pyne="NO"
 ARG pyne_test_base=openmc
-ENV pyne_base=${pyne_test_base}
 ARG ubuntu_version=22.04
 
 FROM ubuntu:${ubuntu_version} AS base_python
@@ -135,7 +134,7 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
     && pip install .
 
 # Build/Install PyNE from develop branch
-FROM ${pyne_base} AS pyne-dev
+FROM ${pyne_test_base} AS pyne-dev
 ARG build_hdf5
 ARG build_pyne
 
@@ -159,7 +158,7 @@ RUN if [ "$build_pyne" = "YES" ]; then \
     && ./ci-run-tests.sh python3
 
 # Build/Install PyNE from release branch
-FROM ${pyne_base} AS pyne
+FROM ${pyne_test_base} AS pyne
 ARG build_hdf5
 ARG build_pyne
 

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,4 +1,5 @@
 ARG build_hdf5="NO"
+ARG build_pyne="NO"
 ARG ubuntu_version=22.04
 
 FROM ubuntu:${ubuntu_version} AS base_python
@@ -134,6 +135,7 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
 # Build/Install PyNE from develop branch
 FROM openmc AS pyne-dev
 ARG build_hdf5
+ARG build_pyne
 
 RUN export PYNE_HDF5_ARGS="" ;\
     if [ "$build_hdf5" != "NO" ]; then \
@@ -157,6 +159,7 @@ RUN if [ "$build_pyne" = "YES" ]; then \
 # Build/Install PyNE from release branch
 FROM openmc AS pyne
 ARG build_hdf5
+ARG build_pyne
 
 RUN export PYNE_HDF5_ARGS="" ;\
     if [ "$build_hdf5" != "NO" ]; then \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -151,7 +151,7 @@ RUN if [ "$build_pyne" = "YES" ]; then \
         cd $HOME \
         && nuc_data_make ; \
     fi \
-    ./ci-run-tests.sh python3
+    && ./ci-run-tests.sh python3
 
 # Build/Install PyNE from release branch
 FROM openmc AS pyne
@@ -172,4 +172,4 @@ RUN if [ "$build_pyne" = "YES" ]; then \
         cd $HOME \
         && nuc_data_make ; \
     fi \
-    ./ci-run-tests.sh python3
+    && ./ci-run-tests.sh python3

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,6 +1,7 @@
 ARG build_hdf5="NO"
 ARG build_pyne="NO"
 ARG pyne_test_base=openmc
+ENV pyne_base=${pyne_test_base}
 ARG ubuntu_version=22.04
 
 FROM ubuntu:${ubuntu_version} AS base_python
@@ -134,8 +135,7 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
     && pip install .
 
 # Build/Install PyNE from develop branch
-ARG pyne_test_base
-FROM ${pyne_test_base} AS pyne-dev
+FROM ${pyne_base} AS pyne-dev
 ARG build_hdf5
 ARG build_pyne
 
@@ -159,8 +159,7 @@ RUN if [ "$build_pyne" = "YES" ]; then \
     && ./ci-run-tests.sh python3
 
 # Build/Install PyNE from release branch
-ARG pyne_test_base
-FROM ${pyne_test_base} AS pyne
+FROM ${pyne_base} AS pyne
 ARG build_hdf5
 ARG build_pyne
 

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -151,6 +151,7 @@ RUN if [ "$build_pyne" = "YES" ]; then \
         cd $HOME \
         && nuc_data_make ; \
     fi \
+    && cd $HOME/opt/pyne/tests \
     && ./ci-run-tests.sh python3
 
 # Build/Install PyNE from release branch
@@ -172,4 +173,5 @@ RUN if [ "$build_pyne" = "YES" ]; then \
         cd $HOME \
         && nuc_data_make ; \
     fi \
+    && cd $HOME/opt/pyne/tests \
     && ./ci-run-tests.sh python3

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,5 +1,4 @@
 ARG build_hdf5="NO"
-ARG build_pyne="NO"
 ARG pyne_test_base=openmc
 ARG ubuntu_version=22.04
 
@@ -100,6 +99,7 @@ RUN export MOAB_HDF5_ARGS=""; \
 # put MOAB on the path
 ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
+ENV PYNE_MOAB_ARGS "--moab $HOME/opt/moab"
 
 FROM moab AS dagmc
 # build/install DAGMC
@@ -121,6 +121,7 @@ RUN cd /root \
     && make install \
     && cd ../.. \
     && rm -rf DAGMC
+ENV PYNE_DAGMC_ARGS "--dagmc $HOME/opt/dagmc"
 
 FROM dagmc AS openmc
 ARG build_hdf5
@@ -136,7 +137,6 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
 # Build/Install PyNE from develop branch
 FROM ${pyne_test_base} AS pyne-dev
 ARG build_hdf5
-ARG build_pyne
 
 RUN export PYNE_HDF5_ARGS="" ;\
     if [ "$build_hdf5" != "NO" ]; then \
@@ -146,21 +146,18 @@ RUN export PYNE_HDF5_ARGS="" ;\
     && git clone -b develop --single-branch https://github.com/pyne/pyne.git \
     && cd pyne \
     && python setup.py install --user \
-                                --moab $HOME/opt/moab --dagmc $HOME/opt/dagmc \
+                                $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
                                 $PYNE_HDF5_ARGS \
                                 --clean -j 3;
 ENV PATH $HOME/.local/bin:$PATH
-RUN if [ "$build_pyne" = "YES" ]; then \
-        cd $HOME \
-        && nuc_data_make ; \
-    fi \
+RUN cd $HOME \
+    && nuc_data_make ; \
     && cd $HOME/opt/pyne/tests \
     && ./ci-run-tests.sh python3
 
 # Build/Install PyNE from release branch
 FROM ${pyne_test_base} AS pyne
 ARG build_hdf5
-ARG build_pyne
 
 RUN export PYNE_HDF5_ARGS="" ;\
     if [ "$build_hdf5" != "NO" ]; then \
@@ -169,13 +166,11 @@ RUN export PYNE_HDF5_ARGS="" ;\
 COPY . $HOME/opt/pyne
 RUN cd $HOME/opt/pyne \
     && python setup.py install --user \
-                                --moab $HOME/opt/moab --dagmc $HOME/opt/dagmc \
+                                $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
                                 $PYNE_HDF5_ARGS \
                                 --clean -j 3;
 ENV PATH $HOME/.local/bin:$PATH
-RUN if [ "$build_pyne" = "YES" ]; then \
-        cd $HOME \
-        && nuc_data_make ; \
-    fi \
+RUN cd $HOME \
+    && nuc_data_make ; \
     && cd $HOME/opt/pyne/tests \
     && ./ci-run-tests.sh python3


### PR DESCRIPTION
## Description
This is a continuation of [this PR](https://github.com/pyne/pyne/pull/1490). The difference between the two PRs is that this PR is based on a branch from the PyNE repo, while the old PR was based on a branch from my `bquan0` forked repo. The reason we decided to move the PR to a branch on the main repo was because we needed to push the PyNE image that we build in the `virtualbox_image.yml` workflow to the ghcr.io (package space) of PyNE. 

This is the [d2vm](https://github.com/linka-cloud/d2vm) command we use to convert the PyNE image from ghcr.io into a virtual box disk image.

## Motivation and Context
This change allows users of PyNE to download a prebuilt VM with PyNE installed instead of having to build PyNE on their own computers. 

## Changes
Compared to where we left off on the old PR, the latest commits of this PR attempts to add the 3 requested things from the latest comment by @gonuke (not counting the 4th item because it's already accomplished by making this PR):
1. make the workflow only run on `release`. (Actually, it's probably not working as intended right now because [the workflow still ran](https://github.com/pyne/pyne/actions/runs/5814771722/job/15765273913) even though I added that run condition)
2. build PyNE once, not twice. I tried to do this by adding a condition in the composite action that will allow it to run the tests without building PyNE first, but it seems like the [tests don't work](https://github.com/pyne/pyne/actions/runs/5814771722/job/15765273913) if PyNE isn't built in the composite action. I'm thinking of just removing the `BuildTest` job from the workflow, but that means that the `pyne` image isn't being tested.
3. after building and testing the `pyne` image, tag it as `latest`. I added this job to `virtualbox_image.yml` and made the `virtualbox_image_build` job dependent to it. It's the same code that's found in `docker_publish.yml`