### PR TITLE
add apt and conda changes to build_test.yml

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,20 +31,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pkg_mgr: ['apt', 'conda']
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
-          - pkg_mgr: 'apt'
-            stage: dagmc
-            hdf5: _hdf5
-          - pkg_mgr: 'conda'
-            stage: dagmc
+          - stage: dagmc
             hdf5: _hdf5
       fail-fast: false
 
     container:
-      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,15 +31,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        pkg_mgr: ['apt', 'conda']
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
-          - stage: dagmc
+          - pkg_mgr: 'apt'
+            stage: dagmc
+            hdf5: _hdf5
+          - pkg_mgr: 'conda'
+            stage: dagmc
             hdf5: _hdf5
       fail-fast: false
 
     container:
-      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -133,7 +133,7 @@ jobs:
           - pkg_mgr: 'apt'
             stage: dagmc
             hdf5: _hdf5
-          - pkg_mgr: 'apt'
+          - pkg_mgr: 'conda'
             stage: dagmc
             hdf5: _hdf5
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Next Version
 **Change**
    * Move tests from nose to pytest (#1478 #1493)
    * Update MOAB dead link and add PyNE logo to readme file (#1481)
-   * Install packages with conda in Dockerfile (#1509)
+   * Install packages with conda in Dockerfile (#1509 #1510)
 
 **Fix**
    * Add missing rxname offsets (#1482)


### PR DESCRIPTION
## Description
This is a continuation of #1509. #1509 made changes to `docker_publish.yml` and the Dockerfile to make it build new images using either the package manager `apt` or `conda`. This PR makes changes to `build_test.yml` to make sure we test the new images being built. 

## Behavior
Regrettably, one of the tests isn't passing in [this workflow run](https://github.com/pyne/pyne/actions/runs/6984643775/job/19007768351) because in the `pushing_test_stable_img` job of `docker_publish.yml`, both of the special includes were `apt` instead of one `apt` and one `conda`. Therefore, that test will not pass until after this PR is merged with the typo fix in `docker_publish.yml`. 