### PR TITLE
Resolve DAGMC Target Conflict and Improve Test Skips

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Next Version
    * reference python_executable rather than assuming `python` exists ()
    * Update FindMOAB to use MOAB config file (#1526)
    * Remove imp module from tests to support Python 3.12 (#1543)
+   * Resolve DAGMC Target Conflict and Improve Test Skips (#1551)
 
 v0.7.8
 ======

--- a/pyne/CMakeLists.txt
+++ b/pyne/CMakeLists.txt
@@ -52,7 +52,7 @@ install(TARGETS cram LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/pyne")
 # dagmc requires a rename and is only built if we have MOAB.
 #
 if(DAGMC_FOUND)
-  set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/dagmc.pyx"
+  set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/_dagmc.pyx"
                               PROPERTIES CYTHON_IS_CXX TRUE)
   cython_add_module(_dagmc _dagmc.pyx "${PROJECT_SOURCE_DIR}/src/dagmc_bridge.cpp")
   target_link_libraries(_dagmc dagmc MOAB pyne)

--- a/pyne/CMakeLists.txt
+++ b/pyne/CMakeLists.txt
@@ -54,9 +54,8 @@ install(TARGETS cram LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/pyne")
 if(DAGMC_FOUND)
   set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/dagmc.pyx"
                               PROPERTIES CYTHON_IS_CXX TRUE)
-  cython_add_module(_dagmc dagmc.pyx "${PROJECT_SOURCE_DIR}/src/dagmc_bridge.cpp")
+  cython_add_module(_dagmc _dagmc.pyx "${PROJECT_SOURCE_DIR}/src/dagmc_bridge.cpp")
   target_link_libraries(_dagmc dagmc MOAB pyne)
-  set_target_properties(_dagmc PROPERTIES OUTPUT_NAME dagmc)
   install(TARGETS _dagmc LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/pyne")
 endif(DAGMC_FOUND)
 

--- a/pyne/_dagmc.pyx
+++ b/pyne/_dagmc.pyx
@@ -9,7 +9,7 @@ from pyne.utils import QA_warn
 cimport numpy as np
 import numpy as np
 
-from pyne cimport cpp_dagmc_bridge
+cimport cpp_dagmc_bridge
 from pyne.mesh import Mesh
 from numpy.linalg import norm
 from pyne.material import Material

--- a/pyne/_dagmc.pyx
+++ b/pyne/_dagmc.pyx
@@ -19,9 +19,6 @@ np.import_array()
 
 QA_warn(__name__)
 
-if sys.version_info[0] >= 3:
-    unichr = chr
-
 # Mesh specific imports
 from pyne.mesh import HAVE_PYMOAB
 from pymoab import core as mb_core, types
@@ -720,7 +717,7 @@ def _tag_to_string(tag):
         # if the byte char code is non 0
         if (part != 0):
             # convert to ascii and join to string
-            a.append(str(unichr(part)))
+            a.append(str(chr(part)))
             string = ''.join(a)
     return string
 

--- a/pyne/_dagmc.pyx
+++ b/pyne/_dagmc.pyx
@@ -9,7 +9,7 @@ from pyne.utils import QA_warn
 cimport numpy as np
 import numpy as np
 
-cimport cpp_dagmc_bridge
+from pyne cimport cpp_dagmc_bridge
 from pyne.mesh import Mesh
 from numpy.linalg import norm
 from pyne.material import Material

--- a/pyne/dagmc.py
+++ b/pyne/dagmc.py
@@ -1,0 +1,25 @@
+"""
+This module attempts to import the DAGMC module from the PyNE library.
+
+DAGMC (Direct Accelerated Geometry Monte Carlo) is a set of interfaces 
+developed by the University of Wisconsin-Madison which allows Monte Carlo 
+radiation transport codes to use CAD-based geometries. It is used in PyNE 
+to enable complex geometry definitions.
+
+To learn more about DAGMC, visit: https://svalinn.github.io/DAGMC/
+
+For more information on installing PyNE with DAGMC, visit: https://pyne.io/install/
+"""
+
+from warnings import warn
+
+try:
+    from pyne._dagmc import *
+    HAVE_DAGMC = True
+except ImportError:
+    warn(
+        "DAGMC module is not available. Please install PyNE with DAGMC enabled.\n"
+        "For more information, see: https://pyne.io/install/",
+        ImportWarning
+        )
+    HAVE_DAGMC = False

--- a/pyne/dbgen/materials_library.py
+++ b/pyne/dbgen/materials_library.py
@@ -65,10 +65,7 @@ def grab_materials_compendium(location="materials_compendium.csv"):
         The materials in the compendium.
     """
     natural_abund("H1")  # initialize natural_abund_map
-    if sys.version_info[0] > 2:
-        f = open(location, "r", newline="", encoding="utf-8")
-    else:
-        f = open(location, "rb")
+    f = open(location, "r", newline="", encoding="utf-8")
     reader = csv.reader(f, delimiter=",", quotechar='"')
     lines = list(filter(is_comp_matname_or_density, reader))
     mats = parse_materials({}, lines)

--- a/pyne/dbgen/wimsdfpy.py
+++ b/pyne/dbgen/wimsdfpy.py
@@ -19,25 +19,18 @@ subsequent fee for these data.
 """
 from __future__ import print_function
 import os
-import re
-import sys
 import shutil
 from pyne.utils import QA_warn
+from html.parser import HTMLParser
+import numpy as np
+import tables as tb
+from pyne import nucname
+from pyne.dbgen.api import BASIC_FILTERS
 
 try:
     import urllib.request as urllib2
 except ImportError:
     import urllib2
-if sys.version_info[0] >= 3:
-    from html.parser import HTMLParser
-else:
-    from HTMLParser import HTMLParser
-
-import numpy as np
-import tables as tb
-
-from pyne import nucname
-from pyne.dbgen.api import BASIC_FILTERS
 
 QA_warn(__name__)
 

--- a/pyne/fortranformat/FortranRecordReader.py
+++ b/pyne/fortranformat/FortranRecordReader.py
@@ -1,15 +1,8 @@
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
-if IS_PYTHON3:
-    exec("from ._input import input as _input")
-    exec("from ._parser import parser as _parser")
-    exec("from ._lexer import lexer as _lexer")
-else:
-    exec("from _input import input as _input")
-    exec("from _parser import parser as _parser")
-    exec("from _lexer import lexer as _lexer")
+exec("from ._input import input as _input")
+exec("from ._parser import parser as _parser")
+exec("from ._lexer import lexer as _lexer")
 
 
 class FortranRecordReader(object):

--- a/pyne/fortranformat/FortranRecordWriter.py
+++ b/pyne/fortranformat/FortranRecordWriter.py
@@ -1,15 +1,8 @@
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
-if IS_PYTHON3:
-    exec("from ._output import output as _output")
-    exec("from ._lexer import lexer as _lexer")
-    exec("from ._parser import parser as _parser")
-else:
-    exec("from _output import output as _output")
-    exec("from _lexer import lexer as _lexer")
-    exec("from _parser import parser as _parser")
+exec("from ._output import output as _output")
+exec("from ._lexer import lexer as _lexer")
+exec("from ._parser import parser as _parser")
 
 
 class FortranRecordWriter(object):

--- a/pyne/fortranformat/__init__.py
+++ b/pyne/fortranformat/__init__.py
@@ -2,13 +2,6 @@ __version__ = "0.2.5"
 
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
-if IS_PYTHON3:
-    exec("from .FortranRecordReader import FortranRecordReader")
-    exec("from .FortranRecordWriter import FortranRecordWriter")
-    exec("from . import config")
-else:
-    exec("from FortranRecordReader import FortranRecordReader")
-    exec("from FortranRecordWriter import FortranRecordWriter")
-    exec("import config")
+exec("from .FortranRecordReader import FortranRecordReader")
+exec("from .FortranRecordWriter import FortranRecordWriter")
+exec("from . import config")

--- a/pyne/fortranformat/_edit_descriptors.py
+++ b/pyne/fortranformat/_edit_descriptors.py
@@ -1,11 +1,6 @@
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
-if IS_PYTHON3:
-    exec("from ._exceptions import *")
-else:
-    exec("from _exceptions import *")
+exec("from ._exceptions import *")
 
 
 def get_edit_descriptor_obj(name):

--- a/pyne/fortranformat/_input.py
+++ b/pyne/fortranformat/_input.py
@@ -2,16 +2,9 @@ import re
 import pdb
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
-if IS_PYTHON3:
-    exec("from ._edit_descriptors import *")
-    exec("from ._misc import expand_edit_descriptors, has_next_iterator")
-    exec("from . import config")
-else:
-    exec("from _edit_descriptors import *")
-    exec("from _misc import expand_edit_descriptors, has_next_iterator")
-    exec("import config")
+exec("from ._edit_descriptors import *")
+exec("from ._misc import expand_edit_descriptors, has_next_iterator")
+exec("from . import config")
 
 WIDTH_OPTIONAL_EDS = [A]
 NON_WIDTH_EDS = [BN, BZ, P, SP, SS, S, X, T, TR, TL, Colon, Slash]
@@ -238,10 +231,7 @@ def _get_substr(w, record, state):
 
 def _next(it, default=None):
     try:
-        if IS_PYTHON3:
-            val = next(it)
-        else:
-            val = it.next()
+        val = next(it)
     except StopIteration:
         val = default
     return val

--- a/pyne/fortranformat/_lexer.py
+++ b/pyne/fortranformat/_lexer.py
@@ -1,13 +1,8 @@
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
+exec("from ._edit_descriptors import *")
+exec("from ._exceptions import *")
 
-if IS_PYTHON3:
-    exec("from ._edit_descriptors import *")
-    exec("from ._exceptions import *")
-else:
-    exec("from _edit_descriptors import *")
-    exec("from _exceptions import *")
 
 # Some lexer tokens to look out for
 DIGITS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]

--- a/pyne/fortranformat/_misc.py
+++ b/pyne/fortranformat/_misc.py
@@ -3,8 +3,6 @@ Miscellaneous functions, classes etc
 """
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
 
 class has_next_iterator(object):
     """
@@ -24,10 +22,7 @@ class has_next_iterator(object):
         if self._has_next:
             result = self._the_next
         else:
-            if IS_PYTHON3:
-                result = next(self.it)
-            else:
-                result = self.it.next()
+            result = next(self.it)
         self._has_next = None
         return result
 
@@ -35,20 +30,14 @@ class has_next_iterator(object):
         if self._has_next:
             result = self._the_next
         else:
-            if IS_PYTHON3:
-                result = next(self.it)
-            else:
-                result = self.it.next()
+            result = next(self.it)
         self._has_next = None
         return result
 
     def has_next(self):
         if self._has_next is None:
             try:
-                if IS_PYTHON3:
-                    self._the_next = next(self.it)
-                else:
-                    self._the_next = self.it.next()
+                self._the_next = next(self.it)
             except StopIteration:
                 self._has_next = False
             else:

--- a/pyne/fortranformat/_output.py
+++ b/pyne/fortranformat/_output.py
@@ -2,16 +2,9 @@ import math
 import itertools
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
-if IS_PYTHON3:
-    exec("from ._edit_descriptors import *")
-    exec("from ._misc import expand_edit_descriptors, has_next_iterator")
-    exec("from . import config")
-else:
-    exec("from _edit_descriptors import *")
-    exec("from _misc import expand_edit_descriptors, has_next_iterator")
-    exec("import config as config")
+exec("from ._edit_descriptors import *")
+exec("from ._misc import expand_edit_descriptors, has_next_iterator")
+exec("from . import config")
 
 
 PROC_SIGN_ZERO = config.PROC_SIGN_ZERO
@@ -59,10 +52,7 @@ def output(eds, reversion_eds, values):
             break
         # take a edit descriptor off the queue if there is any
         if get_ed.has_next():
-            if IS_PYTHON3:
-                ed = next(get_ed)
-            else:
-                ed = get_ed.next()
+            ed = next(get_ed)
         else:
             if reversion_contains_output_ed == True:
                 # take from reversion edit descriptors if there is a value
@@ -86,10 +76,7 @@ def output(eds, reversion_eds, values):
         # check if edit descriptor requires a value
         if isinstance(ed, OUTPUT_EDS):
             if get_value.has_next():
-                if IS_PYTHON3:
-                    val = next(get_value)
-                else:
-                    val = get_value.next()
+                val = next(get_value)
             else:
                 # is a edit descriptor that requires a value but no value
                 # todo: does it stop gracefully or raise error?

--- a/pyne/fortranformat/_parser.py
+++ b/pyne/fortranformat/_parser.py
@@ -1,17 +1,9 @@
 import sys
 
-IS_PYTHON3 = sys.version_info[0] >= 3
-
-if IS_PYTHON3:
-    exec("from ._lexer import Token")
-    exec("from ._edit_descriptors import *")
-    exec("from ._exceptions import *")
-    exec("from . import config")
-else:
-    exec("from _lexer import Token")
-    exec("from _edit_descriptors import *")
-    exec("from _exceptions import *")
-    exec("import config")
+exec("from ._lexer import Token")
+exec("from ._edit_descriptors import *")
+exec("from ._exceptions import *")
+exec("from . import config")
 
 
 def parser(tokens, version=None):
@@ -122,10 +114,7 @@ def _expand_parens(tokens):
             nesting = 1
             while nesting > 0:
                 try:
-                    if IS_PYTHON3:
-                        t1 = next(get_tokens)
-                    else:
-                        t1 = get_tokens.next()
+                    t1 = next(get_tokens)
                 except StopIteration:
                     raise InvalidFormat("Open parens in format")
                 if t1.type == "LEFT_PARENS":

--- a/pyne/fortranformat/config.py
+++ b/pyne/fortranformat/config.py
@@ -17,10 +17,8 @@ ALLOW_ZERO_WIDTH_EDS = True
 RECORD_SEPARATOR = "\n"
 
 # The maximum size for an integer
-if sys.version_info[0] >= 3:
-    PROC_MAXINT = sys.maxsize
-else:
-    PROC_MAXINT = sys.maxint
+PROC_MAXINT = sys.maxsize
+
 # Processor dependant default for including leading plus or not
 PROC_INCL_PLUS = False
 # Option to allow signed binary, octal and hex on input (not a FORTRAN feature)
@@ -42,10 +40,7 @@ PROC_BLANKS_AS_ZEROS = False
 def reset():
     global RET_WRITTEN_VARS_ONLY, RET_UNWRITTEN_VARS_NONE, PROC_INCL_PLUS, PROC_ALLOW_NEG_BOZ, PROC_PAD_CHAR, PROC_NEG_AS_ZERO, PROC_SIGN_ZERO, PROC_MIN_FIELD_WIDTH, PROC_DECIMAL_CHAR, G0_NO_BLANKS, PROC_NO_LEADING_BLANK, PROC_BLANKS_AS_ZEROS, PROC_MAXINT, G_INPUT_TRIAL_EDS, ALLOW_ZERO_WIDTH_EDS
     G_INPUT_TRIAL_EDS = ["F", "L", "A"]
-    if sys.version_info[0] >= 3:
-        PROC_MAXINT = sys.maxsize
-    else:
-        PROC_MAXINT = sys.maxint
+    PROC_MAXINT = sys.maxsize
     RET_WRITTEN_VARS_ONLY = False
     RET_UNWRITTEN_VARS_NONE = True
     PROC_INCL_PLUS = False

--- a/pyne/mcnp.py
+++ b/pyne/mcnp.py
@@ -43,10 +43,8 @@ else:
         ImportWarning,
     )
 
-if sys.version_info[0] > 2:
-
-    def cmp(a, b):
-        return (a > b) - (a < b)
+def cmp(a, b):
+    return (a > b) - (a < b)
 
 
 class Mctal(object):

--- a/pyne/openmc_utils.py
+++ b/pyne/openmc_utils.py
@@ -5,20 +5,16 @@ import os
 import io
 import sys
 from warnings import warn
+import numpy as np
+import tables as tb
+from html.parser import HTMLParser
+from pyne.mesh import MeshTally, HAVE_PYMOAB
 
 try:
     from collections.abc import namedtuple
 except ImportError:
     from collections import namedtuple
-import numpy as np
-import tables as tb
 
-if sys.version_info[0] == 2:
-    from HTMLParser import HTMLParser
-else:
-    from html.parser import HTMLParser
-
-from pyne.mesh import MeshTally, HAVE_PYMOAB
 
 if HAVE_PYMOAB:
     from pyne.mesh import NativeMeshTag
@@ -163,11 +159,8 @@ class CrossSections(HTMLParser):
             This is a path to the cross_sections.xml file, a file handle, or
             None indicating an empty container.
         """
-        # HTMLParser is only a new-style class in python 3
-        if sys.version_info[0] > 2:
-            super(CrossSections, self).__init__()
-        else:
-            HTMLParser.__init__(self)
+
+        super(CrossSections, self).__init__()
         self.reset()
         self._tag = None
         self.path = None

--- a/pyne/partisn.py
+++ b/pyne/partisn.py
@@ -229,10 +229,7 @@ def _get_material_lib(hdf5, data_hdf5path, **kwargs):
     for mat_name in mats:
         mat_name = mat_name.decode("utf-8")
         fluka_name = mats[mat_name].metadata["fluka_name"]
-        if sys.version_info[0] > 2:
-            unique_names[mat_name] = str(fluka_name.encode(), "utf-8")
-        else:
-            unique_names[mat_name] = fluka_name.decode("utf-8")
+        unique_names[mat_name] = str(fluka_name.encode(), "utf-8")
 
         if collapse:
             mats_collapsed[fluka_name] = mats[mat_name].collapse_elements(mat_except)

--- a/pyne/variancereduction.py
+++ b/pyne/variancereduction.py
@@ -5,14 +5,6 @@ import numpy as np
 from pyne.particle import mcnp
 from .mcnp import Wwinp
 from pyne.mesh import Mesh, MeshError, HAVE_PYMOAB
-
-# The buildin zip in python3 behaves as itertools.izip as python2.
-# For python2, we need to import izip as zip.
-# For python3, do nothing with zip.
-try:
-    from itertools import izip as zip
-except ImportError:
-    pass
 from warnings import warn
 from pyne.utils import QA_warn
 

--- a/scripts/ssw_combine.py
+++ b/scripts/ssw_combine.py
@@ -6,8 +6,6 @@ entries with a combined header. The SurfSrc.__cmp__() method is reimplemented
 to compare only the parts of the ssr files that matter for this operation.
 """
 
-from itertools import izip
-
 from numpy import copysign
 
 from pyne.mcnp import SurfSrc
@@ -97,7 +95,7 @@ def combine_multiple_ss_files(newssrname, ssrnames):
     ssrfiles[0].read_tracklist()
     newssr.tracklist = ssrfiles[0].tracklist
 
-    for ssrfile, trackoffset in izip(ssrfiles[1:], trackoffsets[1:]):
+    for ssrfile, trackoffset in zip(ssrfiles[1:], trackoffsets[1:]):
         ssrfile.read_tracklist()
         for cnt, trackdata in enumerate(ssrfile.tracklist):
             trackdata.nps += copysign(trackoffset, trackdata.nps)

--- a/tests/test_activation_responses.py
+++ b/tests/test_activation_responses.py
@@ -14,6 +14,7 @@ from pyne.material import Material
 from pyne.utils import QAWarning, file_block_almost_same
 from pyne.alara import response_to_hdf5, response_hdf5_to_mesh, _make_response_dtype
 from pyne.mesh import Mesh, NativeMeshTag, HAVE_PYMOAB
+from pyne.dagmc import HAVE_DAGMC
 
 if not HAVE_PYMOAB:
     pytest.skip(allow_module_level=True)
@@ -136,7 +137,7 @@ def test_responses_to_hdf5_multiple():
     # skip test if h5diff not exist
     is_h5diff = os.system("which h5diff")
     if is_h5diff != 0:
-        pytest.skip()
+        pytest.skip("h5diff not found", allow_module_level=True)
 
     for response in responses:
         # read  output.txt and write h5 file
@@ -248,7 +249,7 @@ def _activation_responses_test_step2(activation_responses_run_dir):
     # skip test if h5diff not exist
     is_h5diff = os.system("which h5diff")
     if is_h5diff != 0:
-        raise pytest.skip()
+        raise pytest.skip("h5diff not found", allow_module_level=True)
 
     os.chdir(thisdir)
     # copy ../scripts/activation_responses.py to activation_responses_run_dir/activation_responses.py
@@ -313,10 +314,8 @@ def _activation_responses_test_step2(activation_responses_run_dir):
 
 def test_activation_responses_script():
     # skip test without dagmc
-    try:
-        from pyne import dagmc
-    except ImportError:
-        raise pytest.skip()
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     activation_responses_run_dir = os.path.join(
         thisdir, "files_test_activation_responses", "activation_responses_examples"

--- a/tests/test_activation_responses.py
+++ b/tests/test_activation_responses.py
@@ -19,11 +19,6 @@ from pyne.dagmc import HAVE_DAGMC
 if not HAVE_PYMOAB:
     pytest.skip(allow_module_level=True)
 
-if sys.version_info[0] > 2:
-    izip = zip
-else:
-    from itertools import izip
-
 warnings.simplefilter("ignore", QAWarning)
 
 thisdir = os.path.dirname(__file__)

--- a/tests/test_activation_responses.py
+++ b/tests/test_activation_responses.py
@@ -90,7 +90,7 @@ def test_response_to_hdf5():
     # skip test if h5diff not exist
     is_h5diff = os.system("which h5diff")
     if is_h5diff != 0:
-        pytest.skip()
+        pytest.skip("h5diff not found", allow_module_level=True)
 
     for response in responses:
         # read  output.txt and write h5 file

--- a/tests/test_ahot.py
+++ b/tests/test_ahot.py
@@ -3,7 +3,7 @@ import pytest
 try:
     from spatial_solvers import ahot_script
 except:
-     raise pytest.skip("No ahot_script available", allow_module_level=True)
+    pytest.skip("No module named pyne.transport_spatial_methods", allow_module_level=True)
 
 def test_ahotn_ln():
     ahot_script.test_ahotn_ln()

--- a/tests/test_alara.py
+++ b/tests/test_alara.py
@@ -42,7 +42,7 @@ def test_write_fluxin_single():
     """
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     output_name = "fluxin.out"
     forward_fluxin = os.path.join(
@@ -77,7 +77,7 @@ def test_write_fluxin_single_without_bar():
     """
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     output_name = "fluxin.out"
     forward_fluxin = os.path.join(
@@ -112,7 +112,7 @@ def test_write_fluxin_multiple():
     """
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     output_name = "fluxin.out"
     forward_fluxin = os.path.join(
@@ -160,7 +160,7 @@ def test_write_fluxin_multiple_subvoxel():
     """
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     output_name = "fluxin_subvoxel.out"
     forward_fluxin = os.path.join(
@@ -267,7 +267,7 @@ def test_photon_source_hdf5_to_mesh():
     """Tests the function photon source_h5_to_mesh."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     filename = os.path.join(thisdir, "files_test_alara", "phtn_src")
     photon_source_to_hdf5(filename, chunkshape=(10,))
@@ -296,7 +296,7 @@ def test_photon_source_hdf5_to_mesh_subvoxel():
     under sub-voxel r2s condition."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     filename = os.path.join(thisdir, "files_test_alara", "phtn_src")
     photon_source_to_hdf5(filename, chunkshape=(10,))
@@ -361,7 +361,7 @@ def test_photon_source_hdf5_to_mesh_subvoxel_size1():
     under sub-voxel r2s condition."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     filename = os.path.join(thisdir, "files_test_alara", "phtn_src")
     photon_source_to_hdf5(filename, chunkshape=(10,))
@@ -423,7 +423,7 @@ def test_photon_source_hdf5_to_mesh_subvoxel_size1():
 def test_record_to_geom():
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     expected_geom = os.path.join(thisdir, "files_test_alara", "alara_record_geom.txt")
     expected_matlib = os.path.join(
@@ -487,7 +487,7 @@ def test_record_to_geom():
 def test_record_to_geom_subvoxel():
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     expected_geom = os.path.join(
         thisdir, "files_test_alara", "alara_record_geom_subvoxel.txt"
@@ -552,7 +552,7 @@ def test_record_to_geom_subvoxel():
 def test_mesh_to_geom():
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     expected_geom = os.path.join(thisdir, "files_test_alara", "alara_geom.txt")
     expected_matlib = os.path.join(thisdir, "files_test_alara", "alara_matlib.txt")
@@ -595,7 +595,7 @@ def test_mesh_to_geom():
 def test_num_den_to_mesh_shutdown():
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     filename = os.path.join(thisdir, "files_test_alara", "num_density_output.txt")
     m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1, 2]])
@@ -642,7 +642,7 @@ def test_num_den_to_mesh_shutdown():
 def test_num_den_to_mesh_stdout():
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     filename = os.path.join(thisdir, "files_test_alara", "num_density_output.txt")
     m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1, 2]])
@@ -692,7 +692,7 @@ def test_num_den_to_mesh_stdout():
 def test_num_den_to_mesh_1_y():
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     filename = os.path.join(thisdir, "files_test_alara", "num_density_output.txt")
     m = Mesh(structured=True, structured_coords=[[0, 1], [0, 1], [0, 1, 2]])

--- a/tests/test_cccc.py
+++ b/tests/test_cccc.py
@@ -83,7 +83,7 @@ def test_rtflux_basics():
 def test_rtflux_3D():
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     from pyne.mesh import Mesh, NativeMeshTag
 
     rt = Rtflux("files_test_cccc/rtflux_3D")
@@ -172,7 +172,7 @@ def test_rtflux_3D():
 
 def test_rtflux_2D():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     from pyne.mesh import Mesh, NativeMeshTag
 
     rt = Rtflux("files_test_cccc/rtflux_2D")
@@ -221,7 +221,7 @@ def test_rtflux_2D():
 
 def test_rt_flux_1D():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     from pyne.mesh import Mesh, NativeMeshTag
 
     rt = Rtflux("files_test_cccc/rtflux_1D")
@@ -244,7 +244,7 @@ def test_rt_flux_1D():
 
 def test_rtflux_raises():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     from pyne.mesh import Mesh, NativeMeshTag
 
     rt = Rtflux("files_test_cccc/rtflux_1D")
@@ -262,7 +262,7 @@ def test_atflux_adjoint():
 def test_atflux_eng_order():
     """Ensure the energy order is read in reverse for atflux file."""
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     from pyne.mesh import Mesh, NativeMeshTag
 
     # This file is created with: source=1 174R 0 0 1 40R 0

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -5,20 +5,16 @@ import pytest
 from numpy.testing import assert_array_equal
 import multiprocessing
 import numpy as np
-
 from pyne.mesh import HAVE_PYMOAB
-
 from pyne.utils import QAWarning
 
 warnings.simplefilter("ignore", QAWarning)
 
-try:
-    from pyne.mesh import Mesh
+from pyne.mesh import Mesh
+from pyne.dagmc import HAVE_DAGMC
 
-    # See if dagmc module exists but do not import it
-    from pyne import dagmc
-except ImportError:
-    raise pytest.skip(allow_module_level=True)
+if not HAVE_DAGMC:
+    pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
 STRING_TYPES = (str,)
 

--- a/tests/test_dagmc.py
+++ b/tests/test_dagmc.py
@@ -5,13 +5,11 @@ import pytest
 from numpy.testing import assert_array_equal
 import multiprocessing
 import numpy as np
-from pyne.mesh import HAVE_PYMOAB
+from pyne.mesh import Mesh, HAVE_PYMOAB
 from pyne.utils import QAWarning
+from pyne.dagmc import HAVE_DAGMC
 
 warnings.simplefilter("ignore", QAWarning)
-
-from pyne.mesh import Mesh
-from pyne.dagmc import HAVE_DAGMC
 
 if not HAVE_DAGMC:
     pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -4,14 +4,9 @@ import os
 import sys
 import json
 import warnings
+from urllib.request import urlretrieve
+from functools import lru_cache
 
-if sys.version_info[0] >= 3:
-    from urllib.request import urlretrieve
-    from functools import lru_cache
-else:
-    from urllib import urlretrieve
-
-    lru_cache = lambda *args, **kwargs: (lambda f: f)
 
 
 import numpy as np
@@ -96,11 +91,7 @@ def pivot_mat_keys():
     """
     nuc_keys = {}
     for key in MATS.keys():
-        if sys.version_info[0] >= 3:
-            key = str(key, encoding="UTF-8")
-        else:
-            key = str(key).encode("UTF-8")
-
+        key = str(key, encoding="UTF-8")
         _, nuc, t = key.split("_")
         nuc = int(nuc)
         if nuc in METASTABLE_BLACKLIST:

--- a/tests/test_endf.py
+++ b/tests/test_endf.py
@@ -25,7 +25,7 @@ def try_download(url, target, sha):
     try:
         download_file(url, target, sha)
     except:
-        pytest.skip(url + " not available")
+        pytest.skip(url + " is broken or sha mismatched.")
 
 
 def ignore_future_warnings(func):
@@ -104,7 +104,7 @@ def test_endftod():
 
 def test_loadtape():
     try_download(
-        "http://www.nndc.bnl.gov/endf/b6.8/tapes/tape.100",
+        "https://www.nndc.bnl.gov/endf-b6.8/tapes/tape.100",
         "endftape.100",
         "b56dd0aee38bd006c58181e473232776",
     )
@@ -719,7 +719,6 @@ def test_int_linlin():
     obs = library.integrate_tab_range(2, exp_Eint, exp_xs)
     exp = (3 * 13.5 + 6 * 2.5 + 10 * 1.5) / 19.0
     assert_allclose(exp, obs, rtol=1e-12)
-    return exp
 
 
 def test_int_linlin_interpolation():
@@ -838,7 +837,7 @@ def test_discretize():
         import urllib
 
     try_download(
-        "http://t2.lanl.gov/nis/data/data/ENDFB-VII.1-neutron/Ni/59", "Ni59.txt", ""
+        "http://t2.lanl.gov/nis/data/data/ENDFB-VII.1-neutron/Ni/59", "Ni59.txt", "35414d113b6c17456fd3cf94b83fa091"
     )
 
     endfds = ENDFDataSource("Ni59.txt")
@@ -880,7 +879,7 @@ def test_discretize():
         724.64216445611373,
     ]
     assert_array_almost_equal(nonelastic_c, exp)
-    os.remove(Ni59.txt)
+    os.remove("Ni59.txt")
 
 
 def test_photoatomic():

--- a/tests/test_endl.py
+++ b/tests/test_endl.py
@@ -4,23 +4,13 @@ import io
 import warnings
 import sys
 from hashlib import md5
-
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
-
 from pyne.utils import QAWarning
-
-warnings.simplefilter("ignore", QAWarning)
 from pyne.endl import Library
-
-if sys.version_info[0] > 2:
-    from io import StringIO
-else:
-    from StringIO import StringIO
-
-
 from utils import download_file
 
+warnings.simplefilter("ignore", QAWarning)
 
 def test_loadfile():
     download_file(

--- a/tests/test_ensdf_processing.py
+++ b/tests/test_ensdf_processing.py
@@ -16,7 +16,7 @@ def test_alphad():
     try:
         output_dict = ensdf_processing.alphad(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Alphad not found", allow_module_level=True)
     exceptions = [[2, "DATE RUN"]]
     file_comp(
         input_dict["report_file"],
@@ -69,7 +69,7 @@ def test_bldhst():
     try:
         output_dict = ensdf_processing.bldhst(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Bldhst not found", allow_module_level=True)
     ref_table = "ensdf_processing/bldhst/ref_icctbl.dat"
     ref_index = "ensdf_processing/bldhst/ref_iccndx.dat"
     d_table = file_comp(input_dict["output_table_file"], ref_table, [])
@@ -85,7 +85,7 @@ def test_delta():
     try:
         output_dict = ensdf_processing.delta(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Delta not found", allow_module_level=True)
     # exceptions contain lines in the ouptut that can have a tolerable
     # precision difference
     exceptions = [
@@ -153,7 +153,7 @@ def test_gtol():
     try:
         output_dict = ensdf_processing.gtol(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Gtol not found", allow_module_level=True)
     ref_output_report = "ensdf_processing/gtol/ref_gtol.rpt"
     exceptions = [[1, "DATE:"], [1, "INPUT-FILE name:"], [1, "TIME:"]]
     d_report = file_comp(input_dict["report_file"], ref_output_report, exceptions)
@@ -173,7 +173,7 @@ def test_hsicc():
     try:
         output_dict = ensdf_processing.hsicc(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Hsicc not found", allow_module_level=True)
     ref_report = "ensdf_processing/hsicc/ref_hscalc.lst"
     ref_card_deck = "ensdf_processing/hsicc/ref_cards.new"
     ref_comparison_report = "ensdf_processing/hsicc/ref_compar.lst"
@@ -196,7 +196,7 @@ def test_hsmrg():
     try:
         output_dict = ensdf_processing.hsmrg(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Hsmrg not found", allow_module_level=True)
     ref_deck = "ensdf_processing/hsmrg/ref_cards.mrg"
     d_report = file_comp(input_dict["merged_data_deck"], ref_deck, [])
     cleanup_tmp()
@@ -212,7 +212,7 @@ def test_seqhst():
     try:
         output_dict = ensdf_processing.seqhst(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Seqhst not found", allow_module_level=True)
     ref_sequence = "ensdf_processing/seqhst/ref_iccseq.dat"
     d_report = file_comp(input_dict["sequential_output_file"], ref_sequence, [])
     cleanup_tmp()
@@ -228,7 +228,7 @@ def test_logft():
     try:
         output_dict = ensdf_processing.logft(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Logft not found", allow_module_level=True)
     ref_output_data_set = "ensdf_processing/logft/ref_logft.new"
     d_data = file_comp(input_dict["output_data_set"], ref_output_data_set, [])
     cleanup_tmp()
@@ -243,7 +243,7 @@ def test_radd():
     try:
         ensdf_processing.radd(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Radd not found", allow_module_level=True)
     ref_output = "ensdf_processing/radd/ref_output.out"
     d_report = file_comp(input_dict["output_file"], ref_output, [])
     cleanup_tmp()
@@ -295,7 +295,7 @@ def test_ruler():
     try:
         output_dict = ensdf_processing.ruler(input_dict)
     except OSError:
-        pytest.skip()
+        pytest.skip("Ruler not found", allow_module_level=True)
     ref_output = "ensdf_processing/ruler/ref_ruler.rpt"
     exceptions = [[1, "         INPUT FILE:"], [1, "RULER Version 3.2d [20-Jan-2009]"]]
     d_report = file_comp(input_dict["output_report_file"], ref_output, exceptions)
@@ -308,7 +308,7 @@ def create_tmp():
 
 
 def cleanup_tmp():
-    shutil.rmtree(tmp_path)
+    shutil.rmtree(tmp_path, ignore_errors=True)
 
 
 def file_comp(file_out, file_ref, exceptions):

--- a/tests/test_fluka.py
+++ b/tests/test_fluka.py
@@ -14,7 +14,7 @@ def test_single_usrbin():
     """Test a usrbin file containing a single tally."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     usrbin_file = os.path.join(thisdir, "fluka_usrbin_single.lis")
@@ -114,7 +114,7 @@ def test_multiple_usrbin():
     """Test a usrbin file containing multiple (two) tallies."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     usrbin_file = os.path.join(thisdir, "fluka_usrbin_multiple.lis")
@@ -304,7 +304,7 @@ def test_degenerate_usrbin():
     """
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     usrbin_file = os.path.join(thisdir, "fluka_usrbin_degenerate.lis")
@@ -455,7 +455,7 @@ def test_degenerate_usrbin():
 
 def test_mesh_write():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     usrbin_file = os.path.join(thisdir, "fluka_usrbin_single.lis")

--- a/tests/test_mcnp.py
+++ b/tests/test_mcnp.py
@@ -767,7 +767,7 @@ def test_write_to_hdf5():
 # and ouputs are easily strung together.
 def test_wwinp_n():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     wwinp_file = os.path.join(thisdir, "mcnp_wwinp_wwinp_n.txt")
@@ -930,7 +930,7 @@ def test_wwinp_n():
 
 def test_wwinp_p():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     wwinp_file = os.path.join(thisdir, "mcnp_wwinp_wwinp_p.txt")
@@ -1061,7 +1061,7 @@ def test_wwinp_p():
 
 def test_wwinp_np():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     wwinp_file = os.path.join(thisdir, "mcnp_wwinp_wwinp_np.txt")
@@ -1207,7 +1207,7 @@ def test_single_meshtally_meshtal():
     """Test a meshtal file containing a single mesh tally."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     meshtal_file = os.path.join(thisdir, "mcnp_meshtal_single_meshtal.txt")
@@ -1279,7 +1279,7 @@ def test_multiple_meshtally_meshtal():
     """
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     thisdir = os.path.dirname(__file__)
     meshtal_file = os.path.join(thisdir, "mcnp_meshtal_multiple_meshtal.txt")
@@ -1409,7 +1409,7 @@ def test_multiple_meshtally_meshtal():
 
 def test_mesh_to_geom():
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     mats = {
         0: Material({"H1": 1.0, "K39": 1.0}, density=42.0),

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -4,21 +4,7 @@ import time
 import shutil
 import warnings
 import itertools
-
-# The buildin zip in python3 behaves as itertools.izip as python2.
-# For python2, we need to import izip as zip.
-# For python3, do nothing with zip.
-try:
-    from itertools import izip as zip
-except ImportError:
-    pass
-
-# izip_longest in python3 was renamed to zip_longest in python3
-try:
-    from itertools import izip_longest as zip_longest
-except ImportError:
-    from itertools import zip_longest
-
+from itertools import zip_longest
 from operator import itemgetter
 import pytest
 import numpy as np
@@ -644,7 +630,7 @@ def test_iterate_1d():
 
 
 def test_vtx_iterator():
-    # use vanilla izip as we"ll test using non-equal-length iterators
+    # use vanilla zip as we"ll test using non-equal-length iterators
 
     sm = Mesh(
         structured=True, structured_coords=[range(10, 15), range(21, 25), range(31, 34)]

--- a/tests/test_openmc_utils.py
+++ b/tests/test_openmc_utils.py
@@ -261,7 +261,7 @@ def test_get_result_error_from_openmc_sp():
 
 
 def test_create_meshtally():
-    if not HAVE_PYMOAB or sys.version_info[0] == 2:
+    if not HAVE_PYMOAB:
         pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     try:
         import openmc

--- a/tests/test_openmc_utils.py
+++ b/tests/test_openmc_utils.py
@@ -158,11 +158,11 @@ def test_calc_structured_coords():
 
 def test_get_e_bounds_from_openmc_sp():
     if not HAVE_PYMOAB or sys.version_info[0] == 2:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     try:
         import openmc
     except:
-        pytest.skip()
+        pytest.skip("No openmc. Skipping tests", allow_module_level=True)
     # energy bin: [0.0, 1.0, 20.0], 2bins
     # 6 volume elemenes
     filename = os.path.join(cwd, "files_test_openmc", "statepoint.10.h5")
@@ -201,11 +201,11 @@ def test_flux_changes_order():
 
 def test_get_result_error_from_openmc_sp():
     if not HAVE_PYMOAB or sys.version_info[0] == 2:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     try:
         import openmc
     except:
-        pytest.skip()
+        pytest.skip("No openmc. Skipping tests", allow_module_level=True)
     filename = os.path.join(
         os.getcwd(), "files_test_openmc", "statepoint.10.h5"
     )
@@ -262,11 +262,11 @@ def test_get_result_error_from_openmc_sp():
 
 def test_create_meshtally():
     if not HAVE_PYMOAB or sys.version_info[0] == 2:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     try:
         import openmc
     except:
-        pytest.skip()
+        pytest.skip("No openmc. Skipping tests", allow_module_level=True)
     # mesh read from openmc state point file
     # Parameters of the tally and mesh
     # mesh = openmc_utils.Mesh(mesh_id=1, name="n_flux")

--- a/tests/test_openmc_utils.py
+++ b/tests/test_openmc_utils.py
@@ -157,7 +157,7 @@ def test_calc_structured_coords():
 
 
 def test_get_e_bounds_from_openmc_sp():
-    if not HAVE_PYMOAB or sys.version_info[0] == 2:
+    if not HAVE_PYMOAB:
         pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     try:
         import openmc
@@ -200,7 +200,7 @@ def test_flux_changes_order():
 
 
 def test_get_result_error_from_openmc_sp():
-    if not HAVE_PYMOAB or sys.version_info[0] == 2:
+    if not HAVE_PYMOAB:
         pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     try:
         import openmc

--- a/tests/test_partisn.py
+++ b/tests/test_partisn.py
@@ -13,6 +13,7 @@ import unittest
 from pyne.mesh import Mesh, NativeMeshTag, HAVE_PYMOAB
 from pyne.utils import QAWarning
 from pyne import partisn
+from pyne.dagmc import HAVE_DAGMC
 
 warnings.simplefilter("ignore", QAWarning)
 
@@ -137,7 +138,7 @@ def test_get_coord_sys_1D():
     """Test the _get_coord_sys function for a 1D mesh."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     # Create mesh
     xvals = [0.0, 2.0]
@@ -162,7 +163,7 @@ def test_get_coord_sys_2D():
     """Test the _get_coord_sys function for a 2D mesh."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     # Create mesh
     xvals = [-1.0, 0.0, 2.0]
@@ -187,7 +188,7 @@ def test_get_coord_sys_3D():
     """Test the _get_coord_sys function for a 3D mesh."""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     # Create mesh
     xvals = [-1.0, 0.0, 2.0]
@@ -215,6 +216,8 @@ def test_get_coord_sys_3D():
 def get_zones_no_void():
     """Test the _get_zones function if no void is in the meshed area."""
 
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
     from pyne import dagmc
     # hdf5 test file
     THIS_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -266,13 +269,11 @@ def get_zones_no_void():
 def test_get_zones_no_void():
     """Test the _get_zones function if no void is in the meshed area."""
 
-    try:
-        from pyne import dagmc
-    except:
-        raise pytest.skip()
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
     p = multiprocessing.Pool()
     r = p.apply_async(get_zones_no_void)
     p.close()
@@ -321,13 +322,12 @@ def get_zones_iteration_order():
 
 def test_get_zones_iteration_order():
     """Test that _get_zones function gives results in zyx order."""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     p = multiprocessing.Pool()
     r = p.apply_async(get_zones_iteration_order)
@@ -338,6 +338,9 @@ def test_get_zones_iteration_order():
 
 def get_zones_with_void():
     """Test the _get_zones function if a void is present."""
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     from pyne import dagmc
     # hdf5 test file
@@ -391,13 +394,12 @@ def get_zones_with_void():
 
 def test_get_zones_with_void():
     """Test the _get_zones function if a void is present."""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     p = multiprocessing.Pool()
     r = p.apply_async(get_zones_with_void)
@@ -466,13 +468,12 @@ def write_partisn_input_1D():
 
 def test_write_partisn_input_1D():
     """Test full input file creation for 1D case"""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     p = multiprocessing.Pool()
     r = p.apply_async(write_partisn_input_1D)
@@ -523,13 +524,12 @@ def write_partisn_input_2D():
 
 def test_write_partisn_input_2D():
     """Test full input file creation for 2D case"""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     p = multiprocessing.Pool()
     r = p.apply_async(write_partisn_input_2D)
@@ -580,13 +580,12 @@ def write_partisn_input_3D():
 
 def test_write_partisn_input_3D():
     """Test full input file creation for 3D case"""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     p = multiprocessing.Pool()
     r = p.apply_async(write_partisn_input_3D)
@@ -644,13 +643,12 @@ def write_partisn_input_with_names_dict():
 
 def test_write_partisn_input_with_names_dict():
     """Test full input file creation for 1D case with a names_dict provided"""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     p = multiprocessing.Pool()
     r = p.apply_async(write_partisn_input_with_names_dict)
@@ -744,7 +742,7 @@ def test_write_partisn_input_options():
     """Test full input file creation for 1D case with a lot of key work args"""
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     p = multiprocessing.Pool()
     r = p.apply_async(write_partisn_input_options)
@@ -764,13 +762,12 @@ def test_format_repeated_vector():
 
 def test_mesh_to_isotropic_source():
     """Test isotropic SOURCF generation."""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     m = Mesh(structured=True, structured_coords=[range(5), range(5), range(5)])
     m.src = NativeMeshTag(4, float)
@@ -860,13 +857,12 @@ def test_mesh_to_isotropic_source():
 
 def test_isotropic_vol_source():
     """Test isotropic volumetric source generation from DAGMC geometry."""
-    try:
-        from pyne import dagmc
-    except:
-        pytest.skip()
+
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     if not HAVE_PYMOAB:
-        pytest.skip()
+        pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
 
     sc = np.linspace(-25, 25, 6)
     m = Mesh(structured=True, structured_coords=[sc, sc, sc])

--- a/tests/test_r2s.py
+++ b/tests/test_r2s.py
@@ -22,16 +22,10 @@ from pyne.r2s import (
 )
 from pyne.utils import QAWarning, file_almost_same, file_block_almost_same
 from pyne.mesh import Mesh, NativeMeshTag, HAVE_PYMOAB
+from pyne.dagmc import HAVE_DAGMC
 
 if not HAVE_PYMOAB:
     pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
-    
-from pyne.dagmc import HAVE_DAGMC
-
-if sys.version_info[0] > 2:
-    izip = zip
-else:
-    from itertools import izip
 
 warnings.simplefilter("ignore", QAWarning)
 
@@ -147,7 +141,7 @@ def irradiation_setup_structured(flux_tag="n_flux", meshtal_file="meshtal_2x2x1"
     tot_errs = [6.01522e-02, 6.13336e-02, 6.19920e-02, 5.98742e-02]
 
     i = 0
-    for nf, nfe, nft, nfte, comp, density in izip(
+    for nf, nfe, nft, nfte, comp, density in zip(
         n_flux, n_flux_err, n_flux_total, n_flux_err_total, comps, densities
     ):
         assert density == pytest.approx(1.962963e00)
@@ -346,7 +340,7 @@ def irradiation_setup_unstructured(flux_tag="n_flux"):
     tot_errs = [6.01522e-02, 6.13336e-02, 6.19920e-02, 5.98742e-02]
 
     i = 0
-    for nf, nfe, nft, nfte, comp, density in izip(
+    for nf, nfe, nft, nfte, comp, density in zip(
         n_flux, n_flux_err, n_flux_total, n_flux_err_total, comps, densities
     ):
         assert density == pytest.approx(2.0)

--- a/tests/test_r2s.py
+++ b/tests/test_r2s.py
@@ -25,6 +25,8 @@ from pyne.mesh import Mesh, NativeMeshTag, HAVE_PYMOAB
 
 if not HAVE_PYMOAB:
     pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
+    
+from pyne.dagmc import HAVE_DAGMC
 
 if sys.version_info[0] > 2:
     izip = zip
@@ -671,10 +673,8 @@ def _r2s_test_step2(r2s_run_dir, remove_step1_out=True):
 
 def test_r2s_script_step_by_step():
     # skip test without dagmc
-    try:
-        from pyne import dagmc
-    except ImportError:
-        pytest.skip()
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     remove_step1_out = True
     r2s_run_dir = os.path.join(thisdir, "files_test_r2s", "r2s_examples", "r2s_run")
@@ -696,7 +696,7 @@ def test_r2s_script_step_by_step():
     try:
         import openmc
     except:
-        pytest.skip()
+        pytest.skip("No openmc. Skipping tests", allow_module_level=True)
     r2s_run_dir = os.path.join(thisdir, "files_test_r2s", "r2s_examples", "openmc_r2s")
     _r2s_test_step1(r2s_run_dir, remove_step1_out)
     _r2s_test_step2(r2s_run_dir, remove_step1_out)
@@ -704,10 +704,8 @@ def test_r2s_script_step_by_step():
 
 def test_r2s_script():
     # skip test without dagmc
-    try:
-        from pyne import dagmc
-    except ImportError:
-        pytest.skip()
+    if not HAVE_DAGMC:
+        pytest.skip("No DAGMC. Skipping tests", allow_module_level=True)
 
     remove_step1_out = False
     # test voxel r2s
@@ -730,7 +728,7 @@ def test_r2s_script():
     try:
         import openmc
     except ImportError:
-        pytest.skip()
+        pytest.skip("No openmc. Skipping tests", allow_module_level=True)
     r2s_run_dir = os.path.join(thisdir, "files_test_r2s", "r2s_examples", "openmc_r2s")
     _r2s_test_step1(r2s_run_dir, remove_step1_out)
     _r2s_test_step2(r2s_run_dir, remove_step1_out)

--- a/tests/test_rxname.py
+++ b/tests/test_rxname.py
@@ -2,16 +2,11 @@
 from __future__ import unicode_literals, division
 import sys
 import warnings
-
 import pytest
-
+from pyne import rxname
 from pyne.utils import QAWarning
 
 warnings.simplefilter("ignore", QAWarning)
-from pyne import rxname
-
-if sys.version_info[0] > 2:
-    long = int
 
 
 def _hash(s):
@@ -74,8 +69,8 @@ def test_name_ids():
     assert rxname.name(_hash("a")) == "a"
     assert rxname.name(_hash("total")) == "total"
 
-    assert rxname.name(long(_hash("a"))) == "a"
-    assert rxname.name(long(_hash("total"))) == "total"
+    assert rxname.name(int(_hash("a"))) == "a"
+    assert rxname.name(int(_hash("total"))) == "total"
 
     assert rxname.name(str(_hash("a"))) == "a"
     assert rxname.name(str(_hash("total"))) == "total"
@@ -85,8 +80,8 @@ def test_name_mts():
     assert rxname.name(107) == "a"
     assert rxname.name(1) == "total"
 
-    assert rxname.name(long(107)) == "a"
-    assert rxname.name(long(1)) == "total"
+    assert rxname.name(int(107)) == "a"
+    assert rxname.name(int(1)) == "total"
 
     assert rxname.name("107") == "a"
     assert rxname.name("1") == "total"
@@ -117,8 +112,8 @@ def test_id_ids():
     assert rxname.id(_hash("a")) == _hash("a")
     assert rxname.id(_hash("total")) == _hash("total")
 
-    assert rxname.id(long(_hash("a"))) == _hash("a")
-    assert rxname.id(long(_hash("total"))) == _hash("total")
+    assert rxname.id(int(_hash("a"))) == _hash("a")
+    assert rxname.id(int(_hash("total"))) == _hash("total")
 
     assert rxname.id(str(_hash("a"))) == _hash("a")
     assert rxname.id(str(_hash("total"))) == _hash("total")
@@ -128,8 +123,8 @@ def test_id_mts():
     assert rxname.id(107) == _hash("a")
     assert rxname.id(1) == _hash("total")
 
-    assert rxname.id(long(107)) == _hash("a")
-    assert rxname.id(long(1)) == _hash("total")
+    assert rxname.id(int(107)) == _hash("a")
+    assert rxname.id(int(1)) == _hash("total")
 
     assert rxname.id("107") == _hash("a")
     assert rxname.id("1") == _hash("total")
@@ -160,8 +155,8 @@ def test_mt_ids():
     assert rxname.mt(_hash("a")) == 107
     assert rxname.mt(_hash("total")) == 1
 
-    assert rxname.mt(long(_hash("a"))) == 107
-    assert rxname.mt(long(_hash("total"))) == 1
+    assert rxname.mt(int(_hash("a"))) == 107
+    assert rxname.mt(int(_hash("total"))) == 1
 
     assert rxname.mt(str(_hash("a"))) == 107
     assert rxname.mt(str(_hash("total"))) == 1
@@ -171,8 +166,8 @@ def test_mt_mts():
     assert rxname.mt(107) == 107
     assert rxname.mt(1) == 1
 
-    assert rxname.mt(long(107)) == 107
-    assert rxname.mt(long(1)) == 1
+    assert rxname.mt(int(107)) == 107
+    assert rxname.mt(int(1)) == 1
 
     assert rxname.mt("107") == 107
     assert rxname.mt("1") == 1
@@ -225,8 +220,8 @@ def test_label_ids():
     assert rxname.label(_hash("a")) == alabel
     assert rxname.label(_hash("total")) == totlabel
 
-    assert rxname.label(long(_hash("a"))) == alabel
-    assert rxname.label(long(_hash("total"))) == totlabel
+    assert rxname.label(int(_hash("a"))) == alabel
+    assert rxname.label(int(_hash("total"))) == totlabel
 
     assert rxname.label(str(_hash("a"))) == alabel
     assert rxname.label(str(_hash("total"))) == totlabel
@@ -236,8 +231,8 @@ def test_label_mts():
     assert rxname.label(107) == alabel
     assert rxname.label(1) == totlabel
 
-    assert rxname.label(long(107)) == alabel
-    assert rxname.label(long(1)) == totlabel
+    assert rxname.label(int(107)) == alabel
+    assert rxname.label(int(1)) == totlabel
 
     assert rxname.label("107") == alabel
     assert rxname.label("1") == totlabel
@@ -274,8 +269,8 @@ def test_doc_ids():
     assert rxname.doc(_hash("a")) == adoc
     assert rxname.doc(_hash("total")) == totdoc
 
-    assert rxname.doc(long(_hash("a"))) == adoc
-    assert rxname.doc(long(_hash("total"))) == totdoc
+    assert rxname.doc(int(_hash("a"))) == adoc
+    assert rxname.doc(int(_hash("total"))) == totdoc
 
     assert rxname.doc(str(_hash("a"))) == adoc
     assert rxname.doc(str(_hash("total"))) == totdoc
@@ -285,8 +280,8 @@ def test_doc_mts():
     assert rxname.doc(107) == adoc
     assert rxname.doc(1) == totdoc
 
-    assert rxname.doc(long(107)) == adoc
-    assert rxname.doc(long(1)) == totdoc
+    assert rxname.doc(int(107)) == adoc
+    assert rxname.doc(int(1)) == totdoc
 
     assert rxname.doc("107") == adoc
     assert rxname.doc("1") == totdoc

--- a/tests/test_source_sampling.py
+++ b/tests/test_source_sampling.py
@@ -18,7 +18,11 @@ except ImportError:
     pytest.skip("Can't import mesh, skipping tests", allow_module_level=True)
 
 from pyne.source_sampling import Sampler, AliasTable
-from pyne.mesh import Mesh, NativeMeshTag
+from pyne.mesh import Mesh, NativeMeshTag, HAVE_PYMOAB
+
+if not HAVE_PYMOAB:
+    pytest.skip("No pymoab. Skipping tests", allow_module_level=True)
+
 from pyne.r2s import tag_e_bounds
 from pymoab import core as mb_core, types
 from pyne.utils import QAWarning


### PR DESCRIPTION
## Summary

This PR refactors the PyNE build system to handle the conflict caused by the existing `dagmc` target while using Scikit Build Core. Additionally, I have improved the test suite by updating the pytest skips with clear reasons. Key changes include:

1. **Resolving DAGMC Target Conflict:**
   - In the legacy build system, we were managing the `dagmc` target using the line:
     ```cmake
     set_target_properties(_dagmc PROPERTIES OUTPUT_NAME dagmc)
     ```
     However, in the new approach, this method was not feasible. To resolve the conflict:
     - Renamed `dagmc.pyx` to `_dagmc.pyx`, which automatically creates a target `_dagmc` when building the Cython module.
     - Introduced a new `dagmc.py` that loads the `_dagmc` module.
  
2. **Test Suite Updates:**
   - Updated the test files to reflect the changes in the module name.
   - Improved the pytest skip statements by adding clear reasons for each skip, enhancing the understandability and maintainability of the test suite.

## Notes

This refactor ensures compatibility with the Scikit Build Core while preserving the integrity of the module structure and resolving conflicts with the `dagmc` target. The added reasons for pytest skips improve clarity during test runs.
