### PR TITLE
better reference to python

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash -l {0}
       run: |
         cd $GITHUB_WORKSPACE
-        python setup.py install --user --clean --hdf5 /root/opt/hdf5/hdf5-1_14_3" ${{ env.ADD_FLAG}}
+        python setup.py install --user --clean --hdf5 /root/opt/hdf5/hdf5-1_14_3 ${{ env.ADD_FLAG}}
         export PATH="$PATH:/github/home/.local/bin"
         cd ../
         nuc_data_make

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: The docker stage that will be used as the docker image for testing.
     required: true
     default: ''
-  hdf5:
-    description: Information about which version of HDF5 will be used for testing.
-    required: true
-    default: ''
 runs:
   using: "composite"
   steps: 
@@ -22,9 +18,6 @@ runs:
         if [[ "${{ inputs.stage }}" == "dagmc" ]]; then
           export ADD_FLAG="${ADD_FLAG} --dagmc /root/opt/dagmc"
         fi
-        if [[ "${{ inputs.hdf5 }}" == "_hdf5" ]]; then
-          export ADD_FLAG="${ADD_FLAG} --hdf5 /root/opt/hdf5/hdf5-1_14_3"
-        fi
         export ADD_FLAG="${ADD_FLAG} "
         echo "ADD_FLAG=${ADD_FLAG}" >> $GITHUB_ENV
         
@@ -32,7 +25,7 @@ runs:
       shell: bash -l {0}
       run: |
         cd $GITHUB_WORKSPACE
-        python setup.py install --user --clean ${{ env.ADD_FLAG}}
+        python setup.py install --user --clean --hdf5 /root/opt/hdf5/hdf5-1_14_3" ${{ env.ADD_FLAG}}
         export PATH="$PATH:/github/home/.local/bin"
         cd ../
         nuc_data_make

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,4 +45,3 @@ jobs:
         uses: ./.github/actions/build-test
         with:
           stage: ${{ matrix.stage }}
-          hdf5: ${{ matrix.hdf5 }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -7,12 +7,10 @@ on:
     paths:
       - 'docker/*'
       - '.github/workflows/docker_publish.yml'
-      - '.github/actions/build-test/action.yml'
   push:
     paths:
       - 'docker/*'
       - '.github/workflows/docker_publish.yml'
-      - '.github/actions/build-test/action.yml'
 
 env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -7,10 +7,12 @@ on:
     paths:
       - 'docker/*'
       - '.github/workflows/docker_publish.yml'
+      - '.github/actions/build-test/action.yml'
   push:
     paths:
       - 'docker/*'
       - '.github/workflows/docker_publish.yml'
+      - '.github/actions/build-test/action.yml'
 
 env:
   DOCKER_IMAGE_BASENAME: ghcr.io/${{ github.repository_owner }}/pyne_ubuntu_22.04_py3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Next Version
       * new download location for KAERI data archive
       * do not try to download missing (super heavy) data from KAERI
       * update material_library writing interface
+   * reference python_executable rather than assuming `python` exists ()
 
 v0.7.8
 ======

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(PYNE_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}" ${PYNE_INCLUDE_DIRS}
     PARENT_SCOPE)
 
-execute_process(COMMAND python "${CMAKE_CURRENT_LIST_DIR}/../pyne/pyne_version.py" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../pyne/pyne_version.py" WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 pyne_download_platform()
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
## Description
Instead of relying on `python` being on the path with exactly that name, refer to `$PYTHON_EXECUTABLE` in `CMakeLists.txt` files.

## Motivation and Context
PyNE runs python during CMake to generate the `pyne_version.h` file that is included in all C++.  This is done with a CMake `execute_process` where the `COMMAND` has historically been specified as `python`.  Not all systems have a python executable with that name; many are now only `python3`.  Our CI always generates a `python` executable so we don't see this result.

Fixes #1530 

## Changes
Change the remaining reference to a bare `python` executable to the `$PYTHON_EXECUTABLE` discovered in the top level CMake process.
