### PR TITLE
Fix `in` operator for MaterialLibrary

### DIFF
--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           mamba install -y \
               compilers \
-              cmake \
+              "cmake<4.0.0" \
               make \
               libblas \
               liblapack \

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Next Version
    * Fix material testing inaccuracies by using assert_allclose for value comparison (#1552)
    * Fix mcnp version check for serial mcnp6 in PtracReader (#1558)
    * Remove duplicate cmake code that checks for compiler compatibility (#1562)
+   * Fix in operator for MaterialLibrary (#1564) 
 
 v0.7.8
 ======

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Defines the CMake commands/policies
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.5.0)
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
   cmake_policy(SET CMP0074 NEW)

--- a/pyne/cpp_material_library.pxd
+++ b/pyne/cpp_material_library.pxd
@@ -1,3 +1,4 @@
+# cpp_material_library.pxd
 """C++ wrapper for material class."""
 from libcpp.set cimport set
 from libcpp.string cimport string as std_string
@@ -7,6 +8,7 @@ from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr
+from libc.stddef cimport size_t
 
 cimport cpp_jsoncpp
 
@@ -44,6 +46,6 @@ cdef extern from "material_library.h" namespace "pyne":
         std_set[std_string] get_keylist() except +
         std_set[int] get_nuclist() except +
         int size() except +
+        size_t count(std_string) except +
         cpp_umap[std_string, shared_ptr[cpp_material.Material]].iterator begin() except +
         cpp_umap[std_string, shared_ptr[cpp_material.Material]].iterator end() except +
-

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -17,6 +17,7 @@ from libcpp.utility cimport pair as cpp_pair
 from libcpp.set cimport set as cpp_set
 from libcpp.string cimport string as std_string
 from libc.stdlib cimport malloc, free
+from libc.stddef cimport size_t
 from libcpp.unordered_map cimport unordered_map as cpp_umap
 from libcpp.memory cimport shared_ptr
 
@@ -227,6 +228,13 @@ cdef class _MaterialLibrary:
         """
         filename = filename.encode()
         self._inst.write_openmc(filename)
+
+    def __contains__(self, key):
+        """Checks if a key exists in the material library."""
+        c_key = ensure_material_key(key)
+        # Call the C++ count method
+        count_result = self._inst.count(<std_string>c_key)
+        return count_result > 0
 
     def __setitem__(self, key, value):
         """Add a Material to this material library, if the material key already exist it will be overwritten.

--- a/tests/ci-run-tests.sh
+++ b/tests/ci-run-tests.sh
@@ -1,18 +1,3 @@
 #!/bin/bash
     
-for x in $(ls test*.py */test*.py); do 
-  echo
-  echo
-  echo "Testing $x:" 
-  echo 
-  if [ $x == "ensdf_processing.py" ]; then
-    pytest test_ensdf_processing.py --process-timeout=120
-  else
-    pytest "$x"
-  fi
-  status=$?
-  if [ $status -ne 0 ] && [ $status -ne 5 ]; then 
-    echo "Testing failed on $x" 
-    exit $status
-  fi
-done
+pytest -ra

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -241,6 +241,33 @@ def test_hdf5_overwrite():
         assert_mat_almost_equal(umatlib[key], rmatlib[key])
     os.remove(filename)
 
+def test_matlib_contains():
+    """Tests the '__contains__' (in operator) behavior."""
+    lib_dict = {"leu": Material(leu), "water": Material({10010000: 2, 80160000: 1})}
+    matlib = MaterialLibrary(lib_dict)
+
+    # Check existing keys
+    assert "leu" in matlib
+    assert b"leu" in matlib
+    assert "water" in matlib
+    assert 123 not in matlib
+
+    # Check non-existent key
+    assert "nonexistent_key" not in matlib
+    assert b"another_missing" not in matlib
+
+    # Verify that checking for non-existent key did not add it
+    original_keys = set(lib_dict.keys())
+    assert set(matlib.keys()) == original_keys
+    assert len(matlib) == len(original_keys)
+
+    # Test with integer key (should be converted to string implicitly by ensure_material_key)
+    matlib[42] = Material({60120000: 1.0})
+    assert 42 in matlib
+    assert "42" in matlib
+    assert 43 not in matlib
+    assert "43" not in matlib
+    assert len(matlib) == len(original_keys) + 1
 
 def test_matlib_query():
     water = Material()

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -258,7 +258,7 @@ def test_matlib_contains():
     assert 123 not in matlib
 
     # Verify that checking for non-existent key did not add it
-    original_keys = set(lib_dict.keys())
+    original_keys = {b"leu", b"water"}
     assert set(matlib.keys()) == original_keys
     assert len(matlib) == len(original_keys)
 

--- a/tests/test_materials_library.py
+++ b/tests/test_materials_library.py
@@ -250,11 +250,12 @@ def test_matlib_contains():
     assert "leu" in matlib
     assert b"leu" in matlib
     assert "water" in matlib
-    assert 123 not in matlib
+    assert b"water" in matlib
 
     # Check non-existent key
     assert "nonexistent_key" not in matlib
     assert b"another_missing" not in matlib
+    assert 123 not in matlib
 
     # Verify that checking for non-existent key did not add it
     original_keys = set(lib_dict.keys())
@@ -268,6 +269,10 @@ def test_matlib_contains():
     assert 43 not in matlib
     assert "43" not in matlib
     assert len(matlib) == len(original_keys) + 1
+
+    # Test with newly added key
+    expected_keys_after_add = {b'leu', b'water', b'42'}
+    assert set(matlib.keys()) == expected_keys_after_add
 
 def test_matlib_query():
     water = Material()


### PR DESCRIPTION
## Description

Currently, checking for membership in a `MaterialLibrary` using the `in` operator (e.g., `"nonexistent_key" in mat_lib`) incorrectly returns `True` even if the key does not exist in the library. This happens because the default `__contains__` implementation relies on `__getitem__`, and `MaterialLibrary.__getitem__` returns a default-constructed Material instead of raising a `KeyError` for missing keys. This behavior is misleading and can lead to bugs.

## Solution

This PR fixes the issue by:

1.  Explicitly implementing the `__contains__` method in the `_MaterialLibrary` Cython class (`material_library.pyx`).
2.  The new `__contains__` method calls the underlying C++ `MaterialLibrary::count()` method, which efficiently and correctly checks for key existence without side effects.
3.  Adding the necessary declaration for `count()` to `cpp_material_library.pxd`.
4.  Adding a new test case (`test_matlib_contains`) to verify the correct behavior of the `in` operator and ensure that checking for non-existent keys does not modify the library.

## Backward Compatibility

This change corrects buggy behavior. Code relying on `"key" in mat_lib` will now receive the correct `False` value for missing keys. Code that implicitly relied on the incorrect `True` return value will break, but this is necessary to fix the bug. The behavior of `mat_lib[key]` (returning a default Material for missing keys) remains unchanged.

## Testing

Added `test_matlib_contains` to `test_material_library.py`.

## Additional Information

Closes #1563 