### PR TITLE
Remove imp module from tests to support Python 3.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Next Version
       * update material_library writing interface
    * reference python_executable rather than assuming `python` exists ()
    * Update FindMOAB to use MOAB config file (#1526)
+   * Remove imp module from tests to support Python 3.12 (#1543)
 
 v0.7.8
 ======

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -23,7 +23,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 # install python 3.10 because that's what apt uses
 RUN conda update conda
-RUN conda install "python=3.10.12"
+RUN conda install "python=3.12"
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda
 RUN conda install -y conda-libmamba-solver

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -52,6 +52,7 @@ RUN conda update -y --all && \
                 cython \
                 future \
                 progress \
+                meson \
                 && \
     conda clean -y --all
 RUN mkdir -p `python -m site --user-site`

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -23,7 +23,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 # install python 3.10 because that's what apt uses
 RUN conda update conda
-RUN conda install "python=3.10"
+RUN conda install "python=3.10.12"
 RUN conda config --add channels conda-forge
 RUN conda update -n base -c defaults conda
 RUN conda install -y conda-libmamba-solver

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -53,6 +53,7 @@ RUN conda update -y --all && \
                 future \
                 progress \
                 meson \
+                expat \
                 && \
     conda clean -y --all
 RUN mkdir -p `python -m site --user-site`

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -33,6 +33,7 @@ RUN conda uninstall -y conda-libmamba-solver
 RUN conda config --set solver classic
 RUN conda update -y --all && \
     mamba install -y \
+                expat \
                 gxx_linux-64 \
                 gcc_linux-64 \
                 cmake \
@@ -53,7 +54,6 @@ RUN conda update -y --all && \
                 future \
                 progress \
                 meson \
-                expat \
                 && \
     conda clean -y --all
 RUN mkdir -p `python -m site --user-site`

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -15,23 +15,18 @@ RUN apt-get update \
     && apt-get clean -y
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh
-
+    wget --quiet "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge.sh && \
+    /bin/bash ~/miniforge.sh -b -p /opt/conda && \
+    rm ~/miniforge.sh
+    
 ENV PATH /opt/conda/bin:$PATH
 
 # install python 3.10 because that's what apt uses
 RUN conda update conda
 RUN conda install "python=3.12"
-RUN conda config --add channels conda-forge
-RUN conda update -n base -c defaults conda
-RUN conda install -y conda-libmamba-solver
-RUN conda config --set solver libmamba
-RUN conda install -y mamba
-RUN conda uninstall -y conda-libmamba-solver
-RUN conda config --set solver classic
-RUN conda update -y --all && \
+RUN mamba update -n base conda mamba && \
+    mamba update -y python --no-pin && \
+    mamba update -y --all && \
     mamba install -y \
                 expat \
                 gxx_linux-64 \
@@ -55,12 +50,11 @@ RUN conda update -y --all && \
                 progress \
                 meson \
                 && \
-    conda clean -y --all
-RUN mkdir -p `python -m site --user-site`
-
-ENV CC /opt/conda/bin/x86_64-conda_cos6-linux-gnu-gcc
-ENV CXX /opt/conda/bin/x86_64-conda_cos6-linux-gnu-g++
-ENV CPP /opt/conda/bin/x86_64-conda_cos6-linux-gnu-cpp
+    mamba clean -y --all
+RUN mkdir -p $(python3 -m site --user-site)
+ENV CC /opt/conda/bin/x86_64-conda-linux-gnu-gcc
+ENV CXX /opt/conda/bin/x86_64-conda-linux-gnu-g++
+ENV CPP /opt/conda/bin/x86_64-conda-linux-gnu-cpp
 
 # install MOAB
 RUN conda install "conda-forge::moab=5.5.1"

--- a/pyne/xs/channels.py
+++ b/pyne/xs/channels.py
@@ -445,7 +445,7 @@ def chi(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None, eres=101)
         for g in range(G):
             E_space = np.logspace(np.log10(E_g[g]), np.log10(E_g[g + 1]), eres)
             dnumer = models.chi(E_space)
-            numer = scipy.integrate.trapz(dnumer, E_space)
+            numer = scipy.integrate.trapezoid(dnumer, E_space)
             denom = E_g[g + 1] - E_g[g]
             chi_g[g] = numer / denom
         # renormalize chi

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ import io
 import os
 import re
 import sys
-import imp
 import ssl
 import shutil
 import tarfile

--- a/setup_sub.py
+++ b/setup_sub.py
@@ -6,7 +6,6 @@ import io
 import os
 import re
 import sys
-import imp
 import shutil
 import tarfile
 import argparse

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -84,10 +84,7 @@ namespace nucname
   {
   public:
     /// default constructor
-    NotANuclide () 
-    {
-      NaNEstr = "";
-    };
+    NotANuclide () : NaNEstr("") {};
 
     /// default destructor
     ~NotANuclide () throw () {};

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -84,7 +84,10 @@ namespace nucname
   {
   public:
     /// default constructor
-    NotANuclide () {};
+    NotANuclide () 
+    {
+      NaNEstr = "";
+    };
 
     /// default destructor
     ~NotANuclide () throw () {};
@@ -96,6 +99,7 @@ namespace nucname
     {
        nucwas = wasptr;
        nucnow = nowptr;
+       setNaNEstr();
     };
 
     /// Constructor given previous and current state of nulide name
@@ -105,6 +109,7 @@ namespace nucname
     {
       nucwas = wasptr;
       nucnow = pyne::to_str(nowptr);
+      setNaNEstr();
     };
 
     /// Constructor given previous and current state of nulide name
@@ -114,6 +119,7 @@ namespace nucname
     {
       nucwas = pyne::to_str(wasptr);
       nucnow = nowptr;
+      setNaNEstr();
     };
 
     /// Constructor given previous and current state of nulide name
@@ -123,13 +129,12 @@ namespace nucname
     {
       nucwas = pyne::to_str(wasptr);
       nucnow = pyne::to_str(nowptr);
+      setNaNEstr();
     };
 
-    /// Generates an informational message for the exception
-    /// \return The error string
-    virtual const char* what() const throw()
+    void setNaNEstr() 
     {
-      std::string NaNEstr ("Not a Nuclide! ");
+      NaNEstr = "Not a Nuclide! ";
       if (!nucwas.empty())
         NaNEstr += nucwas;
 
@@ -138,13 +143,19 @@ namespace nucname
         NaNEstr += " --> ";
         NaNEstr += nucnow;
       }
-      const char* NaNEstr_rtn = NaNEstr.c_str();
-      return NaNEstr_rtn;
+    };
+
+    /// Generates an informational message for the exception
+    /// \return The error string
+    virtual const char* what() const throw() 
+    {
+      return NaNEstr.c_str();     
     };
 
   private:
     std::string nucwas; ///< previous nuclide state
     std::string nucnow; ///< current nuclide state
+    std::string NaNEstr; 
   };
 
   /// Custom expection for declaring that a value represents one or more nuclides

--- a/src/rxname.h
+++ b/src/rxname.h
@@ -206,7 +206,9 @@ namespace rxname
   public:
 
     /// default constructor
-    NotAReaction () {};
+    NotAReaction () {
+      narxstr = "";
+    };
 
     /// default destructor
     ~NotAReaction () throw () {};
@@ -217,6 +219,7 @@ namespace rxname
     {
        rxwas = wasptr;
        rxnow = nowptr;
+       setNarxstr();
     };
 
     /// Constructor using original reaction (\a wasptr) and the eventual state
@@ -225,6 +228,7 @@ namespace rxname
     {
       rxwas = wasptr;
       rxnow = pyne::to_str(nowptr);
+      setNarxstr();
     };
 
     /// Constructor using original reaction (\a wasptr) and the eventual state
@@ -233,6 +237,7 @@ namespace rxname
     {
       rxwas = pyne::to_str(wasptr);
       rxnow = nowptr;
+      setNarxstr();
     };
 
     /// Constructor using original reaction (\a wasptr) and the eventual state
@@ -241,6 +246,7 @@ namespace rxname
     {
       rxwas = pyne::to_str(wasptr);
       rxnow = pyne::to_str(nowptr);
+      setNarxstr();
     };
 
     /// Constructor using original reaction (\a wasptr) and the eventual state
@@ -249,6 +255,7 @@ namespace rxname
     {
       rxwas = wasptr;
       rxnow = pyne::to_str(nowptr);
+      setNarxstr();
     };
 
     /// Constructor using original reaction (\a wasptr) and the eventual state
@@ -257,6 +264,7 @@ namespace rxname
     {
       rxwas = pyne::to_str(wasptr);
       rxnow = nowptr;
+      setNarxstr();
     };
 
     /// Constructor using original reaction (\a wasptr) and the eventual state
@@ -265,12 +273,12 @@ namespace rxname
     {
       rxwas = pyne::to_str(wasptr);
       rxnow = pyne::to_str(nowptr);
+      setNarxstr();
     };
 
-    /// Returns a helpful error message containing prior and current reaction state.
-    virtual const char* what() const throw()
+    void setNarxstr() 
     {
-      std::string narxstr ("Not a reaction! ");
+      narxstr ="Not a reaction! ";
       if (!rxwas.empty())
         narxstr += rxwas;
 
@@ -279,13 +287,18 @@ namespace rxname
         narxstr += " --> ";
         narxstr += rxnow;
       }
-      const char* narxstr_rtn = narxstr.c_str();
-      return narxstr_rtn;
+    }
+
+    /// Returns a helpful error message containing prior and current reaction state.
+    virtual const char* what() const throw()
+    {
+      return narxstr.c_str();
     };
 
   private:
     std::string rxwas;  ///< previous reaction state
     std::string rxnow;  ///< current reaction state
+    std::string narxstr;
   };
 
 

--- a/src/rxname.h
+++ b/src/rxname.h
@@ -206,9 +206,7 @@ namespace rxname
   public:
 
     /// default constructor
-    NotAReaction () {
-      narxstr = "";
-    };
+    NotAReaction () : narxstr("") {};
 
     /// default destructor
     ~NotAReaction () throw () {};

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -3,7 +3,6 @@ import os.path
 import warnings
 import pytest
 from numpy.testing import assert_array_equal
-import imp
 import multiprocessing
 import numpy as np
 
@@ -17,9 +16,7 @@ try:
     from pyne.mesh import Mesh
 
     # See if dagmc module exists but do not import it
-    pyne_info = imp.find_module("pyne")
-    pyne_mod = imp.load_module("pyne", *pyne_info)
-    imp.find_module("dagmc", pyne_mod.__path__)
+    from pyne import dagmc
 except ImportError:
     raise pytest.skip(allow_module_level=True)
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -766,7 +766,8 @@ def test_getitem_int():
 def test_getitem_str():
     mat = Material(nucvec)
     assert mat["U235"] == 1.0
-    pytest.raises(RuntimeError, lambda: mat["word"])
+    with pytest.raises(RuntimeError):
+        mat["word"]
 
     mat = Material(leu)
     assert mat["U235"] == 0.04

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -764,7 +764,7 @@ def test_getitem_int():
 
 def test_id():
     mat = Material(nucvec)
-    pytest.raises(RuntimeError, lambda: mat[-1])
+    pytest.raises(RuntimeError, lambda: mat[""])
 
 def test_getitem_str():
     mat = Material(nucvec)

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -762,12 +762,14 @@ def test_getitem_int():
     assert mat[922380000] == 0.96
     pytest.raises(KeyError, lambda: mat[922340000])
 
+def test_id():
+    mat = Material(nucvec)
+    pytest.raises(RuntimeError, lambda: mat[-1])
 
 def test_getitem_str():
     mat = Material(nucvec)
     assert mat["U235"] == 1.0
-    with pytest.raises(RuntimeError):
-        mat["word"]
+    pytest.raises(RuntimeError, lambda: mat["word"])
 
     mat = Material(leu)
     assert mat["U235"] == 0.04

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -13,11 +13,7 @@ try:
     from pyne.mesh import Mesh
 
     # see if the source sampling module exists but do not import it
-    import imp
-
-    pyne_info = imp.find_module("pyne")
-    pyne_mod = imp.load_module("pyne", *pyne_info)
-    imp.find_module("source_sampling", pyne_mod.__path__)
+    from pyne import source_sampling
 except ImportError:
     pytest.skip("Can't import mesh, skipping tests", allow_module_level=True)
 


### PR DESCRIPTION
## Description
Removes the `imp` module from 2 tests where they are not used (`setup.py` and `setup_sub.py`) and replaces its usage in another 2 tests (`test_dagmc.py` and `test_source_sample.py`) with a simple `from pyne import ______`. It also changes the conda build python version from `3.10.14` to `3.10.12` to match the apt build to try to fix the conda build that is failing on the develop branch after merging #1540. 

## Motivation and Context
Closes #1542.

## Changes
Bug fix to allow compatibility with Python 3.12, which doesn't have the `imp` module. 