### PR TITLE
Add separate workflow and dockerfile for conda build

### DIFF
--- a/.github/workflows/conda_docker.yml
+++ b/.github/workflows/conda_docker.yml
@@ -1,0 +1,138 @@
+name: Build & Publish docker image for PyNE-CI
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'docker/*'
+      - '.github/workflows/conda_docker.yml'
+      - '.github/actions/build-test/action.yml'
+  push:
+    paths:
+      - 'docker/*'
+      - '.github/workflows/conda_docker.yml'
+      - '.github/actions/build-test/action.yml'
+
+env:
+  DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3_conda
+  USE_LATEST_TAG: false
+
+jobs:
+  # builds and pushes docker images of various stages to ghcr.
+  # These docker images are also stored in ghcr and can be pulled
+  # to be built upon by the subsequent stage.
+  multistage_image_build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        hdf5: ['']
+        hdf5_build_arg: ['NO']
+        include:
+          - hdf5: _hdf5
+            hdf5_build_arg: hdf5-1_12_0
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Tag images with latest if on the main repo's develop branch
+        if: github.repository_owner == 'pyne' && github.ref_name == 'develop'
+        run: echo "USE_LATEST_TAG=true" >> $GITHUB_ENV
+
+      # build base python, moab, dagmc, openmc using multistage docker build action
+      - uses: firehed/multistage-docker-build-action@v1
+        id: build_all_stages
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
+          stages: base_python, moab, dagmc
+          server-stage: openmc
+          quiet: false
+          parallel: true
+          tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
+          dockerfile: docker/conda_build.dockerfile
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=openmc
+
+  # Downloads the images uploaded to ghcr in previous stages and runs pyne
+  # tests to check that they work.
+  BuildTest:
+    needs: [multistage_image_build]
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix: 
+        pyne_test_base: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
+        hdf5_build_arg: ['NO']
+        include:
+          - pyne_test_base: dagmc
+            hdf5: _hdf5
+            hdf5_build_arg: hdf5-1_12_0
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Tag images with latest if on the main repo's develop branch
+        if: github.repository_owner == 'pyne' && github.ref_name == 'develop'
+        run: echo "USE_LATEST_TAG=true" >> $GITHUB_ENV
+
+      # build test stage and pyne-dev stage using multistage docker build action
+      - uses: firehed/multistage-docker-build-action@v1
+        id: multistage_build_and_test
+        with:
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
+          stages: ${{ matrix.pyne_test_base }}
+          server-stage: pyne-dev
+          quiet: false
+          parallel: true
+          tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
+          dockerfile: docker/conda_build.dockerfile
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
+
+  # if the previous step that tests the docker images passes, then the images
+  # can be copied from the ghcr where they are saved using :ci_testing tags to
+  # :latest and :stable tags.
+  pushing_test_stable_img:
+    if: github.repository_owner == 'pyne' && github.ref_name == 'develop'
+    needs: [BuildTest]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [base_python, moab, dagmc, openmc]
+        hdf5: ['']
+        include:
+          - stage: dagmc
+            hdf5: _hdf5
+
+    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3_conda${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Image to stable img
+        uses: akhilerm/tag-push-action@v2.1.0
+        with:
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable

--- a/.github/workflows/conda_docker.yml
+++ b/.github/workflows/conda_docker.yml
@@ -53,7 +53,7 @@ jobs:
         id: build_all_stages
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
-          stages: base_python, moab, dagmc
+          stages: base_conda, moab, dagmc
           server-stage: openmc
           quiet: false
           parallel: true
@@ -69,7 +69,7 @@ jobs:
     
     strategy:
       matrix: 
-        pyne_test_base: [base_python, moab, dagmc, openmc]
+        pyne_test_base: [base_conda, moab, dagmc, openmc]
         hdf5: ['']
         hdf5_build_arg: ['NO']
         include:
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stage: [base_python, moab, dagmc, openmc]
+        stage: [base_conda, moab, dagmc, openmc]
         hdf5: ['']
         include:
           - stage: dagmc

--- a/.github/workflows/conda_docker.yml
+++ b/.github/workflows/conda_docker.yml
@@ -93,13 +93,13 @@ jobs:
         if: github.repository_owner == 'pyne' && github.ref_name == 'develop'
         run: echo "USE_LATEST_TAG=true" >> $GITHUB_ENV
 
-      # build test stage and pyne-dev stage using multistage docker build action
+      # build test stage and pyne stage using multistage docker build action
       - uses: firehed/multistage-docker-build-action@v1
         id: multistage_build_and_test
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
           stages: ${{ matrix.pyne_test_base }}
-          server-stage: pyne-dev
+          server-stage: pyne
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}

--- a/.github/workflows/conda_docker.yml
+++ b/.github/workflows/conda_docker.yml
@@ -1,4 +1,4 @@
-name: Build & Publish docker image for PyNE-CI
+name: Build & Publish Conda docker image for PyNE-CI
 
 on:
   # allows us to run workflows manually

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -30,7 +30,7 @@ jobs:
         hdf5_build_arg: ['NO']
         include:
           - hdf5: _hdf5
-            hdf5_build_arg: hdf5-1_12_0
+            hdf5_build_arg: hdf5-1_10_7
       fail-fast: false
 
     steps:
@@ -75,7 +75,7 @@ jobs:
         include:
           - pyne_test_base: dagmc
             hdf5: _hdf5
-            hdf5_build_arg: hdf5-1_12_0
+            hdf5_build_arg: hdf5-1_10_7
       fail-fast: false
 
     steps:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
           stages: ${{ matrix.pyne_test_base }}
-          server-stage: pyne-dev
+          server-stage: pyne
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -26,15 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        pkg_mgr: ['apt', 'conda']
         hdf5: ['']
         hdf5_build_arg: ['NO']
         include:
-          - pkg_mgr: 'apt'
-            hdf5: _hdf5
-            hdf5_build_arg: hdf5-1_12_0
-          - pkg_mgr: 'conda'
-            hdf5: _hdf5
+          - hdf5: _hdf5
             hdf5_build_arg: hdf5-1_12_0
       fail-fast: false
 
@@ -57,14 +52,14 @@ jobs:
       - uses: firehed/multistage-docker-build-action@v1
         id: build_all_stages
         with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}
-          stages: common_base, ${{ matrix.pkg_mgr }}_deps, base_python, moab, dagmc
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
+          stages: base_python, moab, dagmc
           server-stage: openmc
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: pkg_mgr = ${{ matrix.pkg_mgr }}, build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=openmc
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=openmc
 
   # Downloads the images uploaded to ghcr in previous stages and runs pyne
   # tests to check that they work.
@@ -74,17 +69,11 @@ jobs:
     
     strategy:
       matrix: 
-        pkg_mgr: ['apt', 'conda']
         pyne_test_base: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         hdf5_build_arg: ['NO']
         include:
-          - pkg_mgr: 'apt'
-            pyne_test_base: dagmc
-            hdf5: _hdf5
-            hdf5_build_arg: hdf5-1_12_0
-          - pkg_mgr: 'conda'
-            pyne_test_base: dagmc
+          - pyne_test_base: dagmc
             hdf5: _hdf5
             hdf5_build_arg: hdf5-1_12_0
       fail-fast: false
@@ -108,14 +97,14 @@ jobs:
       - uses: firehed/multistage-docker-build-action@v1
         id: multistage_build_and_test
         with:
-          repository: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}
+          repository: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}
           stages: ${{ matrix.pyne_test_base }}
           server-stage: pyne-dev
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.USE_LATEST_TAG }}
           dockerfile: docker/ubuntu_22.04-dev.dockerfile
-          build-args: pkg_mgr = ${{ matrix.pkg_mgr }}, build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
+          build-args: build_hdf5=${{ matrix.hdf5_build_arg }}, pyne_test_base=${{ matrix.pyne_test_base }}
 
   # if the previous step that tests the docker images passes then the images
   # can be copied from the ghcr where they are saved using :ci_testing tags to
@@ -126,18 +115,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pkg_mgr: ['apt', 'conda']
         stage: [base_python, moab, dagmc, openmc]
         hdf5: ['']
         include:
-          - pkg_mgr: 'apt'
-            stage: dagmc
-            hdf5: _hdf5
-          - pkg_mgr: 'conda'
-            stage: dagmc
+          - stage: dagmc
             hdf5: _hdf5
 
-    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
+    name: "ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3${{ matrix.hdf5 }}/${{ matrix.stage }}: latest -> stable"
 
     steps:
       - name: Log in to the Container registry
@@ -150,5 +134,5 @@ jobs:
       - name: Push Image to stable img
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
-          dst: ${{ env.DOCKER_IMAGE_BASENAME }}_${{ matrix.pkg_mgr }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable
+          src: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:latest
+          dst: ${{ env.DOCKER_IMAGE_BASENAME }}${{ matrix.hdf5 }}/${{ matrix.stage }}:stable

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Version
 ============
 **Change**
    * Test install script on multiple Ubuntu versions (#1484)
+   * Add new workflow and dockerfile for conda build (#1527)
 
 **Fix**
    * Fix Type Mismatch Error in PyNE's ENSDF Processing Module (#1519)

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -9,8 +9,7 @@ ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV HOME /root
 
-# set default python version to 3.10
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
 
 RUN apt-get update \
     && apt-get install -y --fix-missing \
@@ -25,6 +24,10 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     rm ~/miniconda.sh
 
 ENV PATH /opt/conda/bin:$PATH
+
+# install python 3.10 and set it as default
+RUN conda install python=3.10
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -25,10 +25,8 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 
 ENV PATH /opt/conda/bin:$PATH
 
-# install python 3.10 and set it as default
+# install python 3.10 so we have imp python module
 RUN conda install python=3.10
-RUN python -v
-
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda
 RUN conda install -y conda-libmamba-solver
@@ -38,7 +36,10 @@ RUN conda uninstall -y conda-libmamba-solver
 RUN conda config --set solver classic
 RUN conda update -y --all && \
     mamba install -y \
+                gxx_linux-64 \
+                gcc_linux-64 \
                 cmake \
+                make \
                 git \
                 setuptools \
                 pytest \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -45,7 +45,7 @@ RUN conda update -y --all && \
                 numpy \
                 scipy \
                 nose \
-                hdf5<1.14 \
+                "hdf5<1.14" \
                 matplotlib \
                 git \
                 setuptools \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -45,7 +45,6 @@ RUN conda update -y --all && \
                 numpy \
                 scipy \
                 nose \
-                "hdf5<1.14" \
                 matplotlib \
                 git \
                 setuptools \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -79,7 +79,7 @@ RUN conda update -n base conda
 RUN mamba install conda-forge::dagmc
 
 FROM dagmc AS openmc
-RUN conda install conda-forge::openmc
+RUN mamba install conda-forge::openmc
 
 # Build/Install PyNE from release branch
 FROM ${pyne_test_base} AS pyne

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -25,7 +25,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 # install python 3.10 to match apt dockerfile
 RUN conda update conda
-RUN conda install python=3.10.0
+RUN conda install python<3.10
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda
 RUN conda install -y conda-libmamba-solver

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -71,7 +71,7 @@ RUN mkdir -p $HOME/opt
 RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
 
 FROM base_conda AS moab
-RUN conda install "conda-forge::moab==5.3.0"
+RUN conda install "conda-forge::moab=5.3.0"
 
 FROM moab AS dagmc
 RUN conda install conda-forge::dagmc

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -37,7 +37,7 @@ RUN conda update -y --all && \
                 pytest \
                 pytables \
                 jinja2 \
-                cython \
+                "cython<3" \
                 && \
     mamba install -y --force-reinstall libsqlite && \
     conda clean -y --all

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -9,6 +9,9 @@ ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV HOME /root
 
+# set default python version to 3.10
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
 RUN apt-get update \
     && apt-get install -y --fix-missing \
         wget \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -24,6 +24,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 ENV PATH /opt/conda/bin:$PATH
 
 # install python 3.10 to match apt dockerfile
+RUN conda update conda
 RUN conda install python=3.10.0
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -40,6 +40,14 @@ RUN conda update -y --all && \
                 gcc_linux-64 \
                 cmake \
                 make \
+                gfortran \
+                libblas \
+                liblapack \
+                eigen \
+                numpy \
+                scipy \
+                nose \
+                matplotlib \
                 git \
                 setuptools \
                 pytest \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -76,7 +76,7 @@ RUN conda install "conda-forge::moab=5.3.0"
 
 FROM moab AS dagmc
 RUN conda update -n base conda
-RUN conda install conda-forge::dagmc
+RUN mamba install conda-forge::dagmc
 
 FROM dagmc AS openmc
 RUN conda install conda-forge::openmc

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -23,8 +23,8 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 
 ENV PATH /opt/conda/bin:$PATH
 
-# install python 3.10 so we have imp python module
-RUN conda install python=3.10
+# install python 3.10 to match apt dockerfile
+RUN conda install python=3.10.0
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda
 RUN conda install -y conda-libmamba-solver

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -1,0 +1,91 @@
+ARG build_hdf5="NO"
+ARG pyne_test_base=openmc
+ARG ubuntu_version=22.04
+
+FROM ubuntu:${ubuntu_version} AS base_conda
+
+# Ubuntu Setup
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update \
+    && apt-get install -y --fix-missing \
+        wget \
+        bzip2 \
+        ca-certificates \
+    && apt-get clean -y
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
+
+ENV PATH /opt/conda/bin:$PATH
+
+RUN conda config --add channels conda-forge
+RUN conda update -n base -c defaults conda
+RUN conda install -y conda-libmamba-solver
+RUN conda config --set solver libmamba
+RUN conda install -y mamba
+RUN conda uninstall -y conda-libmamba-solver
+RUN conda config --set solver classic
+RUN conda update -y --all && \
+    mamba install -y \
+                cmake \
+                git \
+                libblas \
+                liblapack \
+                hdf5 \
+                setuptools \
+                pytest \
+                pytables \
+                jinja2 \
+                cython \
+                && \
+    mamba install -y --force-reinstall libsqlite && \
+    conda clean -y --all
+RUN mkdir -p `python -m site --user-site`
+
+# make starting directory
+RUN mkdir -p $HOME/opt
+RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
+
+# build HDF5
+ARG build_hdf5="NO"
+ENV HDF5_INSTALL_PATH=$HOME/opt/hdf5/$build_hdf5
+RUN if [ "$build_hdf5" != "NO" ]; then \
+        cd $HOME/opt \
+        && mkdir hdf5 \
+        && cd hdf5 \
+        && git clone --single-branch --branch $build_hdf5 https://github.com/HDFGroup/hdf5.git \
+        && cd hdf5 \
+        && ./configure --prefix=$HDF5_INSTALL_PATH --enable-shared \
+        && make -j 3 \
+        && make install \
+        && cd .. \
+        && rm -rf hdf5; \
+    fi
+# put HDF5 on the path
+ENV LD_LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LIBRARY_PATH
+
+FROM base_conda AS moab
+RUN conda install conda-forge::moab
+
+FROM moab AS dagmc
+RUN conda install conda-forge::dagmc
+
+FROM dagmc AS openmc
+RUN conda install conda-forge::openmc
+
+# Build/Install PyNE from release branch
+FROM ${pyne_test_base} AS pyne
+RUN conda install conda-forge::pyne
+
+ENV PATH $HOME/.local/bin:$PATH
+RUN cd $HOME \
+    && nuc_data_make \
+    && cd $HOME/opt/pyne/tests \
+    && ./ci-run-tests.sh python3
+
+ 

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -75,6 +75,7 @@ FROM base_conda AS moab
 RUN conda install "conda-forge::moab=5.3.0"
 
 FROM moab AS dagmc
+RUN conda update -n base conda
 RUN conda install conda-forge::dagmc
 
 FROM dagmc AS openmc

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -7,6 +7,7 @@ FROM ubuntu:${ubuntu_version} AS base_conda
 # Ubuntu Setup
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV HOME /root
 
 RUN apt-get update \
     && apt-get install -y --fix-missing \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -9,8 +9,6 @@ ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV HOME /root
 
-
-
 RUN apt-get update \
     && apt-get install -y --fix-missing \
         wget \
@@ -47,6 +45,7 @@ RUN conda update -y --all && \
                 numpy \
                 scipy \
                 nose \
+                hdf5<1.14 \
                 matplotlib \
                 git \
                 setuptools \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -25,7 +25,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 # install python 3.10 to match apt dockerfile
 RUN conda update conda
-RUN conda install python<3.10
+RUN conda install "python<3.10"
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda
 RUN conda install -y conda-libmamba-solver

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -54,6 +54,8 @@ RUN conda update -y --all && \
                 pytables \
                 jinja2 \
                 "cython<3" \
+                future \
+                progress \
                 && \
     mamba install -y --force-reinstall libsqlite && \
     conda clean -y --all

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -63,13 +63,16 @@ RUN conda install conda-forge::dagmc
 FROM dagmc AS openmc
 RUN conda install conda-forge::openmc
 
-# Build/Install PyNE from develop branch
-FROM ${pyne_test_base} AS pyne-dev
+# Build/Install PyNE from release branch
+FROM ${pyne_test_base} AS pyne
+ARG build_hdf5
 
 RUN export PYNE_HDF5_ARGS="" ;\
-    && cd $HOME/opt \
-    && git clone -b develop --single-branch https://github.com/pyne/pyne.git \
-    && cd pyne \
+    if [ "$build_hdf5" != "NO" ]; then \
+            export PYNE_HDF5_ARGS="--hdf5 $HDF5_INSTALL_PATH" ; \
+    fi;
+COPY . $HOME/opt/pyne
+RUN cd $HOME/opt/pyne \
     && python setup.py install --user \
                                 $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
                                 $PYNE_HDF5_ARGS \
@@ -79,3 +82,4 @@ RUN cd $HOME \
     && nuc_data_make \
     && cd $HOME/opt/pyne/tests \
     && ./ci-run-tests.sh python3
+    

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -71,7 +71,7 @@ RUN mkdir -p $HOME/opt
 RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
 
 FROM base_conda AS moab
-RUN conda install conda-forge::moab
+RUN conda install "conda-forge::moab==5.3.0"
 
 FROM moab AS dagmc
 RUN conda install conda-forge::dagmc

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -27,7 +27,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 # install python 3.10 and set it as default
 RUN conda install python=3.10
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+RUN python -v
 
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
     pip install --upgrade pip; \
-    pip install numpy==1.23 \
+    pip install numpy \
             scipy \
             cython \
             nose \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy \
             scipy \
-            cython \
+            "cython<3" \
             nose \
             pytest \
             tables \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -134,27 +134,6 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
     && git checkout tags/v0.13.0 \
     && pip install .
 
-# Build/Install PyNE from develop branch
-FROM ${pyne_test_base} AS pyne-dev
-ARG build_hdf5
-
-RUN export PYNE_HDF5_ARGS="" ;\
-    if [ "$build_hdf5" != "NO" ]; then \
-            export PYNE_HDF5_ARGS="--hdf5 $HDF5_INSTALL_PATH" ; \
-    fi \
-    && cd $HOME/opt \
-    && git clone -b develop --single-branch https://github.com/pyne/pyne.git \
-    && cd pyne \
-    && python setup.py install --user \
-                                $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
-                                $PYNE_HDF5_ARGS \
-                                --clean -j 3;
-ENV PATH $HOME/.local/bin:$PATH
-RUN cd $HOME \
-    && nuc_data_make \
-    && cd $HOME/opt/pyne/tests \
-    && ./ci-run-tests.sh python3
-
 # Build/Install PyNE from release branch
 FROM ${pyne_test_base} AS pyne
 ARG build_hdf5

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,15 +1,13 @@
-ARG pkg_mgr=apt
 ARG build_hdf5="NO"
 ARG pyne_test_base=openmc
 ARG ubuntu_version=22.04
 
-FROM ubuntu:${ubuntu_version} AS common_base
+FROM ubuntu:${ubuntu_version} AS base_python
 
 # Ubuntu Setup
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-FROM common_base AS apt_deps
 ENV HOME /root
 RUN apt-get update \
     && apt-get install -y --fix-missing \
@@ -31,7 +29,7 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \
-            'cython<3' \
+            cython \
             nose \
             pytest \
             tables \
@@ -41,46 +39,6 @@ RUN apt-get update \
             future \
             progress
 
-FROM common_base AS conda_deps
-RUN apt-get update \
-    && apt-get install -y --fix-missing \
-        wget \
-        bzip2 \
-        ca-certificates \
-    && apt-get clean -y
-
-RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh
-
-ENV PATH /opt/conda/bin:$PATH
-
-RUN conda config --add channels conda-forge
-RUN conda update -n base -c defaults conda
-RUN conda install -y conda-libmamba-solver
-RUN conda config --set solver libmamba
-RUN conda install -y mamba
-RUN conda uninstall -y conda-libmamba-solver
-RUN conda config --set solver classic
-RUN conda update -y --all && \
-    mamba install -y \
-                cmake \
-                git \
-                libblas \
-                liblapack \
-                hdf5 \
-                setuptools \
-                pytest \
-                pytables \
-                jinja2 \
-                "cython<3" \
-                && \
-    mamba install -y --force-reinstall libsqlite && \
-    conda clean -y --all
-RUN mkdir -p `python -m site --user-site`
-
-FROM ${pkg_mgr}_deps AS base_python
 # make starting directory
 RUN mkdir -p $HOME/opt
 RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
@@ -103,7 +61,6 @@ RUN if [ "$build_hdf5" != "NO" ]; then \
 # put HDF5 on the path
 ENV LD_LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LIBRARY_PATH
-
 
 FROM base_python AS moab
 ARG build_hdf5

--- a/tests/test_ace.py
+++ b/tests/test_ace.py
@@ -6,8 +6,7 @@ import pytest
 
 import pyne.ace
 
-@pytest.fixture(autouse=True)
-def setup_function():
+def setup_module():
     try:
         import urllib.request as urllib
     except ImportError:
@@ -102,6 +101,6 @@ def test_read_c12_binary():
     assert table.reactions[2].sigma[-1] == 1.00772
 
 
-def teardown_function():
+def teardown_module():
     if os.path.exists("C12-binary.ace"):
         os.remove("C12-binary.ace")

--- a/tests/test_ace.py
+++ b/tests/test_ace.py
@@ -7,7 +7,7 @@ import pytest
 import pyne.ace
 
 
-def setup():
+def setup_function():
     try:
         import urllib.request as urllib
     except ImportError:
@@ -102,6 +102,6 @@ def test_read_c12_binary():
     assert table.reactions[2].sigma[-1] == 1.00772
 
 
-def teardown():
+def teardown_function():
     if os.path.exists("C12-binary.ace"):
         os.remove("C12-binary.ace")

--- a/tests/test_ace.py
+++ b/tests/test_ace.py
@@ -6,7 +6,7 @@ import pytest
 
 import pyne.ace
 
-
+@pytest.fixture(autouse=True)
 def setup_function():
     try:
         import urllib.request as urllib

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -42,7 +42,7 @@ MATS = None
 O2HLS = None  # Origen Half-lives
 
 
-def setup_function():
+def setup_module():
     global MATS, O2HLS
     o2benchurl = "https://github.com/pyne/data/raw/master/" + H5NAME
     if not os.path.exists(H5NAME):

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -42,7 +42,7 @@ MATS = None
 O2HLS = None  # Origen Half-lives
 
 
-def setup():
+def setup_function():
     global MATS, O2HLS
     o2benchurl = "https://github.com/pyne/data/raw/master/" + H5NAME
     if not os.path.exists(H5NAME):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -127,10 +127,11 @@ def test_ve_center():
 
 def test_structured_mesh_from_coords():
     sm = Mesh(
-        structured_coords=[list(range(1, 5)), list(range(1, 4)), list(range(1, 3))], structured=True
+        structured_coords=[range(1, 5), range(1, 4), range(1, 3)], structured=True
     )
     assert sm.dims == [0, 0, 0, 3, 2, 1]
-    assert_array_equal(sm.structured_coords, [list(range(1, 5)), list(range(1, 4)), list(range(1, 3))])
+    for obs, exp in zip(sm.structured_coords, [range(1, 5), range(1, 4), range(1, 3)]):
+        assert_array_equal(obs, exp)
     assert sm.structured_ordering == "xyz"
 
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -127,10 +127,10 @@ def test_ve_center():
 
 def test_structured_mesh_from_coords():
     sm = Mesh(
-        structured_coords=[range(1, 5), range(1, 4), range(1, 3)], structured=True
+        structured_coords=[list(range(1, 5)), list(range(1, 4)), list(range(1, 3))], structured=True
     )
     assert sm.dims == [0, 0, 0, 3, 2, 1]
-    assert_array_equal(sm.structured_coords, [range(1, 5), range(1, 4), range(1, 3)])
+    assert_array_equal(sm.structured_coords, [list(range(1, 5)), list(range(1, 4)), list(range(1, 3))])
     assert sm.structured_ordering == "xyz"
 
 

--- a/tests/transmute/test_chainsolve.py
+++ b/tests/transmute/test_chainsolve.py
@@ -21,12 +21,12 @@ from pyne.transmute.chainsolve import Transmuter
 tm = None
 
 
-def setup():
+def setup_function():
     global tm
     tm = Transmuter()
 
 
-def teardown():
+def teardown_function():
     global tm
     del tm
 

--- a/tests/transmute/test_chainsolve.py
+++ b/tests/transmute/test_chainsolve.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import warnings
 
-from numpy.testing import dec, assert_array_equal
+from numpy.testing import assert_array_equal
 
 import numpy as np
 import tables as tb

--- a/tests/transmute/test_chainsolve.py
+++ b/tests/transmute/test_chainsolve.py
@@ -21,12 +21,12 @@ from pyne.transmute.chainsolve import Transmuter
 tm = None
 
 
-def setup_function():
+def setup_module():
     global tm
     tm = Transmuter()
 
 
-def teardown_function():
+def teardown_module():
     global tm
     del tm
 


### PR DESCRIPTION
## Description
This is a continuation of the closed PR #1516. In the dockerfile of that PR, we had one stage for installing dependencies via apt and one stage for installing dependencies via conda. However, we decided that it would be best to split up the apt build and the conda build for a few reasons
- the builds weren't working.
- When we had apt and conda in one dockerfile, we weren't able to take advantage of the fact that we could install `moab`, `dagmc`, and `openmc` via conda. This structural difference means that it's better to have 2 separate workflows and dockerfiles. 

In this PR, I have reverted `ubuntu_22.04-dev.dockerfile` and `docker_publish.yml` to what they were 7 months ago, right before any of the conda changes were made. The only change I made was to remove the `cython` restriction in the dockerfile. 

I also added a new `conda_build.dockerfile` and `conda_docker.yml` to build and test PyNE by installing packages via conda. It's still a work in progress and I'm open to any feedback about how I can change and improve it. 

## Motivation and Context
This PR will be the new PR to close #1515. 

## Changes
This should be a fix to the current situation on develop where conda builds weren't working properly at all. This should also be a better way to implement what #1516 was trying to accomplish. 

## Behavior
Current behavior is that we try to build PyNE via conda dependencies or apt dependencies in the same workflow/dockerfile. New behavior is that there will be separate workflows/dockerfiles.