### PR TITLE
CI for MacOS 

### DIFF
--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -79,7 +79,7 @@ jobs:
           export CXX=$CONDA_PREFIX/bin/clang++
           export CPP=$CONDA_PREFIX/bin/clang-cpp
           mkdir -p $(python3 -m site --user-site)
-          python3 setup.py install --user -j 3
+          python3 setup.py install --user -j 3 -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path)
           export PATH=$HOME/.local/bin:$PATH
           nuc_data_make
           cd tests && ./ci-run-tests.sh python3

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -85,7 +85,7 @@ jobs:
           gfortran -v
           echo $PATH
           mkdir -p $(python3 -m site --user-site)
-          python3 setup.py install --user -j 3
+          python3 setup.py install --user -j 3 -DCMAKE_Fortran_FLAGS="-isysroot $(xcrun --show-sdk-path)"
           export PATH=$HOME/.local/bin:$PATH
           nuc_data_make
           cd tests && ./ci-run-tests.sh python3

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -63,7 +63,6 @@ jobs:
               compilers \
               cmake \
               make \
-              gfortran \
               libblas \
               liblapack \
               eigen \

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -78,12 +78,6 @@ jobs:
           export CXX=$CONDA_PREFIX/bin/clang++
           export CPP=$CONDA_PREFIX/bin/clang-cpp
           export FC=$CONDA_PREFIX/bin/gfortran
-
-          sw_vers
-          xcode-select -p
-          xcrun --show-sdk-path
-          gfortran -v
-          echo $PATH
           mkdir -p $(python3 -m site --user-site)
           python3 setup.py install --user -j 3 -DCMAKE_Fortran_FLAGS="-isysroot $(xcrun --show-sdk-path)"
           export PATH=$HOME/.local/bin:$PATH

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         macos_versions: [
-            macos-12,
             macos-13,
             macos-14,
         ]
@@ -78,8 +77,9 @@ jobs:
           export CC=$CONDA_PREFIX/bin/clang
           export CXX=$CONDA_PREFIX/bin/clang++
           export CPP=$CONDA_PREFIX/bin/clang-cpp
+          export FC=$CONDA_PREFIX/bin/gfortran
           mkdir -p $(python3 -m site --user-site)
-          python3 setup.py install --user -j 3 -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path)
+          python3 setup.py install --user -j 3
           export PATH=$HOME/.local/bin:$PATH
           nuc_data_make
           cd tests && ./ci-run-tests.sh python3

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -79,7 +79,7 @@ jobs:
           export CPP=$CONDA_PREFIX/bin/clang-cpp
           export FC=$CONDA_PREFIX/bin/gfortran
           mkdir -p $(python3 -m site --user-site)
-          python3 setup.py install --user -j 3 -DCMAKE_Fortran_FLAGS="-isysroot $(xcrun --show-sdk-path)"
+          python3 setup.py install --user -j 3
           export PATH=$HOME/.local/bin:$PATH
           nuc_data_make
           cd tests && ./ci-run-tests.sh python3

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -1,0 +1,89 @@
+name: MacOS Build/Test Pyne
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - ".github/workflows/build_test.yml"
+      - ".github/workflows/changelog_test.yml"
+      - ".github/workflows/conda_docker.yml"
+      - ".github/workflows/docker_publish.yml"
+      - ".github/workflows/install_script.yml"
+      - ".github/workflows/virtualbox_image.yml"
+      - "doc/**"
+      - "CHANGELOG.rst"
+  push:
+    paths-ignore:
+      - ".github/workflows/build_test.yml"
+      - ".github/workflows/changelog_test.yml"
+      - ".github/workflows/conda_docker.yml"
+      - ".github/workflows/docker_publish.yml"
+      - ".github/workflows/install_script.yml"
+      - ".github/workflows/virtualbox_image.yml"
+      - "doc/**"
+      - "CHANGELOG.rst"
+
+jobs:
+  build-test-conda:
+    strategy:
+      fail-fast: false
+      matrix:
+        macos_versions: [
+            macos-12,
+            macos-13,
+            macos-14,
+        ]
+
+    runs-on: ["${{ matrix.macos_versions }}"]
+
+    steps:
+      - name: Setup XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest
+
+      - name: Checkout Pyne
+        uses: actions/checkout@v4
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: "latest"
+          conda-solver: "libmamba"
+          auto-update-conda: true
+          channels: conda-forge
+
+      - name: Build and Test Pyne
+        id: build-pyne
+        shell: bash -el {0}
+        run: |
+          mamba install -y \
+              expat \
+              compilers \
+              cmake \
+              make \
+              gfortran \
+              libblas \
+              liblapack \
+              eigen \
+              numpy \
+              scipy \
+              matplotlib \
+              git \
+              setuptools \
+              pytest \
+              pytables \
+              jinja2 \
+              cython \
+              future \
+              progress \
+              meson
+          export CC=$CONDA_PREFIX/bin/clang
+          export CXX=$CONDA_PREFIX/bin/clang++
+          export CPP=$CONDA_PREFIX/bin/clang-cpp
+          mkdir -p $(python3 -m site --user-site)
+          python3 setup.py install --user -j 3
+          export PATH=$HOME/.local/bin:$PATH
+          nuc_data_make
+          cd tests && ./ci-run-tests.sh python3

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -78,6 +78,12 @@ jobs:
           export CXX=$CONDA_PREFIX/bin/clang++
           export CPP=$CONDA_PREFIX/bin/clang-cpp
           export FC=$CONDA_PREFIX/bin/gfortran
+
+          sw_vers
+          xcode-select -p
+          xcrun --show-sdk-path
+          gfortran -v
+          echo $PATH
           mkdir -p $(python3 -m site --user-site)
           python3 setup.py install --user -j 3
           export PATH=$HOME/.local/bin:$PATH

--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -59,13 +59,11 @@ jobs:
         shell: bash -el {0}
         run: |
           mamba install -y \
-              expat \
               compilers \
               cmake \
               make \
               libblas \
               liblapack \
-              eigen \
               numpy \
               scipy \
               matplotlib \
@@ -76,8 +74,7 @@ jobs:
               jinja2 \
               cython \
               future \
-              progress \
-              meson
+              progress
           export CC=$CONDA_PREFIX/bin/clang
           export CXX=$CONDA_PREFIX/bin/clang++
           export CPP=$CONDA_PREFIX/bin/clang-cpp

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Next Version
    * Add dockerfile and workflow to build PyNE with Conda (#1540)
    * Support Cython3+ (#1528)
    * Remove deprecated references to ``basestring`` (#1544)
+   * Add CI for MacOS (#1557)
 
 **Fix**
    * Fix Type Mismatch Error in PyNE's ENSDF Processing Module (#1519)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ enable_language(ASM)
 set(BUILD_SHARED_LIBS true)
 message("-- CMake Install Prefix: ${CMAKE_INSTALL_PREFIX}")
 
+if(APPLE)
+  message("OSX_SYSROOT: ${CMAKE_OSX_SYSROOT}")
+  link_directories("${CMAKE_OSX_SYSROOT}/usr/lib")
+endif()
+
 
 #
 # Allow for dependnecies to exist in non-install location

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Setup the project
 project(pyne)
+message("CMAKE_OSX_SYSROOT: ${CMAKE_OSX_SYSROOT}")
 
 # check for and enable c++11 support
 INCLUDE(CheckCXXCompilerFlag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Setup the project
 project(pyne)
-message("CMAKE_OSX_SYSROOT: ${CMAKE_OSX_SYSROOT}")
 
 # check for and enable c++11 support
 INCLUDE(CheckCXXCompilerFlag)
@@ -44,6 +43,7 @@ message("-- CMake Install Prefix: ${CMAKE_INSTALL_PREFIX}")
 if(APPLE)
   message("OSX_SYSROOT: ${CMAKE_OSX_SYSROOT}")
   link_directories("${CMAKE_OSX_SYSROOT}/usr/lib")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
 endif()
 
 

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -222,11 +222,11 @@ endmacro()
 
 macro(pyne_download_platform)
   # Download bateman solver from PyNE data
-  download_platform("http://raw.githubusercontent.com/pyne/data/master" "decay"
+  download_platform("http://raw.githubusercontent.com/bennibbelink/pyne-data/apple-arm" "decay"
                       ".cpp" ".s")
 
   # Download CRAM solver from PyNE data
-  download_platform("http://raw.githubusercontent.com/pyne/data/master" "cram"
+  download_platform("http://raw.githubusercontent.com/bennibbelink/pyne-data/apple-arm" "cram"
                          ".c" ".s")
 endmacro()
 

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -222,11 +222,11 @@ endmacro()
 
 macro(pyne_download_platform)
   # Download bateman solver from PyNE data
-  download_platform("http://raw.githubusercontent.com/bennibbelink/pyne-data/apple-arm" "decay"
+  download_platform("http://raw.githubusercontent.com/pyne/data/master" "decay"
                       ".cpp" ".s")
 
   # Download CRAM solver from PyNE data
-  download_platform("http://raw.githubusercontent.com/bennibbelink/pyne-data/apple-arm" "cram"
+  download_platform("http://raw.githubusercontent.com/pyne/data/master" "cram"
                          ".c" ".s")
 endmacro()
 

--- a/cmake/PyneMacros.cmake
+++ b/cmake/PyneMacros.cmake
@@ -48,6 +48,10 @@ macro(pyne_set_asm_platform)
   else()
     set(_plat "${_plat}-NOTFOUND")
   endif()
+  # then set architecture
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    set(_plat "${_plat}-arm64")
+  endif()
   set(PYNE_ASM_PLATFORM "${_plat}")
 endmacro()
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -48,7 +48,7 @@ nucvec = {
 leu = {922380000: 0.96, 922350000: 0.04}
 
 # Relative Tolerance
-rtol = 1e-20
+rtol = 1e-15
 
 # Absolute Tolerance
 atol = 0


### PR DESCRIPTION
## Description
This PR adds a CI workflow for MacOS, along with some minor build updates to make this possible.

## Motivation and Context
Closes #1555. 

## Changes
What kind of change does this PR introduce? (Bug fix, feature, documentation update...)

## Other Information
This PR currently references a branch of `pyne/data` to validate that the arm64 versions of cram and decay do in fact work.  Before merging this PR the reference should be modified to reference `pyne/data:main`

- [x] Change `pyne/data` reference back to `main`
