### PR TITLE
Add apt and conda changes to build_test.yml: Part 2

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,15 +31,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        pkg_mgr: ['apt', 'conda']
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
-          - stage: dagmc
+          - pkg_mgr: 'apt'
+            stage: dagmc
+            hdf5: _hdf5
+          - pkg_mgr: 'conda'
+            stage: dagmc
             hdf5: _hdf5
       fail-fast: false
 
     container:
-      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+      image: ghcr.io/pyne/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
 
     steps:
       - name: Checkout repository
@@ -50,4 +55,3 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           hdf5: ${{ matrix.hdf5 }}
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Next Version
 **Change**
    * Move tests from nose to pytest (#1478 #1493)
    * Update MOAB dead link and add PyNE logo to readme file (#1481)
-   * Install packages with conda in Dockerfile (#1509 #1510)
+   * Install packages with conda in Dockerfile (#1509 #1510 #1511)
 
 **Fix**
    * Add missing rxname offsets (#1482)


### PR DESCRIPTION
## Description
Does what #1510 tried to do, but couldn't because there was a typo in `docker_publish.yml` in the last job where it was tagging images with `stable`. Basically, I did the special include for `apt` twice instead of doing one special include for `apt` and another for `conda`, which meant the conda + hdf5 image was never getting tagged with `stable`. [This workflow](https://github.com/pyne/pyne/actions/runs/6985660935/job/19010284234) shows that the conda + hdf5 is now indeed getting tagged with `stable`, so the `build_test.yml` workflow should work properly. 