### PR TITLE
Change references of `basestring` to `str`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next Version
    * Update MOAB, OpenMC, hdf5 versions in apt build (#1529)
    * Add dockerfile and workflow to build PyNE with Conda (#1540)
    * Support Cython3+ (#1528)
+   * Remove deprecated references to ``basestring`` (#1544)
 
 **Fix**
    * Fix Type Mismatch Error in PyNE's ENSDF Processing Module (#1519)

--- a/pyne/_argparse.py
+++ b/pyne/_argparse.py
@@ -98,9 +98,6 @@ except NameError:
     # for python < 2.4 compatibility (sets module is there since 2.3):
     from sets import Set as set
 
-if _sys.version_info[0] > 2:
-    basestring = str
-
 try:
     sorted
 except NameError:
@@ -1713,7 +1710,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 if not hasattr(namespace, action.dest):
                     if action.default is not SUPPRESS:
                         default = action.default
-                        if isinstance(action.default, basestring):
+                        if isinstance(action.default, str):
                             default = self._get_value(action, default)
                         setattr(namespace, action.dest, default)
 
@@ -2194,7 +2191,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 value = action.const
             else:
                 value = action.default
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 value = self._get_value(action, value)
                 self._check_value(action, value)
 

--- a/pyne/ace.pyx
+++ b/pyne/ace.pyx
@@ -173,7 +173,7 @@ class Library(object):
             Tables from the file to read in.  If None, reads in all of the
             tables. If str, reads in only the single table of a matching name.
         """
-        if isinstance(table_names, basestring):
+        if isinstance(table_names, str):
             table_names = [table_names]
 
         if table_names is not None:

--- a/pyne/alara.py
+++ b/pyne/alara.py
@@ -23,11 +23,6 @@ import re
 
 QA_warn(__name__)
 
-try:
-    basestring
-except NameError:
-    basestring = str
-
 if HAVE_PYMOAB:
     from pyne.mesh import mesh_iterate
 else:
@@ -705,7 +700,7 @@ def num_density_to_mesh(lines, time, m):
     m : PyNE Mesh
         Mesh object for which mats will be applied to.
     """
-    if isinstance(lines, basestring):
+    if isinstance(lines, str):
         with open(lines) as f:
             lines = f.readlines()
     elif not isinstance(lines, collectionsAbc.Sequence):
@@ -817,7 +812,7 @@ def irradiation_blocks(
     # Cooling times
     s += "cooling\n"
     if isinstance(cooling, collectionsAbc.Iterable) and not isinstance(
-        cooling, basestring
+        cooling, str
     ):
         for c in cooling:
             s += "    {0}\n".format(c)
@@ -839,7 +834,7 @@ def irradiation_blocks(
     # Output block
     s += "output zone\n    units Ci cm3\n"
     if isinstance(output, collectionsAbc.Iterable) and not isinstance(
-        output, basestring
+        output, str
     ):
         for out in output:
             s += "    {0}\n".format(out)

--- a/pyne/data.pyx
+++ b/pyne/data.pyx
@@ -97,7 +97,7 @@ def atomic_mass(nuc):
     """
     if isinstance(nuc, int):
         mass = cpp_data.atomic_mass(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         mass = cpp_data.atomic_mass(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):
@@ -140,7 +140,7 @@ def natural_abund(nuc):
     """
     if isinstance(nuc, int):
         abund = cpp_data.natural_abund(<int> pyne.nucname.id(nuc))
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         abund = cpp_data.natural_abund(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):
@@ -176,7 +176,7 @@ def q_val(nuc):
     """
     if isinstance(nuc, int):
         q_val = cpp_data.q_val(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         q_val = cpp_data.q_val(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):
@@ -212,7 +212,7 @@ def gamma_frac(nuc):
     """
     if isinstance(nuc, int):
         gamma_frac = cpp_data.gamma_frac(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         gamma_frac = cpp_data.gamma_frac(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):
@@ -259,26 +259,26 @@ def simple_xs(nuc, rx, energy):
     if isinstance(rx, bytes):
         rx = rx.decode("utf-8")
 
-    if not isinstance(energy, basestring):
+    if not isinstance(energy, str):
         raise ValueError('energy must be string')
-    elif not isinstance(nuc, int) and not isinstance(nuc, basestring):
+    elif not isinstance(nuc, int) and not isinstance(nuc, str):
         raise ValueError('nuc must be int or string')
-    elif not isinstance(rx, int) and not isinstance(rx, basestring):
+    elif not isinstance(rx, int) and not isinstance(rx, str):
         raise ValueError('rx must be int or string')
 
     energy_bytes = energy.encode()
     if isinstance(nuc, int) and isinstance(rx, int):
         xs = cpp_data.simple_xs(<int> nuc, <int> rx,
                                 std_string(<char *> energy_bytes))
-    elif isinstance(nuc, int) and isinstance(rx, basestring):
+    elif isinstance(nuc, int) and isinstance(rx, str):
         rxin_bytes = rx.encode()
         xs = cpp_data.simple_xs(<int> nuc, std_string(<char *> rxin_bytes),
                                 std_string(<char *> energy_bytes))
-    elif isinstance(nuc, basestring) and isinstance(rx, int):
+    elif isinstance(nuc, str) and isinstance(rx, int):
         nucin_bytes = nuc.encode()
         xs = cpp_data.simple_xs(std_string(<char *> nucin_bytes),
                                 <int> rx, std_string(<char *> energy_bytes))
-    elif isinstance(nuc, basestring) and isinstance(rx, basestring):
+    elif isinstance(nuc, str) and isinstance(rx, str):
         rxin_bytes = rx.encode()
         nucin_bytes = nuc.encode()
         xs = cpp_data.simple_xs(std_string(<char *> nucin_bytes),
@@ -329,7 +329,7 @@ def ext_air_dose(nuc, source=0):
 
     if isinstance(nuc, int):
         ext_air_dose = cpp_data.ext_air_dose(<int> nuc, <int> source)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         ext_air_dose = cpp_data.ext_air_dose(<char *> nuc_bytes, <int> source)
     else:
@@ -377,7 +377,7 @@ def dose_ratio(nuc, source=0):
 
     if isinstance(nuc, int):
         ratio = cpp_data.dose_ratio(<int> nuc, <int> source)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         ratio = cpp_data.dose_ratio(<char *> nuc_bytes, <int> source)
     else:
@@ -424,7 +424,7 @@ def ext_soil_dose(nuc, source=0):
 
     if isinstance(nuc, int):
         ext_soil_dose = cpp_data.ext_soil_dose(<int> nuc, <int> source)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         ext_soil_dose = cpp_data.ext_soil_dose(<char *> nuc_bytes, <int> source)
     else:
@@ -471,7 +471,7 @@ def ingest_dose(nuc, source=0):
 
     if isinstance(nuc, int):
         ingest_dose = cpp_data.ingest_dose(<int> nuc, <int> source)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         ingest_dose = cpp_data.ingest_dose(<char *> nuc_bytes, <int> source)
     else:
@@ -518,7 +518,7 @@ def dose_fluid_frac(nuc, source=0):
 
     if isinstance(nuc, int):
         fluid_frac = cpp_data.dose_fluid_frac(<int> nuc, <int> source)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         fluid_frac = cpp_data.dose_fluid_frac(<char *> nuc_bytes, <int> source)
     else:
@@ -565,7 +565,7 @@ def inhale_dose(nuc, source=0):
 
     if isinstance(nuc, int):
         inhale_dose = cpp_data.inhale_dose(<int> nuc, <int> source)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         inhale_dose = cpp_data.inhale_dose(<char *> nuc_bytes, <int> source)
     else:
@@ -612,7 +612,7 @@ def dose_lung_model(nuc, source=0):
 
     if isinstance(nuc, int):
         lung_mod = cpp_data.dose_lung_model(<int> nuc, <int> source)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         lung_mod = cpp_data.dose_lung_model(<char *> nuc_bytes, <int> source)
     else:
@@ -653,7 +653,7 @@ def b_coherent(nuc):
 
     if isinstance(nuc, int):
         value = cpp_data.b_coherent(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         value = cpp_data.b_coherent(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):
@@ -693,7 +693,7 @@ def b_incoherent(nuc):
 
     if isinstance(nuc, int):
         value = cpp_data.b_incoherent(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         value = cpp_data.b_incoherent(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):
@@ -739,7 +739,7 @@ def b(nuc):
     """
     if isinstance(nuc, int):
         value = cpp_data.b(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         value = cpp_data.b(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):
@@ -791,7 +791,7 @@ def fpyield(from_nuc, to_nuc, source=0, get_errors=False):
         raise ValueError('Only ints or strings are accepted')
     if isinstance(from_nuc, int):
         fn = pyne.cpp_nucname.id(<int> from_nuc)
-    elif isinstance(from_nuc, basestring):
+    elif isinstance(from_nuc, str):
         from_nuc_bytes = from_nuc.encode()
         fn = pyne.cpp_nucname.id(std_string(<char *> from_nuc_bytes))
     elif isinstance(from_nuc, bytes):
@@ -801,7 +801,7 @@ def fpyield(from_nuc, to_nuc, source=0, get_errors=False):
 
     if isinstance(to_nuc, int):
         tn = pyne.cpp_nucname.id(<int> to_nuc)
-    elif isinstance(to_nuc, basestring):
+    elif isinstance(to_nuc, str):
         to_nuc_bytes = to_nuc.encode()
         tn = pyne.cpp_nucname.id(std_string(<char *> to_nuc_bytes))
     elif isinstance(to_nuc, bytes):
@@ -870,7 +870,7 @@ def half_life(nuc, use_metastable=True):
             return float('nan')  # nuclide doesn't exist
     if isinstance(nuc, int):
         hl = cpp_data.half_life(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         hl = cpp_data.half_life(<char *> nuc_bytes)
     else:
@@ -909,7 +909,7 @@ def decay_const(nuc, use_metastable=True):
             return 0.0  # nuclide doesn't exist, assume stable
     if isinstance(nuc, int):
         dc = cpp_data.decay_const(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         dc = cpp_data.decay_const(<char *> nuc_bytes)
     else:
@@ -954,7 +954,7 @@ def branch_ratio(from_nuc, to_nuc, use_metastable=True):
             return 0.0
     if isinstance(from_nuc, int):
         fn = pyne.cpp_nucname.id(<int> from_nuc)
-    elif isinstance(from_nuc, basestring):
+    elif isinstance(from_nuc, str):
         from_nuc_bytes = from_nuc.encode()
         fn = pyne.cpp_nucname.id(std_string(<char *> from_nuc_bytes))
     else:
@@ -962,7 +962,7 @@ def branch_ratio(from_nuc, to_nuc, use_metastable=True):
 
     if isinstance(to_nuc, int):
         tn = pyne.cpp_nucname.id(<int> to_nuc)
-    elif isinstance(to_nuc, basestring):
+    elif isinstance(to_nuc, str):
         to_nuc_bytes = to_nuc.encode()
         tn = pyne.cpp_nucname.id(std_string(<char *> to_nuc_bytes))
     else:
@@ -1000,7 +1000,7 @@ def state_energy(nuc, use_metastable=True):
             return 0.0  # nuclide doesn't exist, assume stable
     if isinstance(nuc, int):
         se = cpp_data.state_energy(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         se = cpp_data.state_energy(<char *> nuc_bytes)
     else:
@@ -1039,7 +1039,7 @@ def decay_children(nuc, use_metastable=True):
 
     if isinstance(nuc, int):
         dc.set_ptr[0] = cpp_data.decay_children(<int> nuc)
-    elif isinstance(nuc, basestring):
+    elif isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         dc.set_ptr[0] = cpp_data.decay_children(<char *> nuc_bytes)
     elif isinstance(nuc, bytes):

--- a/pyne/dbgen/cinder.py
+++ b/pyne/dbgen/cinder.py
@@ -16,9 +16,6 @@ from .. import nucname
 from ..utils import warning
 from .api import BASIC_FILTERS
 
-if sys.version_info[0] > 2:
-    basestring = str
-
 QA_warn(__name__)
 
 
@@ -29,7 +26,7 @@ def grab_cinder_dat(build_dir="", datapath=""):
     if os.path.exists(build_filename):
         return True
 
-    if isinstance(datapath, basestring) and 0 < len(datapath):
+    if isinstance(datapath, str) and 0 < len(datapath):
         pass
     elif "DATAPATH" in os.environ:
         datapath = os.environ["DATAPATH"]

--- a/pyne/dbgen/cinder.py
+++ b/pyne/dbgen/cinder.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import os
 import io
 import re
-import sys
 import shutil
 from glob import glob
 from pyne.utils import QA_warn

--- a/pyne/dbgen/kaeri.py
+++ b/pyne/dbgen/kaeri.py
@@ -15,10 +15,6 @@ from pyne import nucname
 
 QA_warn(__name__)
 
-if sys.version_info[0] > 2:
-    basestring = str
-
-
 def grab_kaeri_nuclide(nuc, build_dir="", n=None):
     """Grabs a nuclide file from KAERI from the web and places
     it a {nuc}.html file in the build directory.
@@ -33,7 +29,7 @@ def grab_kaeri_nuclide(nuc, build_dir="", n=None):
         Optional flag on data to grab.  None = basic data,
         2 = cross section summary, 3 = cross section graphs.
     """
-    if not isinstance(nuc, basestring):
+    if not isinstance(nuc, str):
         nuc = nucname.name(nuc).upper()
 
     if n is None:

--- a/pyne/dbgen/kaeri.py
+++ b/pyne/dbgen/kaeri.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import os
 import re
-import sys
 from pyne.utils import QA_warn
 
 try:

--- a/pyne/dtypes.pyx
+++ b/pyne/dtypes.pyx
@@ -27,9 +27,6 @@ cimport extra_types
 
 dtypes = {}
 
-if PY_MAJOR_VERSION >= 3:
-    basestring = str
-
 # Dirty ifdef, else, else preprocessor hack
 # see http://comments.gmane.org/gmane.comp.python.cython.user/4080
 cdef extern from *:

--- a/pyne/endf.pyx
+++ b/pyne/endf.pyx
@@ -115,7 +115,7 @@ class Library(rxdata.RxLib):
             Returns a 1d float64 NumPy array.
         """
         opened_here = False
-        if isinstance(self.fh, basestring):
+        if isinstance(self.fh, str):
             fh = open(self.fh, 'r')
             opened_here = True
         else:
@@ -130,7 +130,7 @@ class Library(rxdata.RxLib):
     def _read_tpid(self):
         if self.chars_til_now == 0:
             opened_here = False
-            if isinstance(self.fh, basestring):
+            if isinstance(self.fh, str):
                 fh = open(self.fh, 'r')
                 opened_here = True
             else:
@@ -157,7 +157,7 @@ class Library(rxdata.RxLib):
         cdef int mat_id
         cdef double nucd
         opened_here = False
-        if isinstance(self.fh, basestring):
+        if isinstance(self.fh, str):
             fh = open(self.fh, 'r')
             opened_here = True
         else:
@@ -1065,7 +1065,7 @@ class Library(rxdata.RxLib):
             1d, float64 NumPy array containing the reaction data.
         """
         opened_here = False
-        if isinstance(self.fh, basestring):
+        if isinstance(self.fh, str):
             fh = open(self.fh, 'r')
             opened_here = True
         else:

--- a/pyne/endl.py
+++ b/pyne/endl.py
@@ -32,9 +32,6 @@ from pyne import nucname
 
 QA_warn(__name__)
 
-if sys.version_info[0] > 2:
-    basestring = str
-
 END_OF_TABLE_RE = re.compile(" {71}1")
 
 DataTuple = namedtuple("DataTuple", ["yo", "limits", "x1"])
@@ -71,7 +68,7 @@ class Library(rxdata.RxLib):
     def _read_headers(self):
         """Read all the table headers from an ENDL file."""
         opened_here = False
-        if isinstance(self.fh, basestring):
+        if isinstance(self.fh, str):
             fh = open(self.fh, "r")
             opened_here = True
         else:
@@ -324,7 +321,7 @@ class Library(rxdata.RxLib):
             raise e
 
         start, stop = data_tuple.limits
-        if isinstance(self.fh, basestring):
+        if isinstance(self.fh, str):
             fh = open(self.fh, "r")
             opened_here = True
         else:

--- a/pyne/endl.py
+++ b/pyne/endl.py
@@ -16,7 +16,6 @@ For more information, contact Davide Mancusi <davide.mancusi@cea.fr>.
 from __future__ import print_function, division, unicode_literals
 
 import re
-import sys
 
 try:
     from collections.abc import namedtuple, defaultdict

--- a/pyne/ensdf.py
+++ b/pyne/ensdf.py
@@ -14,9 +14,6 @@ import numpy as np
 
 from pyne import nucname, rxname, data
 
-if sys.version_info[0] > 2:
-    basestring = str
-
 QA_warn(__name__)
 
 _valexp = re.compile("([0-9.]*)([Ee][+-]?\d*)")

--- a/pyne/ensdf.py
+++ b/pyne/ensdf.py
@@ -1,6 +1,5 @@
 from __future__ import division
 import re
-import sys
 import copy
 
 try:

--- a/pyne/ensdf_processing.py
+++ b/pyne/ensdf_processing.py
@@ -1,6 +1,6 @@
 """This module accesses various ensdf processing tools"""
 
-import sys, os, shutil, subprocess, tarfile
+import os, subprocess, tarfile
 from warnings import warn
 from pyne.utils import QA_warn
 

--- a/pyne/ensdf_processing.py
+++ b/pyne/ensdf_processing.py
@@ -9,9 +9,6 @@ try:
 except ImportError:
     import urllib2 as urllib
 
-if sys.version_info[0] > 2:
-    basestring = str
-
 QA_warn(__name__)
 
 

--- a/pyne/jsoncpp.pyx
+++ b/pyne/jsoncpp.pyx
@@ -42,11 +42,11 @@ cdef cpp_jsoncpp.Value * tocppval(object doc) except NULL:
     elif isinstance(doc, collectionsAbc.Mapping):
         cval = new cpp_jsoncpp.Value(<cpp_jsoncpp.ValueType> cpp_jsoncpp.objectValue)
         for k, v in doc.items():
-            if not isinstance(k, basestring):
+            if not isinstance(k, str):
                 raise KeyError('object keys must be strings, got {0}'.format(k))
             k_bytes = k.encode()
             cval[0][<const_char *> k_bytes].swap(deref(tocppval(v)))
-    elif isinstance(doc, basestring):
+    elif isinstance(doc, str):
         # string must come before other sequences
         doc_bytes = doc.encode()
         cval = new cpp_jsoncpp.Value(<char *> doc_bytes)
@@ -118,7 +118,7 @@ cdef class Value(object):
         cdef Value pyvalue = Value(view=True)
 
         # convert key and get value
-        if isinstance(pykey, basestring):
+        if isinstance(pykey, str):
             pykey_bytes = pykey.encode()
             cvalue = &self._inst[0][<const_char *> pykey_bytes]
         elif isinstance(pykey, bytes):
@@ -162,7 +162,7 @@ cdef class Value(object):
 
     def __setitem__(self, key, value):
         cdef cpp_jsoncpp.Value * ckey = NULL
-        if isinstance(key, basestring):
+        if isinstance(key, str):
             key_bytes = key.encode()
             ckey = &self._inst[0][<const_char *> key_bytes]
             ckey.swap(deref(tocppval(value)))
@@ -187,7 +187,7 @@ cdef class Value(object):
     def __delitem__(self, key):
         cdef int i, ikey, curr_size, end_size
         cdef cpp_jsoncpp.Value ctemp
-        if isinstance(key, basestring) and \
+        if isinstance(key, str) and \
            (self._inst.type() == cpp_jsoncpp.objectValue):
             key_bytes = key.encode()
             self._inst.removeMember(<const_char *> key_bytes)
@@ -217,7 +217,7 @@ cdef class Value(object):
 
     def __contains__(self, item):
         cdef int i, curr_size
-        if isinstance(item, basestring) and (self._inst.type() == cpp_jsoncpp.objectValue):
+        if isinstance(item, str) and (self._inst.type() == cpp_jsoncpp.objectValue):
             item_bytes = item.encode()
             return self._inst.isMember(<const_char *> item_bytes)
         elif (self._inst.type() == cpp_jsoncpp.arrayValue):
@@ -507,7 +507,7 @@ cdef class Reader(object):
         cdef Value root = Value()
         cdef char * cdocval
         cdef std_string cdoc
-        if isinstance(document, basestring):
+        if isinstance(document, str):
             document_bytes = document.encode()
             cdocval = document_bytes
         else:

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -23,7 +23,6 @@ cimport numpy as np
 import numpy as np
 from pyne.utils import QA_warn
 import os
-import sys
 import tables as tb
 
 # local imports

--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -24,10 +24,6 @@ import numpy as np
 from pyne.utils import QA_warn
 import os
 import sys
-if sys.version_info[0] >= 3:
-    #Python2 basestring is now Python3 string
-    basestring = str
-
 import tables as tb
 
 # local imports
@@ -80,7 +76,7 @@ cdef class _Material:
             comp = dict_to_comp(nucvec)
             self.mat_pointer = new cpp_material.Material(
                     comp, mass, density, atoms_per_molecule, deref(cmetadata._inst))
-        elif isinstance(nucvec, basestring):
+        elif isinstance(nucvec, str):
             # Material from file
             nucvec = nucvec.encode()
             self.mat_pointer = new cpp_material.Material(
@@ -1214,7 +1210,7 @@ cdef class _Material:
                 if 0 == af.count(key_zz):
                     af[key_zz] = 0.0
                 af[key_zz] = af[key_zz] + val
-            elif isinstance(key, basestring):
+            elif isinstance(key, str):
                 key_zz = nucname.id(key)
                 if 0 == af.count(key_zz):
                     af[key_zz] = 0.0
@@ -1268,7 +1264,7 @@ cdef class _Material:
             val = <double> value
             if isinstance(key, int):
                 key_zz = <int> nucname.id(key)
-            elif isinstance(key, basestring):
+            elif isinstance(key, str):
                 key_zz = nucname.id(key)
             else:
                 raise TypeError("Activity keys must be integers, "
@@ -1489,7 +1485,7 @@ cdef class _Material:
                 raise KeyError("key {0} not found".format(repr(key)))
 
         # Get single string-key
-        elif isinstance(key, basestring):
+        elif isinstance(key, str):
             key_zz = nucname.id(key)
             return self[key_zz]
 
@@ -1531,7 +1527,7 @@ cdef class _Material:
             self._comp = None
 
         # Set single string-key
-        elif isinstance(key, basestring):
+        elif isinstance(key, str):
             key_zz = nucname.id(key)
             self[key_zz] = value
 
@@ -1581,7 +1577,7 @@ cdef class _Material:
             self._comp = None
 
         # Remove single string-key
-        elif isinstance(key, basestring):
+        elif isinstance(key, str):
             key_zz = nucname.id(key)
             del self[key_zz]
 
@@ -2135,7 +2131,7 @@ cdef class _MapStrMaterial:
         cdef std_string s
         cdef _Material pymat
 
-        if isinstance(key, basestring):
+        if isinstance(key, str):
             key = key.encode()
             s = std_string(<char *> key)
         else:
@@ -2269,7 +2265,7 @@ def mats_latex_table(mats, labels=None, align=None, format=".5g"):
         align = '|l|' + 'c|'*len(mats)
     if labels is None:
         labels = []
-    if isinstance(format, basestring):
+    if isinstance(format, str):
         format = [format] * len(mats)
 
     nucs = set()

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -34,10 +34,6 @@ try:
 except AttributeError:
     collectionsAbc = collections
 cimport numpy as np
-if sys.version_info[0] >= 3:
-    # Python2 basestring is now Python3 string
-    basestring = str
-
 
 # local imports
 cimport pyne.stlcontainers as conv
@@ -79,8 +75,7 @@ cdef class _MaterialLibrary:
         if lib != None:
             if sys.version_info[0] >= 3 and isinstance(lib, bytes):
                 lib = lib.decode()
-            if (isinstance(lib, basestring) or isinstance(lib, unicode)) \
-                    and not isinstance(lib, collectionsAbc.Mapping):
+            if (isinstance(lib, str)) and not isinstance(lib, collectionsAbc.Mapping):
                 # Python2: basestring = (std + unicode)
                 c_filename = lib.encode('UTF-8')
                 c_datapath = datapath.encode('UTF-8')
@@ -138,7 +133,7 @@ cdef class _MaterialLibrary:
         ----------
         mat_name : str Name of the material be removed from this material library
         """
-        if isinstance(mat_name, basestring):
+        if isinstance(mat_name, str):
             c_matname = mat_name.encode('UTF-8')
             self._inst.del_material(< std_string > c_matname)
         else:
@@ -284,7 +279,7 @@ class MaterialLibrary(_MaterialLibrary, collectionsAbc.MutableMapping):
 
 
 def ensure_material_key(key):
-    if isinstance(key, basestring):
+    if isinstance(key, str):
         key = key.encode('UTF-8')
     elif isinstance(key, _INTEGRAL_TYPES):
         key = str(key).encode('UTF-8')

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -8,7 +8,6 @@ import pyne.stlcontainers as conv
 from pyne cimport cpp_material_library
 from pyne cimport cpp_material
 import tables as tb
-import sys
 import os
 from pyne.utils import QA_warn
 import numpy as np
@@ -73,7 +72,7 @@ cdef class _MaterialLibrary:
             The path in the hierarchy to the nuclide array in an HDF5 file.
         """
         if lib != None:
-            if sys.version_info[0] >= 3 and isinstance(lib, bytes):
+            if isinstance(lib, bytes):
                 lib = lib.decode()
             if (isinstance(lib, str)) and not isinstance(lib, collectionsAbc.Mapping):
                 # Python2: basestring = (std + unicode)

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -37,9 +37,6 @@ except ImportError:
 
 _BOX_DIMS_TAG_NAME = "BOX_DIMS"
 
-if sys.version_info[0] > 2:
-    basestring = str
-
 # dictionary of lamba functions for mesh arithmetic
 _ops = {
     "+": lambda val_1, val_2: (val_1 + val_2),
@@ -873,7 +870,7 @@ class Mesh(object):
             )
         if mesh is None:
             self.mesh = mb_core.Core()
-        elif isinstance(mesh, basestring):
+        elif isinstance(mesh, str):
             self.mesh = mb_core.Core()
             self.mesh.load_file(mesh)
         else:
@@ -1000,7 +997,7 @@ class Mesh(object):
 
         # sets mats
         mats_in_mesh_file = False
-        if isinstance(mesh, basestring) and len(mats) == 0:
+        if isinstance(mesh, str) and len(mats) == 0:
             with tb.open_file(mesh) as h5f:
                 if "/mat_name" in h5f:
                     mats_in_mesh_file = True

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division
 from future.utils import implements_iterator
 from pyne.material import Material, MultiMaterial
 from pyne.material_library import MaterialLibrary
-import sys
 import copy
 import itertools
 

--- a/pyne/nucname.pyx
+++ b/pyne/nucname.pyx
@@ -111,7 +111,7 @@ def isnuclide(nuc):
     flag : bool
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         flag = cpp_nucname.isnuclide(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -134,7 +134,7 @@ def iselement(nuc):
     flag : bool
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         flag = cpp_nucname.iselement(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -183,7 +183,7 @@ def id(nuc):
         Output nuclide id.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc = nuc.encode()
         newnuc = cpp_nucname.id(<char *> nuc)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -210,7 +210,7 @@ def name(nuc):
 
     """
     cdef std_string newnuc
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.name(<char *> nuc_bytes)
     elif isinstance(nuc, int):
@@ -234,7 +234,7 @@ def znum(nuc):
         The number of protons in the nucleus.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         z = cpp_nucname.znum(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -258,7 +258,7 @@ def anum(nuc):
         The number of protons and neutrons in the nucleus.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         a = cpp_nucname.anum(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -282,7 +282,7 @@ def snum(nuc):
         The excitation level the nucleus.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         s = cpp_nucname.snum(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -306,7 +306,7 @@ def zzaaam(nuc):
         Output nuclide in zzaaam form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzaaam(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -331,7 +331,7 @@ def zzaaam_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzaaam_to_id(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -355,7 +355,7 @@ def zzzaaa(nuc):
         Output nuclide in zzzaaa form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzzaaa(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -380,7 +380,7 @@ def zzzaaa_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         newnuc = cpp_nucname.zzzaaa_to_id(<char *> nuc)
     elif isinstance(nuc, int) or isinstance(nuc, long):
         newnuc = cpp_nucname.zzzaaa_to_id(<int> nuc)
@@ -411,7 +411,7 @@ def mcnp(nuc):
 
     """
 
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.mcnp(<char *> nuc_bytes)
     elif isinstance(nuc, int):
@@ -436,7 +436,7 @@ def mcnp_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.mcnp_to_id(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -461,7 +461,7 @@ def openmc(nuc):
 
     """
 
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.openmc(<char *> nuc_bytes)
     elif isinstance(nuc, int):
@@ -541,7 +541,7 @@ def zzllaaam(nuc):
         Output nuclide in zzllaaam form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzllaaam(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -566,7 +566,7 @@ def zzllaaam_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzllaaam_to_id(<char *> nuc_bytes)
     else:
@@ -591,7 +591,7 @@ def serpent(nuc):
     """
     cdef std_string newnuc
 
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.serpent(<char *> nuc_bytes)
     elif isinstance(nuc, int):
@@ -617,7 +617,7 @@ def serpent_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.serpent_to_id(<char *> nuc_bytes)
     #elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -643,7 +643,7 @@ def nist(nuc):
     """
     cdef std_string newnuc
 
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.nist(<char *> nuc_bytes)
     elif isinstance(nuc, int):
@@ -669,7 +669,7 @@ def nist_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.nist_to_id(<char *> nuc_bytes)
     #elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -693,7 +693,7 @@ def cinder(nuc):
         Output nuclide in CINDER (aaazzzm) form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.cinder(<char *> nuc_bytes)
     elif isinstance(nuc, int):
@@ -718,7 +718,7 @@ def cinder_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         newnuc = cpp_nucname.cinder_to_id(<char *> nuc)
     elif isinstance(nuc, int) or isinstance(nuc, long):
         newnuc = cpp_nucname.cinder_to_id(<int> nuc)
@@ -743,7 +743,7 @@ def alara(nuc):
     """
     cdef std_string newnuc
 
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.alara(<char *> nuc_bytes)
     elif isinstance(nuc, int):
@@ -769,7 +769,7 @@ def alara_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.alara_to_id(<char *> nuc_bytes)
     #elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -793,7 +793,7 @@ def sza(nuc):
         Output nuclide in SZA form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.sza(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -818,7 +818,7 @@ def sza_to_id(nuc):
         Output nuclide in identifier form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.sza_to_id(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -842,7 +842,7 @@ def groundstate(nuc):
         Output nuclide in Groundstate form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.groundstate(<char *> nuc_bytes)
     elif isinstance(nuc, int) or isinstance(nuc, long):
@@ -917,7 +917,7 @@ def ensdf_to_id(nuc):
         Output nuclide in nuc_id form.
 
     """
-    if isinstance(nuc, basestring):
+    if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         return cpp_nucname.ensdf_to_id(<char *> nuc_bytes)
     else:

--- a/pyne/openmc_utils.py
+++ b/pyne/openmc_utils.py
@@ -41,10 +41,6 @@ except:
         "Some aspects of the openmc module may be incomplete."
     )
 
-if sys.version_info[0] > 2:
-    basestring = str
-
-
 class AceTable(
     namedtuple(
         "_AceTable",

--- a/pyne/origen22.py
+++ b/pyne/origen22.py
@@ -25,10 +25,6 @@ from pyne.xs import cache
 from pyne import decay_tape9
 from pyne.material import Material, from_atom_frac
 
-if sys.version_info[0] > 2:
-    basestring = str
-    unicode = str
-
 QA_warn(__name__)
 
 BASE_TAPE9 = os.path.join(os.path.dirname(__file__), "base_tape9.inp")
@@ -1890,7 +1886,7 @@ def write_tape4(mat, outfile="TAPE4.INP"):
 
     # Write to the file
     opened_here = False
-    if isinstance(outfile, basestring):
+    if isinstance(outfile, str):
         outfile = open(outfile, "w")
         opened_here = True
 
@@ -2064,7 +2060,7 @@ def write_tape5_irradiation(
     tape5 = _tape5_irradiation_template.format(**tape5_kw)
 
     opened_here = False
-    if isinstance(outfile, basestring):
+    if isinstance(outfile, str):
         outfile = open(outfile, "w")
         opened_here = True
 
@@ -2148,7 +2144,7 @@ def write_tape5_decay(
     tape5 = _tape5_decay_template.format(**tape5_kw)
 
     opened_here = False
-    if isinstance(outfile, basestring):
+    if isinstance(outfile, str):
         outfile = open(outfile, "w")
         opened_here = True
 
@@ -2284,7 +2280,7 @@ def parse_tape6(tape6="TAPE6.OUT"):
     """
     # Read the TAPE6 file
     opened_here = False
-    if isinstance(tape6, basestring):
+    if isinstance(tape6, str):
         tape6 = open(tape6, "r")
         opened_here = True
 
@@ -2699,7 +2695,7 @@ def parse_tape9(tape9="TAPE9.INP"):
     """
     # Read and strip lines
     opened_here = False
-    if isinstance(tape9, basestring):
+    if isinstance(tape9, str):
         tape9 = open(tape9, "r")
         opened_here = True
 
@@ -2749,7 +2745,7 @@ def loads_tape9(tape9):
     parsed : dict
         A dictionary of the data from the TAPE9 file.
     """
-    if isinstance(tape9, unicode):
+    if isinstance(tape9, str):
         t9 = StringIO(tape9)
     else:
         t9 = StringIO(tape9.decode())
@@ -3047,7 +3043,7 @@ def write_tape9(tape9, outfile="TAPE9.INP", precision=3):
         t9 += "  -1\n"
 
     opened_here = False
-    if isinstance(outfile, basestring):
+    if isinstance(outfile, str):
         outfile = open(outfile, "w")
         opened_here = True
 

--- a/pyne/origen22.py
+++ b/pyne/origen22.py
@@ -6,7 +6,6 @@ except ImportError:
     pass
 import os
 import re
-import sys
 from io import StringIO
 
 try:

--- a/pyne/particle.pyx
+++ b/pyne/particle.pyx
@@ -124,7 +124,7 @@ def name(x):
     -------
     n : str Unique particle name
     """
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.name(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -147,7 +147,7 @@ def mcnp(x):
     -------
     n : str Unique particle name
     """
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.mcnp(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -171,7 +171,7 @@ def mcnp6(x):
     -------
     n : str Unique particle name
     """
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.mcnp6(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -195,7 +195,7 @@ def fluka(x):
     -------
     n : str Unique particle name
     """
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.fluka(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -218,7 +218,7 @@ def geant4(x):
     -------
     n : str Unique particle name
     """
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.geant4(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -243,7 +243,7 @@ def describe(x):
     n : str Unique particle description
     """
 
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.describe(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -267,7 +267,7 @@ def id(x):
     n : int Unique PDC number
     """
 
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.id(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -291,7 +291,7 @@ def is_valid(x):
     n : bool true/false 
     """
 
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.is_valid(std_string(<char *> x_bytes))
     elif isinstance(x, int):
@@ -315,7 +315,7 @@ def is_heavy_ion(x):
     n : bool true/false 
     """
 
-    if isinstance(x, basestring):
+    if isinstance(x, str):
         x_bytes = x.encode()
         cn = cpp_particle.is_heavy_ion(std_string(<char *> x_bytes))
     elif isinstance(x, int):

--- a/pyne/rxname.pyx
+++ b/pyne/rxname.pyx
@@ -233,7 +233,7 @@ def name(x, y=None, z="n"):
     cdef std_string cn
     cdef int from_nuc, to_nuc
     if y is None:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             cn = cpp_rxname.name(std_string(<char *> x_bytes))
         elif isinstance(x, int):
@@ -241,12 +241,12 @@ def name(x, y=None, z="n"):
         elif isinstance(x, long):
             cn = cpp_rxname.name(<extra_types.uint32> x)
     else:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             from_nuc = cpp_nucname.id(std_string(<char *> x_bytes))
         elif isinstance(x, int):
             from_nuc = cpp_nucname.id(<int> x)
-        if isinstance(y, basestring):
+        if isinstance(y, str):
             y_bytes = y.encode()
             to_nuc = cpp_nucname.id(std_string(<char *> y_bytes))
         elif isinstance(y, int):
@@ -280,7 +280,7 @@ def id(x, y=None, z="n"):
     """
     cdef int from_nuc, to_nuc
     if y is None:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             rxid = cpp_rxname.id(std_string(<char *> x_bytes))
         elif isinstance(x, int):
@@ -288,12 +288,12 @@ def id(x, y=None, z="n"):
         elif isinstance(x, long):
             rxid = cpp_rxname.id(<extra_types.uint32> x)
     else:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             from_nuc = cpp_nucname.id(std_string(<char *> x_bytes))
         elif isinstance(x, int):
             from_nuc = cpp_nucname.id(<int> x)
-        if isinstance(y, basestring):
+        if isinstance(y, str):
             y_bytes = y.encode()
             to_nuc = cpp_nucname.id(std_string(<char *> y_bytes))
         elif isinstance(y, int):
@@ -324,7 +324,7 @@ def mt(x, y=None, z="n"):
     """
     cdef int from_nuc, to_nuc
     if y is None:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             mtnum = cpp_rxname.mt(std_string(<char *> x_bytes))
         elif isinstance(x, int):
@@ -332,12 +332,12 @@ def mt(x, y=None, z="n"):
         elif isinstance(x, long):
             mtnum = cpp_rxname.mt(<extra_types.uint32> x)
     else:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             from_nuc = cpp_nucname.id(std_string(<char *> x_bytes))
         elif isinstance(x, int):
             from_nuc = cpp_nucname.id(<int> x)
-        if isinstance(y, basestring):
+        if isinstance(y, str):
             y_bytes = y.encode()
             to_nuc = cpp_nucname.id(std_string(<char *> y_bytes))
         elif isinstance(y, int):
@@ -369,7 +369,7 @@ def label(x, y=None, z="n"):
     cdef std_string clab
     cdef int from_nuc, to_nuc
     if y is None:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             clab = cpp_rxname.label(std_string(<char *> x_bytes))
         elif isinstance(x, int):
@@ -377,12 +377,12 @@ def label(x, y=None, z="n"):
         elif isinstance(x, long):
             clab = cpp_rxname.label(<extra_types.uint32> x)
     else:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             from_nuc = cpp_nucname.id(std_string(<char *> x_bytes))
         elif isinstance(x, int):
             from_nuc = cpp_nucname.id(<int> x)
-        if isinstance(y, basestring):
+        if isinstance(y, str):
             y_bytes = y.encode()
             to_nuc = cpp_nucname.id(std_string(<char *> y_bytes))
         elif isinstance(y, int):
@@ -415,7 +415,7 @@ def doc(x, y=None, z="n"):
     cdef std_string cd
     cdef int from_nuc, to_nuc
     if y is None:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             cd = cpp_rxname.doc(std_string(<char *> x_bytes))
         elif isinstance(x, int):
@@ -423,12 +423,12 @@ def doc(x, y=None, z="n"):
         elif isinstance(x, long):
             cd = cpp_rxname.doc(<extra_types.uint32> x)
     else:
-        if isinstance(x, basestring):
+        if isinstance(x, str):
             x_bytes = x.encode()
             from_nuc = cpp_nucname.id(std_string(<char *> x_bytes))
         elif isinstance(x, int):
             from_nuc = cpp_nucname.id(<int> x)
-        if isinstance(y, basestring):
+        if isinstance(y, str):
             y_bytes = y.encode()
             to_nuc = cpp_nucname.id(std_string(<char *> y_bytes))
         elif isinstance(y, int):
@@ -460,9 +460,9 @@ def child(nuc, rx, z="n"):
     """
     cdef std_string ptype
     cdef int to_nuc
-    cdef bint nuc_is_str = isinstance(nuc, basestring)
-    cdef bint z_is_str = isinstance(z, basestring)
-    cdef bint rx_is_str = isinstance(rx, basestring)
+    cdef bint nuc_is_str = isinstance(nuc, str)
+    cdef bint z_is_str = isinstance(z, str)
+    cdef bint rx_is_str = isinstance(rx, str)
     # convert particle to std::string
     z_bytes = z.encode() if z_is_str else z
     ptype = std_string(<char *> z_bytes)
@@ -505,9 +505,9 @@ def parent(nuc, rx, z="n"):
     """
     cdef std_string ptype
     cdef int from_nuc
-    cdef bint nuc_is_str = isinstance(nuc, basestring)
-    cdef bint z_is_str = isinstance(z, basestring)
-    cdef bint rx_is_str = isinstance(rx, basestring)
+    cdef bint nuc_is_str = isinstance(nuc, str)
+    cdef bint z_is_str = isinstance(z, str)
+    cdef bint rx_is_str = isinstance(rx, str)
     # convert particle to std::string
     z_bytes = z.encode() if z_is_str else z
     ptype = std_string(<char *> z_bytes)

--- a/pyne/serpent.py
+++ b/pyne/serpent.py
@@ -1,7 +1,5 @@
 import re
-import sys
 import numpy as np
-import pdb
 from pyne.utils import QA_warn
 
 QA_warn(__name__)

--- a/pyne/serpent.py
+++ b/pyne/serpent.py
@@ -4,9 +4,6 @@ import numpy as np
 import pdb
 from pyne.utils import QA_warn
 
-if sys.version_info[0] > 2:
-    basestring = str
-
 QA_warn(__name__)
 
 _if_idx_str_serpent1 = (
@@ -138,7 +135,7 @@ def parse_res(resfile, write_py=False):
         a complete description of contents.
 
     """
-    if isinstance(resfile, basestring):
+    if isinstance(resfile, str):
         with open(resfile, "r") as mfile:
             f = mfile.read()
     else:
@@ -223,7 +220,7 @@ def parse_res(resfile, write_py=False):
 
     # Write the file out
     if write_py:
-        if isinstance(resfile, basestring):
+        if isinstance(resfile, str):
             new_filename = resfile.rpartition(".")[0] + ".py"
         else:
             new_filename = resfile.name.rpartition(".")[0] + ".py"
@@ -260,7 +257,7 @@ def parse_dep(depfile, write_py=False, make_mats=True):
         manual for a complete description of contents.
 
     """
-    if isinstance(depfile, basestring):
+    if isinstance(depfile, str):
         with open(depfile, "r") as mfile:
             f = mfile.read()
     else:
@@ -321,7 +318,7 @@ def parse_dep(depfile, write_py=False, make_mats=True):
 
     # Write the file out
     if write_py:
-        if isinstance(depfile, basestring):
+        if isinstance(depfile, str):
             new_filename = depfile.rpartition(".")[0] + ".py"
         else:
             new_filename = depfile.name.rpartition(".")[0] + ".py"
@@ -369,7 +366,7 @@ def parse_det(detfile, write_py=False):
         a complete description of contents.
 
     """
-    if isinstance(detfile, basestring):
+    if isinstance(detfile, str):
         with open(detfile, "r") as mfile:
             f = mfile.read()
     else:
@@ -424,7 +421,7 @@ def parse_det(detfile, write_py=False):
 
     # Write the file out
     if write_py:
-        if isinstance(detfile, basestring):
+        if isinstance(detfile, str):
             new_filename = detfile.rpartition(".")[0] + ".py"
         else:
             new_filename = detfile.name.rpartition(".")[0] + ".py"

--- a/pyne/stlcontainers.pyx
+++ b/pyne/stlcontainers.pyx
@@ -40,9 +40,6 @@ from libcpp.string cimport string as std_string
 # Imports For Types
 import numpy as np
 
-if PY_MAJOR_VERSION >= 3:
-    basestring = str
-
 # Dirty ifdef, else, else preprocessor hack
 # see http://comments.gmane.org/gmane.comp.python.cython.user/4080
 cdef extern from *:
@@ -119,7 +116,7 @@ cdef class _SetStr:
     def __contains__(self, value):
         cdef std_string s
         cdef char * value_proxy
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             value_bytes = value.encode()
             s = std_string(<char *> value_bytes)
         else:
@@ -381,7 +378,7 @@ cdef class _MapStrStr:
     def __contains__(self, key):
         cdef std_string k
         cdef char * key_proxy
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             return False
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -404,7 +401,7 @@ cdef class _MapStrStr:
         cdef std_string v
         cdef char * key_proxy
 
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError("Only string keys are valid.")
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -532,7 +529,7 @@ cdef class _MapStrInt:
     def __contains__(self, key):
         cdef std_string k
         cdef char * key_proxy
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             return False
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -555,7 +552,7 @@ cdef class _MapStrInt:
         cdef int v
         cdef char * key_proxy
 
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError("Only string keys are valid.")
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -834,7 +831,7 @@ cdef class _MapStrUInt:
     def __contains__(self, key):
         cdef std_string k
         cdef char * key_proxy
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             return False
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -857,7 +854,7 @@ cdef class _MapStrUInt:
         cdef extra_types.uint32 v
         cdef char * key_proxy
 
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError("Only string keys are valid.")
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -1136,7 +1133,7 @@ cdef class _MapStrDouble:
     def __contains__(self, key):
         cdef std_string k
         cdef char * key_proxy
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             return False
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -1159,7 +1156,7 @@ cdef class _MapStrDouble:
         cdef double v
         cdef char * key_proxy
 
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError("Only string keys are valid.")
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -2065,7 +2062,7 @@ cdef class _MapStrVectorDouble:
     def __contains__(self, key):
         cdef std_string k
         cdef char * key_proxy
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             return False
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)
@@ -2089,7 +2086,7 @@ cdef class _MapStrVectorDouble:
         cdef char * key_proxy
         cdef np.ndarray v_proxy
         cdef np.npy_intp v_proxy_shape[1]
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError("Only string keys are valid.")
         key_bytes = key.encode()
         k = std_string(<char *> key_bytes)

--- a/pyne/xs/cache.py
+++ b/pyne/xs/cache.py
@@ -1,9 +1,6 @@
 """This module offers a cross-section cache that automates the extraction of 
 cross-section data from supplied nuclear data sets."""
-import sys
 import inspect
-
-from itertools import product
 
 try:
     from collections.abc import MutableMapping
@@ -11,11 +8,8 @@ except ImportError:
     from collections import MutableMapping
 
 import numpy as np
-import tables as tb
 
-from pyne import nucname
-from pyne.pyne_config import pyne_conf
-from pyne.xs.models import partial_energy_matrix, phi_g, same_arr_or_none
+from pyne.xs.models import same_arr_or_none
 from pyne.xs import data_source
 from pyne.utils import QA_warn
 

--- a/pyne/xs/cache.py
+++ b/pyne/xs/cache.py
@@ -21,10 +21,6 @@ from pyne.utils import QA_warn
 
 QA_warn(__name__)
 
-if sys.version_info[0] > 2:
-    basestring = str
-
-
 def _valid_group_struct(E_g):
     if E_g is None:
         return None
@@ -107,7 +103,7 @@ class XSCache(MutableMapping):
         """Key lookup by via custom loading from the nuc_data database file."""
         kw = dict(zip(["nuc", "rx", "temp"], key))
         scalar = self._scalars.get(kw["nuc"], None)
-        if (key not in self._cache) and not isinstance(key, basestring):
+        if (key not in self._cache) and not isinstance(key, str):
             E_g = self._cache["E_g"]
             if E_g is None:
                 for ds in self.data_sources:

--- a/pyne/xs/channels.py
+++ b/pyne/xs/channels.py
@@ -5,7 +5,6 @@ for higher-level functionalities, including cross-section computation
 for materials, fission energy spectra, metastable ratios, and more.
 """
 from __future__ import division
-import sys
 import collections
 
 try:
@@ -25,7 +24,6 @@ from .. import rxname
 from ..material import Material
 from . import models
 from . import cache
-from .models import group_collapse
 
 QA_warn(__name__)
 

--- a/pyne/xs/channels.py
+++ b/pyne/xs/channels.py
@@ -29,9 +29,6 @@ from .models import group_collapse
 
 QA_warn(__name__)
 
-if sys.version_info[0] > 2:
-    basestring = str
-
 np.seterr(all="ignore")
 
 
@@ -100,7 +97,7 @@ def sigma_f(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None):
     """
     xs_cache = cache.xs_cache if xs_cache is None else xs_cache
     _prep_cache(xs_cache, group_struct, phi_g)
-    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, basestring):
+    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, str):
         return _atom_mass_channel(sigma_f, nuc, temp=temp, xs_cache=xs_cache)
     nuc = nucname.id(nuc)
     key = (nuc, rxname.id("fission"), temp)
@@ -146,7 +143,7 @@ def sigma_s_gh(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None):
     """
     xs_cache = cache.xs_cache if xs_cache is None else xs_cache
     _prep_cache(xs_cache, group_struct, phi_g)
-    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, basestring):
+    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, str):
         return _atom_mass_channel(sigma_s_gh, nuc, temp=temp, xs_cache=xs_cache)
     nuc = nucname.id(nuc)
     key = (nuc, "s_gh", temp)
@@ -221,7 +218,7 @@ def sigma_s(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None):
     """
     xs_cache = cache.xs_cache if xs_cache is None else xs_cache
     _prep_cache(xs_cache, group_struct, phi_g)
-    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, basestring):
+    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, str):
         return _atom_mass_channel(sigma_s, nuc, temp=temp, xs_cache=xs_cache)
     nuc = nucname.id(nuc)
     key_g = (nuc, "s_g", temp)
@@ -281,7 +278,7 @@ def sigma_a_reaction(nuc, rx, temp=300.0, group_struct=None, phi_g=None, xs_cach
     rx = rxname.id(rx)
     xs_cache = cache.xs_cache if xs_cache is None else xs_cache
     _prep_cache(xs_cache, group_struct, phi_g)
-    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, basestring):
+    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, str):
         return _atom_mass_channel(
             sigma_a_reaction, nuc, rx=rx, temp=temp, xs_cache=xs_cache
         )
@@ -329,7 +326,7 @@ def metastable_ratio(nuc, rx, temp=300.0, group_struct=None, phi_g=None, xs_cach
     pyne.xs.data_source.RX_TYPES_MAP
 
     """
-    if isinstance(nuc, int) or isinstance(nuc, basestring):
+    if isinstance(nuc, int) or isinstance(nuc, str):
         xs_cache = cache.xs_cache if xs_cache is None else xs_cache
         _prep_cache(xs_cache, group_struct, phi_g)
         nuc = nucname.id(nuc)
@@ -382,7 +379,7 @@ def sigma_a(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None):
     """
     xs_cache = cache.xs_cache if xs_cache is None else xs_cache
     _prep_cache(xs_cache, group_struct, phi_g)
-    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, basestring):
+    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, str):
         return _atom_mass_channel(sigma_a, nuc, temp=temp, xs_cache=xs_cache)
     nuc = nucname.id(nuc)
     key = (nuc, rxname.id("absorption"), temp)
@@ -421,7 +418,7 @@ def chi(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None, eres=101)
     """
     xs_cache = cache.xs_cache if xs_cache is None else xs_cache
     _prep_cache(xs_cache, group_struct, phi_g)
-    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, basestring):
+    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, str):
         return _atom_mass_channel(chi, nuc, temp=temp, xs_cache=xs_cache, eres=eres)
     nuc = nucname.id(nuc)
     key = (nuc, "chi", temp)
@@ -489,7 +486,7 @@ def sigma_t(nuc, temp=300.0, group_struct=None, phi_g=None, xs_cache=None):
     """
     xs_cache = cache.xs_cache if xs_cache is None else xs_cache
     _prep_cache(xs_cache, group_struct, phi_g)
-    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, basestring):
+    if isinstance(nuc, collectionsAbc.Iterable) and not isinstance(nuc, str):
         return _atom_mass_channel(sigma_t, nuc, temp=temp, xs_cache=xs_cache)
     nuc = nucname.id(nuc)
     key_a = (nuc, rxname.id("absorption"), temp)

--- a/pyne/xs/data_source.py
+++ b/pyne/xs/data_source.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 import os
 import io
-import sys
 from pyne.utils import QA_warn
 
 try:

--- a/pyne/xs/data_source.py
+++ b/pyne/xs/data_source.py
@@ -35,12 +35,6 @@ QA_warn(__name__)
 
 IO_TYPES = (io.IOBase, StringIO)
 
-py3k = False
-if sys.version_info[0] > 2:
-    basestring = str
-    py3k = True
-
-
 class DataSource(object):
     """Base cross section data source.
 
@@ -532,10 +526,7 @@ class CinderDataSource(DataSource):
 
         # Set query condition
         if rx in self._rx_avail:
-            if py3k:
-                cond = "(from_nuc == {0}) & (reaction_type == {1})"
-            else:
-                cond = "(from_nuc == {0}) & (reaction_type == '{1}')"
+            cond = "(from_nuc == {0}) & (reaction_type == {1})"
             cond = cond.format(nuc, self._rx_avail[rx].encode())
         elif rx == fissrx:
             cond = "nuc == {0}".format(nuc)
@@ -681,10 +672,7 @@ class EAFDataSource(DataSource):
         absrx = rxname.id("absorption")
 
         if rx in self._rx_avail:
-            if py3k is True:
-                cond = "(nuc_zz == {0}) & (rxnum == {1})"
-            else:
-                cond = "(nuc_zz == {0}) & (rxnum == '{1}')"
+            cond = "(nuc_zz == {0}) & (rxnum == {1})"
             cond = cond.format(nuc, self._rx_avail[rx])
         elif rx == absrx:
             cond = "(nuc_zz == {0})".format(nuc)
@@ -767,7 +755,7 @@ class ENDFDataSource(DataSource):
     @property
     def exists(self):
         if self._exists is None:
-            if isinstance(self.fh, basestring):
+            if isinstance(self.fh, str):
                 self._exists = os.path.isfile(self.fh)
             else:
                 self._exists = isinstance(self.fh, IO_TYPES)

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -1,6 +1,4 @@
 from __future__ import print_function
-import sys
-import unittest
 import os.path
 import warnings
 import pytest

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -25,10 +25,7 @@ try:
 except ImportError:
     raise pytest.skip(allow_module_level=True)
 
-if sys.version_info[0] < 3:
-    STRING_TYPES = (basestring, str, unicode)
-else:
-    STRING_TYPES = (str,)
+STRING_TYPES = (str,)
 
 path = os.path.join(os.path.dirname(__file__), "unitbox.h5m")
 


### PR DESCRIPTION
## Description
Removes code that was in place to support Python2 and Python3.  The brunt of this PR is changing references to `basestring` to reference `str` instead.

## Motivation and Context
I noticed the prevalence of `basestring` when working on #1543.  It doesn't necessarily fix the issues experienced in that PR, but it just simplifies the codebase a little bit.

## Changes
Deprecation of Python2 support.
