### PR TITLE
Fix Type Mismatch Error in PyNE's ENSDF Processing Module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ PyNE Change Log
 
 Next Version
 ============
-
+**Fix**
+   * Fix Type Mismatch Error in PyNE's ENSDF Processing Module (#1519)
 
 v0.7.8
 ======

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ ELSE()
 ENDIF()
 
 option ( ENABLE_SPATIAL_SOLVERS     "Should build AHOT spatial solvers?"                 OFF )
-option ( ENABLE_ENSDF_PROCESSIONG   "Should build ENSDF processing tools?"               OFF )
+option ( ENABLE_ENSDF_PROCESSIONG   "Should build ENSDF processing tools?"               ON )
 
 include(PyneMacros)
 pyne_print_logo()  # Beware of dragons

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -122,7 +122,7 @@ macro(pyne_setup_fortran)
 
   # add -fallow-argument-mismatch to fix build with gfortran 10+
   # https://github.com/pyne/pyne/issues/1416
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+  #set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
 endmacro()
 
 

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -122,7 +122,7 @@ macro(pyne_setup_fortran)
 
   # add -fallow-argument-mismatch to fix build with gfortran 10+
   # https://github.com/pyne/pyne/issues/1416
-  #set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
 endmacro()
 
 

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -119,6 +119,10 @@ macro(pyne_setup_fortran)
     set(CMAKE_Fortran_FLAGS_RELEASE "-fpic")
     set(CMAKE_Fortran_FLAGS_DEBUG   "-fpic")
   endif(Fortran_COMPILER_NAME MATCHES "gfortran.*")
+
+  # add -fallow-argument-mismatch to fix build with gfortran 10+
+  # https://github.com/pyne/pyne/issues/1416
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
 endmacro()
 
 


### PR DESCRIPTION
## Description
This PR addresses the type mismatch error encountered during the installation of PyNE when enabling `ENABLE_ENSDF_PROCESSING` with `gfortran 10+`. The error arises due to discrepancies in the argument types passed to the `CNVU2S` subroutine calls in the `alphad.f` file.

## Changes
- Added the `-fallow-argument-mismatch` flag to `CMAKE_Fortran_FLAGS` in order to allow for type mismatches during compilation.

## Related Issue
Fixes #1416 