### PR TITLE
Support Cython3+ (new)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Version
 ============
 **Change**
    * Test install script on multiple Ubuntu versions (#1484)
+   * Support Cython3+ (#1528)
 
 **Fix**
    * Fix Type Mismatch Error in PyNE's ENSDF Processing Module (#1519)

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
     pip install --upgrade pip; \
     pip install numpy==1.23 \
             scipy \
-            'cython<3' \
+            cython \
             nose \
             pytest \
             tables \
@@ -74,7 +74,7 @@ RUN conda update -y --all && \
                 pytest \
                 pytables \
                 jinja2 \
-                "cython<3" \
+                cython \
                 && \
     mamba install -y --force-reinstall libsqlite && \
     conda clean -y --all
@@ -118,7 +118,7 @@ RUN export MOAB_HDF5_ARGS=""; \
     && cd $HOME/opt \
     && mkdir moab \
     && cd moab \
-    && git clone --depth 1 --single-branch -b 5.3.0 https://bitbucket.org/fathomteam/moab \
+    && git clone --depth 1 --single-branch -b 5.5.1 https://bitbucket.org/fathomteam/moab \
     && cd moab \
     && mkdir build \
     && cd build \

--- a/pyne/cram.pyx
+++ b/pyne/cram.pyx
@@ -14,11 +14,11 @@ np.import_ufunc()
 cdef int i, j, idx
 N = c_cram.pyne_cram_transmute_info.n
 NNZ = c_cram.pyne_cram_transmute_info.nnz
-cpdef dict C_IJ = {}
+cdef dict C_IJ = {}
 for idx in range(c_cram.pyne_cram_transmute_info.nnz):
     C_IJ[c_cram.pyne_cram_transmute_info.i[idx], c_cram.pyne_cram_transmute_info.j[idx]] = idx
 IJ = C_IJ
-cpdef list C_NUCS = []
+cdef list C_NUCS = []
 for idx in range(c_cram.pyne_cram_transmute_info.n):
     b = c_cram.pyne_cram_transmute_info.nucs[idx]
     s = b.decode()

--- a/pyne/enrichment.pyx
+++ b/pyne/enrichment.pyx
@@ -180,7 +180,7 @@ cdef class Cascade:
         def __set__(self, value):
             cdef pyne.material._Material value_proxy
             value_proxy = pyne.material.Material(value, free_mat=not isinstance(value, pyne.material._Material))
-            (<cpp_enrichment.Cascade *> self._inst).mat_feed = value_proxy.mat_pointer[0]
+            (<cpp_enrichment.Cascade *> self._inst).mat_feed = (<pyne.cpp_material.Material> value_proxy.mat_pointer[0])
             self._mat_feed = None
 
     property mat_prod:
@@ -197,7 +197,7 @@ cdef class Cascade:
         def __set__(self, value):
             cdef pyne.material._Material value_proxy
             value_proxy = pyne.material.Material(value, free_mat=not isinstance(value, pyne.material._Material))
-            (<cpp_enrichment.Cascade *> self._inst).mat_prod = value_proxy.mat_pointer[0]
+            (<cpp_enrichment.Cascade *> self._inst).mat_prod = (<pyne.cpp_material.Material> value_proxy.mat_pointer[0])
             self._mat_prod = None
 
     property mat_tail:
@@ -214,7 +214,7 @@ cdef class Cascade:
         def __set__(self, value):
             cdef pyne.material._Material value_proxy
             value_proxy = pyne.material.Material(value, free_mat=not isinstance(value, pyne.material._Material))
-            (<cpp_enrichment.Cascade *> self._inst).mat_tail = value_proxy.mat_pointer[0]
+            (<cpp_enrichment.Cascade *> self._inst).mat_tail = (<pyne.cpp_material.Material> value_proxy.mat_pointer[0])
             self._mat_tail = None
 
     property l_t_per_feed:

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -247,7 +247,7 @@ cdef class _MaterialLibrary:
         cdef cpp_pair[std_string, cpp_material.Material] item
         value_proxy = material.Material(
             value, free_mat=not isinstance(value, material._Material))
-        self._inst.add_material(ensure_material_key(key), deref(( < material._Material > value_proxy).mat_pointer))
+        self._inst.add_material(ensure_material_key(key), <cpp_material.Material> deref(( < material._Material > value_proxy).mat_pointer))
 
     def __getitem__(self, key):
         cdef shared_ptr[cpp_material.Material] c_mat


### PR DESCRIPTION
## Description
This PR includes changes to support the use of Cython3+ in building PyNE.  Replaces #1525 

## Motivation and Context
It removes the pin of `cython<3` in the Dockerfile, closes #1522 

## Changes
Dependency update

## Behavior
Current behavior: PyNE build fails on the Cython compilation of `enrichment.pyx`, `material_library.pyx`, and `cram.pyx` when using Cython3+
New behavior: PyNE build succeeds using Cython3+

## Other Information
This updates the MOAB version used in `docker/ubuntu_22.04-dev.dockerfile` to a 5.5.1, a version that supports Cython3+. 

