### PR TITLE
Install packages with Conda in Dockerfile

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -35,7 +35,11 @@ jobs:
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
-          - stage: dagmc
+          - pkg_mgr: 'apt'
+            stage: dagmc
+            hdf5: _hdf5
+          - pkg_mgr: 'conda'
+            stage: dagmc
             hdf5: _hdf5
       fail-fast: false
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        pkg_mgr: ['apt', 'conda']
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
@@ -39,7 +40,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
+        pkg_mgr: ['apt', 'conda']
         hdf5: ['']
         hdf5_build_arg: ['NO']
         include:
@@ -52,14 +53,14 @@ jobs:
       - uses: firehed/multistage-docker-build-action@v1
         id: build_all_stages
         with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
-          stages: base_python, moab, dagmc
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}
+          stages: common_base, ${{ matrix.pkg_mgr }}_deps, base_python, moab, dagmc
           server-stage: openmc
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=openmc
+          build-args: pkg_mgr = ${{ matrix.pkg_mgr }}, build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=openmc
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
@@ -69,6 +70,7 @@ jobs:
     
     strategy:
       matrix: 
+        pkg_mgr: ['apt', 'conda']
         pyne_test_base: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         hdf5_build_arg: ['NO']
@@ -97,14 +99,14 @@ jobs:
       - uses: firehed/multistage-docker-build-action@v1
         id: multistage_build_and_test
         with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}
           stages: ${{ matrix.pyne_test_base }}
           server-stage: pyne-dev
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
+          build-args: pkg_mgr = ${{ matrix.pkg_mgr }}, build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to
@@ -115,13 +117,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        pkg_mgr: ['apt', 'conda']
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
           - stage: dagmc
             hdf5: _hdf5
 
-    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
+    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
 
     steps:
       - name: Log in to the Container registry
@@ -134,5 +137,5 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -30,7 +30,11 @@ jobs:
         hdf5: ['']
         hdf5_build_arg: ['NO']
         include:
-          - hdf5: _hdf5
+          - pkg_mgr: 'apt'
+            hdf5: _hdf5
+            hdf5_build_arg: hdf5-1_12_0
+          - pkg_mgr: 'conda'
+            hdf5: _hdf5
             hdf5_build_arg: hdf5-1_12_0
       fail-fast: false
 
@@ -75,7 +79,12 @@ jobs:
         hdf5: ['']
         hdf5_build_arg: ['NO']
         include:
-          - pyne_test_base: dagmc
+          - pkg_mgr: 'apt'
+            pyne_test_base: dagmc
+            hdf5: _hdf5
+            hdf5_build_arg: hdf5-1_12_0
+          - pkg_mgr: 'conda'
+            pyne_test_base: dagmc
             hdf5: _hdf5
             hdf5_build_arg: hdf5-1_12_0
       fail-fast: false
@@ -121,7 +130,11 @@ jobs:
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
-          - stage: dagmc
+          - pkg_mgr: 'apt'
+            stage: dagmc
+            hdf5: _hdf5
+          - pkg_mgr: 'apt'
+            stage: dagmc
             hdf5: _hdf5
 
     name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -36,7 +36,7 @@ jobs:
         uses: firehed/multistage-docker-build-action@v1
         id: build_pyne
         with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}
           stages: openmc
           server-stage: pyne
           quiet: false
@@ -61,14 +61,14 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:stable
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}/pyne:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}/pyne:stable
 
       - name: Push Image to release tag img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:${{ github.ref_name }}
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}/pyne:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}/pyne:${{ github.ref_name }}
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]
@@ -102,7 +102,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.pkg_mgr }}/pyne:stable_${{ github.ref_name }} -p ${{ env.VM_PASSWORD }} -o pyne_${{ github.ref_name }}.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}/pyne:stable_${{ github.ref_name }} -p ${{ env.VM_PASSWORD }} -o pyne_${{ github.ref_name }}.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/virtualbox_image.yml
+++ b/.github/workflows/virtualbox_image.yml
@@ -16,6 +16,10 @@ env:
 jobs:
   pyne_image_build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        pkg_mgr: ['apt', 'conda']
+      fail-fast: false
 
     steps:
       - name: Checkout repository
@@ -28,12 +32,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # before merging, change tag-latest-on-default to true
       - name: Build PyNE docker image
         uses: firehed/multistage-docker-build-action@v1
         id: build_pyne
         with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}
           stages: openmc
           server-stage: pyne
           quiet: false
@@ -43,6 +46,10 @@ jobs:
   pushing_test_stable_img:
     needs: [pyne_image_build]
     runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        pkg_mgr: ['apt', 'conda']
+      fail-fast: false
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -54,18 +61,22 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:stable
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:stable
 
       - name: Push Image to release tag img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}/pyne:${{ github.ref_name }}
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.pkg_mgr }}/pyne:${{ github.ref_name }}
 
   virtualbox_image_build:
     needs: [pushing_test_stable_img]
     runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        pkg_mgr: ['apt', 'conda']
+      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -91,7 +102,7 @@ jobs:
             qemu-utils            
           curl -sL "https://github.com/linka-cloud/d2vm/releases/download/v0.2.0/d2vm_v0.2.0_linux_amd64.tar.gz" | tar -xvz d2vm
           sudo mv d2vm /usr/local/bin/
-          sudo d2vm convert ghcr.io/${{ github.repository_owner  }}/pyne_ubuntu_22.04_py3/pyne:stable_${{ github.ref_name }} -p ${{ env.VM_PASSWORD }} -o pyne_${{ github.ref_name }}.vdi
+          sudo d2vm convert ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.pkg_mgr }}/pyne:stable_${{ github.ref_name }} -p ${{ env.VM_PASSWORD }} -o pyne_${{ github.ref_name }}.vdi
 
       - name: Upload VirtualBox image as artifact
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Next Version
 **Change**
    * Move tests from nose to pytest (#1478 #1493)
    * Update MOAB dead link and add PyNE logo to readme file (#1481)
+   * Install packages with conda in Dockerfile (#1508)
 
 **Fix**
    * Add missing rxname offsets (#1482)

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -42,7 +42,8 @@ RUN apt-get update \
             progress
 
 FROM common_base AS conda_deps
-RUN apt-get install -y --fix-missing \
+RUN apt-get update \
+    && apt-get install -y --fix-missing \
         wget \
         bzip2 \
         ca-certificates \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -54,7 +54,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh
 
-ENV PATH /opt/conda/bin:$
+ENV PATH /opt/conda/bin:$PATH
 
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -42,11 +42,11 @@ RUN apt-get update \
             progress
 
 FROM common_base AS conda_deps
-RUN apt install -y \
+RUN apt-get install -y --fix-missing \
         wget \
         bzip2 \
         ca-certificates \
-    && apt clean -y all
+    && apt-get clean -y
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \


### PR DESCRIPTION
## Description
This PR adds a `conda_deps` stage to the `ubuntu_22.04-dev.dockerfile`, which provides an alternative to using `apt` and `pip` to install packages. The new stages in the dockerfile are:
- `common_base`: does some basic ubuntu setup
- `apt_deps`: installs packages via `apt` and `pip`
- `conda_deps`: installs packages via `conda`
- `base_python`: installs hdf5 if specified. 

Note: `apt_deps` and `conda_deps` are mutually exclusive stages (only one is used in a given build)

I also made the necessary changes in the `docker_publish.yml` workflow to make the multistage action build these new stages. 

These conda stage changes were mostly copied from the [Dockerfile in the Cyclus repo](https://github.com/cyclus/cyclus/blob/main/docker/Dockerfile), with the packages installed in the `conda_deps` stage modified to fit PyNE. 

## Motivation and Context
This change provides another option to install packages and is also part of the process of updating the conda-forge feedstock for PyNE. 

## Behavior
The changes seem to be working according to [this workflow run](https://github.com/bquan0/pyne/actions/runs/6960830462). However, it is possible that I missed some packages in the `conda_deps` stage since I'm not sure of the names of the conda packages that correspond to their `apt` and `pip` counterparts. 
