### PR TITLE
Update docker

### DIFF
--- a/.github/workflows/macos_build_test.yml
+++ b/.github/workflows/macos_build_test.yml
@@ -37,11 +37,6 @@ jobs:
     runs-on: ["${{ matrix.macos_versions }}"]
 
     steps:
-      - name: Setup XCode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest
-
       - name: Checkout Pyne
         uses: actions/checkout@v4
 
@@ -78,8 +73,6 @@ jobs:
           export CXX=$CONDA_PREFIX/bin/clang++
           export CPP=$CONDA_PREFIX/bin/clang-cpp
           export FC=$CONDA_PREFIX/bin/gfortran
-          mkdir -p $(python3 -m site --user-site)
-          python3 setup.py install --user -j 3
-          export PATH=$HOME/.local/bin:$PATH
+          python3 setup.py install --prefix $CONDA_PREFIX -j 4
           nuc_data_make
           cd tests && ./ci-run-tests.sh python3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Next Version
    * Fix mcnp version check for serial mcnp6 in PtracReader (#1558)
    * Remove duplicate cmake code that checks for compiler compatibility (#1562)
    * Fix in operator for MaterialLibrary (#1564) 
+   * Update Dockerfile syntax ()
+   * Remove reference to Python `long` ()
 
 v0.7.8
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,8 @@ Next Version
    * Fix mcnp version check for serial mcnp6 in PtracReader (#1558)
    * Remove duplicate cmake code that checks for compiler compatibility (#1562)
    * Fix in operator for MaterialLibrary (#1564) 
-   * Update Dockerfile syntax ()
-   * Remove reference to Python `long` ()
+   * Update Dockerfile syntax (#1565)
+   * Remove reference to Python `long` (#1565)
 
 v0.7.8
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,8 @@ Next Version
    * Fix mcnp version check for serial mcnp6 in PtracReader (#1558)
    * Remove duplicate cmake code that checks for compiler compatibility (#1562)
    * Fix in operator for MaterialLibrary (#1564) 
-   * Update Dockerfile syntax (#1565)
-   * Remove reference to Python `long` (#1565)
+   * Update Dockerfile syntax (#1566)
+   * Remove reference to Python `long` (#1566)
 
 v0.7.8
 ======

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:${ubuntu_version} AS pyne-deps
 ENV TZ=America/Chicago \
     HOME=/root \
     PATH=/opt/conda/bin:$PATH \
-    LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
+    LD_LIBRARY_PATH=/opt/conda/lib
 
 # Use bash for RUN shell
 SHELL ["/bin/bash", "-c"]

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:${ubuntu_version} AS pyne-deps
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-ENV HOME /root
+ENV HOME=/root
 RUN apt-get update \
     && apt-get install -y --fix-missing \
         wget \
@@ -19,7 +19,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     /bin/bash ~/miniforge.sh -b -p /opt/conda && \
     rm ~/miniforge.sh
     
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH=/opt/conda/bin:$PATH
 
 # install python 3.12 because that's what apt uses
 RUN conda install "python=3.12"
@@ -51,9 +51,9 @@ RUN mamba update -n base conda mamba && \
                 && \
     mamba clean -y --all
 RUN mkdir -p $(python3 -m site --user-site)
-ENV CC /opt/conda/bin/x86_64-conda-linux-gnu-gcc
-ENV CXX /opt/conda/bin/x86_64-conda-linux-gnu-g++
-ENV CPP /opt/conda/bin/x86_64-conda-linux-gnu-cpp
+ENV CC=/opt/conda/bin/x86_64-conda-linux-gnu-gcc
+ENV CXX=/opt/conda/bin/x86_64-conda-linux-gnu-g++
+ENV CPP=/opt/conda/bin/x86_64-conda-linux-gnu-cpp
 
 # install MOAB
 RUN conda install "conda-forge::moab=5.5.1"
@@ -68,21 +68,21 @@ RUN mamba install conda-forge::openmc
 FROM pyne-deps AS pyne
 
 # put conda on the path
-ENV LD_LIBRARY_PATH /opt/conda/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
 
 # make starting directory
 RUN mkdir -p $HOME/opt
 RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
 
-ENV PYNE_MOAB_ARGS "--moab"
-ENV PYNE_DAGMC_ARGS "--dagmc"
+ENV PYNE_MOAB_ARGS="--moab"
+ENV PYNE_DAGMC_ARGS="--dagmc"
 
 COPY . $HOME/opt/pyne
 RUN cd $HOME/opt/pyne \
     && python setup.py install --user \
                                 $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
                                 --clean -j 3;
-ENV PATH $HOME/.local/bin:$PATH
+ENV PATH=$HOME/.local/bin:$PATH
 RUN cd $HOME \
     && nuc_data_make \
     && cd $HOME/opt/pyne/tests \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -1,86 +1,74 @@
-ARG ubuntu_version=22.04
-
+ARG ubuntu_version=24.04
 FROM ubuntu:${ubuntu_version} AS pyne-deps
 
-# Ubuntu Setup
-ENV TZ=America/Chicago
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+# Set environment variables
+ENV TZ=America/Chicago \
+    HOME=/root \
+    PATH=/opt/conda/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
 
-ENV HOME=/root
-RUN apt-get update \
-    && apt-get install -y --fix-missing \
+# Use bash for RUN shell
+SHELL ["/bin/bash", "-c"]
+
+# Base system setup and timezone
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ >/etc/timezone && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         wget \
         bzip2 \
-        ca-certificates \
-    && apt-get clean -y
+        ca-certificates && \
+    apt-get clean -y  && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+# Install Miniforge (Conda) and setup environment
+RUN echo 'export PATH=/opt/conda/bin:$PATH' >/etc/profile.d/conda.sh && \
     wget --quiet "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge.sh && \
-    /bin/bash ~/miniforge.sh -b -p /opt/conda && \
-    rm ~/miniforge.sh
-    
-# put conda on the path
-ENV PATH=/opt/conda/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
-
-# install python 3.12 because that's what apt uses
-RUN conda install --freeze-installed "python=3.12"
-RUN mamba update -n base conda mamba && \
+    bash ~/miniforge.sh -b -p /opt/conda && \
+    rm ~/miniforge.sh && \
+    conda install -y --freeze-installed "python=3.12" && \
     mamba update -y --all && \
-    mamba install -y \
-                expat \
-                gxx_linux-64 \
-                gcc_linux-64 \
-                cmake \
-                make \
-                gfortran \
-                libblas \
-                liblapack \
-                eigen \
-                numpy \
-                scipy \
-                matplotlib \
-                git \
-                setuptools \
-                pytest \
-                pytables \
-                jinja2 \
-                cython \
-                future \
-                progress \
-                meson \
-                && \
-    mamba clean -y --all
+    mamba install -y -c conda-forge \
+        expat \
+        gxx \
+        gcc \
+        cmake \
+        make \
+        gfortran \
+        libblas \
+        liblapack \
+        eigen \
+        numpy \
+        scipy \
+        matplotlib \
+        git \
+        setuptools \
+        pytest \
+        pytables \
+        jinja2 \
+        cython \
+        future \
+        progress \
+        meson \
+        moab \
+        dagmc \
+        openmc && \
+    mamba clean --all -f -y && \
+    rm -rf ~/.cache ~/.conda
 
-ENV CC=/opt/conda/bin/x86_64-conda-linux-gnu-gcc
-ENV CXX=/opt/conda/bin/x86_64-conda-linux-gnu-g++
-ENV CPP=/opt/conda/bin/x86_64-conda-linux-gnu-cpp
-
-# install MOAB
-RUN conda install "conda-forge::moab=5.5.1"
-
-# install DAGMC
-RUN mamba install conda-forge::dagmc
-
-# install OpenMC
-RUN mamba install conda-forge::openmc
-
-# Build/Install PyNE from release branch
+# ------------------------------
+# Stage 2: Build PyNE
+# ------------------------------
 FROM pyne-deps AS pyne
 
-# make starting directory
-RUN mkdir -p $HOME/opt
+# Arguments for PyNE build
+ENV PYNE_MOAB_ARGS="--moab" \
+    PYNE_DAGMC_ARGS="--dagmc"
 
-ENV PYNE_MOAB_ARGS="--moab"
-ENV PYNE_DAGMC_ARGS="--dagmc"
+# Copy PyNE source and build
+COPY . $HOME/pyne
+WORKDIR $HOME/pyne
 
-COPY . $HOME/opt/pyne
-RUN cd $HOME/opt/pyne \
-    && python setup.py install --prefix /opt/conda \
-                                $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
-                                --clean -j 4;
-
-RUN cd $HOME \
-    && nuc_data_make \
-    && cd $HOME/opt/pyne/tests \
-    && pytest -ra
+RUN python setup.py install --prefix /opt/conda $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS --clean -j 4 && \
+    cd tests && \
+    nuc_data_make && \
+    pytest -ra

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -83,5 +83,4 @@ RUN cd $HOME/opt/pyne \
 RUN cd $HOME \
     && nuc_data_make \
     && cd $HOME/opt/pyne/tests \
-    && ./ci-run-tests.sh python3
-    
+    && pytest -ra

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -19,12 +19,13 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     /bin/bash ~/miniforge.sh -b -p /opt/conda && \
     rm ~/miniforge.sh
     
+# put conda on the path
 ENV PATH=/opt/conda/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
 
 # install python 3.12 because that's what apt uses
-RUN conda install "python=3.12"
+RUN conda install --freeze-installed "python=3.12"
 RUN mamba update -n base conda mamba && \
-    conda install --freeze-installed "python=3.12" && \
     mamba update -y --all && \
     mamba install -y \
                 expat \
@@ -50,7 +51,7 @@ RUN mamba update -n base conda mamba && \
                 meson \
                 && \
     mamba clean -y --all
-RUN mkdir -p $(python3 -m site --user-site)
+
 ENV CC=/opt/conda/bin/x86_64-conda-linux-gnu-gcc
 ENV CXX=/opt/conda/bin/x86_64-conda-linux-gnu-g++
 ENV CPP=/opt/conda/bin/x86_64-conda-linux-gnu-cpp
@@ -67,22 +68,18 @@ RUN mamba install conda-forge::openmc
 # Build/Install PyNE from release branch
 FROM pyne-deps AS pyne
 
-# put conda on the path
-ENV LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
-
 # make starting directory
 RUN mkdir -p $HOME/opt
-RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
 
 ENV PYNE_MOAB_ARGS="--moab"
 ENV PYNE_DAGMC_ARGS="--dagmc"
 
 COPY . $HOME/opt/pyne
 RUN cd $HOME/opt/pyne \
-    && python setup.py install --user \
+    && python setup.py install --prefix /opt/conda \
                                 $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
-                                --clean -j 3;
-ENV PATH=$HOME/.local/bin:$PATH
+                                --clean -j 4;
+
 RUN cd $HOME \
     && nuc_data_make \
     && cd $HOME/opt/pyne/tests \

--- a/docker/conda_build.dockerfile
+++ b/docker/conda_build.dockerfile
@@ -21,11 +21,10 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     
 ENV PATH /opt/conda/bin:$PATH
 
-# install python 3.10 because that's what apt uses
-RUN conda update conda
+# install python 3.12 because that's what apt uses
 RUN conda install "python=3.12"
 RUN mamba update -n base conda mamba && \
-    mamba update -y python --no-pin && \
+    conda install --freeze-installed "python=3.12" && \
     mamba update -y --all && \
     mamba install -y \
                 expat \
@@ -60,7 +59,6 @@ ENV CPP /opt/conda/bin/x86_64-conda-linux-gnu-cpp
 RUN conda install "conda-forge::moab=5.5.1"
 
 # install DAGMC
-RUN conda update -n base conda
 RUN mamba install conda-forge::dagmc
 
 # install OpenMC

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -1,5 +1,6 @@
 ARG pyne_test_base=openmc
 ARG ubuntu_version=22.04
+ARG make_cores=4
 
 FROM ubuntu:${ubuntu_version} AS base_python
 
@@ -7,7 +8,7 @@ FROM ubuntu:${ubuntu_version} AS base_python
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-ENV HOME /root
+ENV HOME=/root
 RUN apt-get update \
     && apt-get install -y --fix-missing \
             software-properties-common \
@@ -24,7 +25,7 @@ RUN apt-get update \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
     pip install --upgrade pip; \
-    pip install numpy==1.23 \
+    pip install numpy \
             scipy \
             cython \
             pytest \
@@ -40,7 +41,7 @@ RUN mkdir -p $HOME/opt
 RUN echo "export PATH=$HOME/.local/bin:\$PATH" >> ~/.bashrc
 
 # build HDF5
-ARG build_hdf5="hdf5-1_14_3"
+ARG build_hdf5="hdf5-1.14.6"
 ENV HDF5_INSTALL_PATH=$HOME/opt/hdf5/$build_hdf5
 RUN cd $HOME/opt \
     && mkdir hdf5 \
@@ -48,13 +49,13 @@ RUN cd $HOME/opt \
     && git clone --single-branch --branch $build_hdf5 https://github.com/HDFGroup/hdf5.git \
     && cd hdf5 \
     && ./configure --prefix=$HDF5_INSTALL_PATH --enable-shared \
-    && make -j 3 \
+    && make -j ${make_cores} \
     && make install \
     && cd .. \
     && rm -rf hdf5;
 # put HDF5 on the path
-ENV LD_LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LD_LIBRARY_PATH
-ENV LIBRARY_PATH $HDF5_INSTALL_PATH/lib:$LIBRARY_PATH
+ENV LD_LIBRARY_PATH=$HDF5_INSTALL_PATH/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH=$HDF5_INSTALL_PATH/lib:$LIBRARY_PATH
 RUN echo "export PATH=$PATH:$HDF5_INSTALL_PATH" >> ~/.bashrc
 
 FROM base_python AS moab
@@ -79,7 +80,7 @@ RUN export MOAB_HDF5_ARGS="-DHDF5_ROOT=$HDF5_INSTALL_PATH"; \
             -DBUILD_SHARED_LIBS=ON \
             -DENABLE_BLASLAPACK=OFF \
             -DENABLE_FORTRAN=OFF \
-    && make -j 3 \
+    && make -j ${make_cores} \
     && cd pymoab \
     && pip install . \
     && cd .. \
@@ -88,15 +89,16 @@ RUN export MOAB_HDF5_ARGS="-DHDF5_ROOT=$HDF5_INSTALL_PATH"; \
     && rm -rf moab ;
 
 # put MOAB on the path
-ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
-ENV LIBRARY_PATH $HOME/opt/moab/lib:$LIBRARY_PATH
-ENV PYNE_MOAB_ARGS "--moab $HOME/opt/moab"
+ENV LD_LIBRARY_PATH=$HOME/opt/moab/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH=$HOME/opt/moab/lib:$LIBRARY_PATH
+ENV PYNE_MOAB_ARGS="--moab $HOME/opt/moab"
 
 FROM moab AS dagmc
 # build/install DAGMC
 ENV INSTALL_PATH=$HOME/opt/dagmc
+ARG dagmc_version="v3.2.4"
 RUN cd /root \
-    && git clone --depth 1 --branch stable https://github.com/svalinn/DAGMC.git \
+    && git clone --depth 1 --branch ${dagmc_version} https://github.com/svalinn/DAGMC.git \
     && cd DAGMC \
     && mkdir bld \
     && cd bld \
@@ -108,22 +110,23 @@ RUN cd /root \
                 -DBUILD_MAKE_WATERTIGHT=OFF \
                 -DBUILD_OVERLAP_CHECK=OFF \
                 -DBUILD_TESTS=OFF \
-    && make -j 3\
+    && make -j ${make_cores} \
     && make install \
     && cd ../.. \
     && rm -rf DAGMC
-ENV PYNE_DAGMC_ARGS "--dagmc $HOME/opt/dagmc"
+ENV PYNE_DAGMC_ARGS="--dagmc $HOME/opt/dagmc"
 
 FROM dagmc AS openmc
-ARG openmc_version="v0.14.0"
+ARG openmc_version="v0.15.2"
 # build/install OpenMC Python API
 RUN export HDF5_ROOT="$HDF5_INSTALL_PATH" ; \
     git clone --depth 1 --branch $openmc_version https://github.com/openmc-dev/openmc.git $HOME/opt/openmc \
     && cd  $HOME/opt/openmc \
-    && pip install .
+    && pip install --user .
 
 # Build/Install PyNE from release branch
 FROM ${pyne_test_base} AS pyne
+ARG make_cores=4
 
 COPY . $HOME/opt/pyne
 RUN export PYNE_HDF5_ARGS="--hdf5 $HDF5_INSTALL_PATH"; \
@@ -131,8 +134,8 @@ RUN export PYNE_HDF5_ARGS="--hdf5 $HDF5_INSTALL_PATH"; \
     && python setup.py install --user \
                                 $PYNE_MOAB_ARGS $PYNE_DAGMC_ARGS \
                                 $PYNE_HDF5_ARGS \
-                                --clean -j 3;
-ENV PATH $HOME/.local/bin:$PATH
+                                --clean -j ${make_cores};
+ENV PATH=$HOME/.local/bin:$PATH
 RUN cd $HOME \
     && nuc_data_make \
     && cd $HOME/opt/pyne/tests \

--- a/docker/ubuntu_22.04-dev.dockerfile
+++ b/docker/ubuntu_22.04-dev.dockerfile
@@ -60,6 +60,8 @@ RUN echo "export PATH=$PATH:$HDF5_INSTALL_PATH" >> ~/.bashrc
 
 FROM base_python AS moab
 ARG moab_version="5.5.1"
+ARG make_cores=4
+
 ENV INSTALL_PATH=$HOME/opt/moab
 
 # build MOAB
@@ -97,6 +99,8 @@ FROM moab AS dagmc
 # build/install DAGMC
 ENV INSTALL_PATH=$HOME/opt/dagmc
 ARG dagmc_version="v3.2.4"
+ARG make_cores=4
+
 RUN cd /root \
     && git clone --depth 1 --branch ${dagmc_version} https://github.com/svalinn/DAGMC.git \
     && cd DAGMC \
@@ -117,7 +121,8 @@ RUN cd /root \
 ENV PYNE_DAGMC_ARGS="--dagmc $HOME/opt/dagmc"
 
 FROM dagmc AS openmc
-ARG openmc_version="v0.15.2"
+# pinned at version 0.14 because Ubuntu 22.04 comes with Python 3.10 and 0.15.x requires Python 3.11+
+ARG openmc_version="v0.14.0"  
 # build/install OpenMC Python API
 RUN export HDF5_ROOT="$HDF5_INSTALL_PATH" ; \
     git clone --depth 1 --branch $openmc_version https://github.com/openmc-dev/openmc.git $HOME/opt/openmc \

--- a/pyne/_utils.pyx
+++ b/pyne/_utils.pyx
@@ -152,7 +152,7 @@ def fromendf_tok(s):
     cs = s
     cdef int i, num_entries
     cdef char entry[12]
-    cdef long pos = 0
+    cdef int pos = 0
     cdef np.ndarray[np.float64_t, ndim=1] cdata
     i = 0
     num_entries = len(cs)//81 * 6
@@ -185,7 +185,7 @@ def fromendl_tok(s, num_fields):
     cs = s
     cdef int i, num_entries, num_lines, line_length
     cdef char entry[12]
-    cdef long pos = 0
+    cdef int pos = 0
     cdef np.ndarray[np.float64_t, ndim=1] cdata
     i = 0
     line_length = num_fields*11+1

--- a/pyne/nucname.pyx
+++ b/pyne/nucname.pyx
@@ -114,7 +114,7 @@ def isnuclide(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         flag = cpp_nucname.isnuclide(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         flag = cpp_nucname.isnuclide(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -137,7 +137,7 @@ def iselement(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         flag = cpp_nucname.iselement(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         flag = cpp_nucname.iselement(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -186,7 +186,7 @@ def id(nuc):
     if isinstance(nuc, str):
         nuc = nuc.encode()
         newnuc = cpp_nucname.id(<char *> nuc)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -237,7 +237,7 @@ def znum(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         z = cpp_nucname.znum(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         z = cpp_nucname.znum(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -261,7 +261,7 @@ def anum(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         a = cpp_nucname.anum(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         a = cpp_nucname.anum(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -285,7 +285,7 @@ def snum(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         s = cpp_nucname.snum(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         s = cpp_nucname.snum(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -309,7 +309,7 @@ def zzaaam(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzaaam(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.zzaaam(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -334,7 +334,7 @@ def zzaaam_to_id(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzaaam_to_id(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.zzaaam_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -358,7 +358,7 @@ def zzzaaa(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzzaaa(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.zzzaaa(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -382,7 +382,7 @@ def zzzaaa_to_id(nuc):
     """
     if isinstance(nuc, str):
         newnuc = cpp_nucname.zzzaaa_to_id(<char *> nuc)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.zzzaaa_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -439,7 +439,7 @@ def mcnp_to_id(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.mcnp_to_id(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.mcnp_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -544,7 +544,7 @@ def zzllaaam(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.zzllaaam(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.zzllaaam(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -620,7 +620,7 @@ def serpent_to_id(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.serpent_to_id(<char *> nuc_bytes)
-    #elif isinstance(nuc, int) or isinstance(nuc, long):
+    #elif isinstance(nuc, int):
     #    newnuc = cpp_nucname.serpent_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -672,7 +672,7 @@ def nist_to_id(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.nist_to_id(<char *> nuc_bytes)
-    #elif isinstance(nuc, int) or isinstance(nuc, long):
+    #elif isinstance(nuc, int):
     #    newnuc = cpp_nucname.nist_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -720,7 +720,7 @@ def cinder_to_id(nuc):
     """
     if isinstance(nuc, str):
         newnuc = cpp_nucname.cinder_to_id(<char *> nuc)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.cinder_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -772,7 +772,7 @@ def alara_to_id(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.alara_to_id(<char *> nuc_bytes)
-    #elif isinstance(nuc, int) or isinstance(nuc, long):
+    #elif isinstance(nuc, int):
     #    newnuc = cpp_nucname.alara_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -796,7 +796,7 @@ def sza(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.sza(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.sza(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -821,7 +821,7 @@ def sza_to_id(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.sza_to_id(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.sza_to_id(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -845,7 +845,7 @@ def groundstate(nuc):
     if isinstance(nuc, str):
         nuc_bytes = nuc.encode()
         newnuc = cpp_nucname.groundstate(<char *> nuc_bytes)
-    elif isinstance(nuc, int) or isinstance(nuc, long):
+    elif isinstance(nuc, int):
         newnuc = cpp_nucname.groundstate(<int> nuc)
     else:
         raise NucTypeError(nuc)
@@ -868,7 +868,7 @@ def state_id_to_id(state):
         found, None is returned.
 
     """
-    if isinstance(state, int) or isinstance(state, long):
+    if isinstance(state, int):
         newnuc = cpp_nucname.state_id_to_id(<int> state)
     else:
         raise NucTypeError(state)
@@ -893,7 +893,7 @@ def id_to_state_id(nuc):
         found, None is returned.
 
     """
-    if isinstance(nuc, int) or isinstance(nuc, long):
+    if isinstance(nuc, int):
         newnuc = cpp_nucname.id_to_state_id(<int> nuc)
     else:
         raise NucTypeError(nuc)

--- a/pyne/particle.pyx
+++ b/pyne/particle.pyx
@@ -128,7 +128,7 @@ def name(x):
         x_bytes = x.encode()
         cn = cpp_particle.name(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.name(<int> long(x))
+        cn = cpp_particle.name(<int> x)
 
     n = bytes(<char *> cn.c_str()).decode()
     
@@ -151,7 +151,7 @@ def mcnp(x):
         x_bytes = x.encode()
         cn = cpp_particle.mcnp(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.mcnp(<int> long(x))
+        cn = cpp_particle.mcnp(<int> x)
 
     n = bytes(<char *> cn.c_str()).decode()
     
@@ -175,7 +175,7 @@ def mcnp6(x):
         x_bytes = x.encode()
         cn = cpp_particle.mcnp6(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.mcnp6(<int> long(x))
+        cn = cpp_particle.mcnp6(<int> x)
 
     n = bytes(<char *> cn.c_str()).decode()
     
@@ -199,7 +199,7 @@ def fluka(x):
         x_bytes = x.encode()
         cn = cpp_particle.fluka(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.fluka(<int> long(x))
+        cn = cpp_particle.fluka(<int> x)
 
     n = bytes(<char *> cn.c_str()).decode()
     
@@ -222,7 +222,7 @@ def geant4(x):
         x_bytes = x.encode()
         cn = cpp_particle.geant4(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.geant4(<int> long(x))
+        cn = cpp_particle.geant4(<int> x)
 
     n = bytes(<char *> cn.c_str()).decode()
     
@@ -247,7 +247,7 @@ def describe(x):
         x_bytes = x.encode()
         cn = cpp_particle.describe(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.describe(<int> long(x))
+        cn = cpp_particle.describe(<int> x)
 
     n = bytes(<char *> cn.c_str()).decode()
     
@@ -271,7 +271,7 @@ def id(x):
         x_bytes = x.encode()
         cn = cpp_particle.id(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.id(<int> long(x))
+        cn = cpp_particle.id(<int> x)
 
     n = cn
     
@@ -295,7 +295,7 @@ def is_valid(x):
         x_bytes = x.encode()
         cn = cpp_particle.is_valid(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.is_valid(<int> long(x))
+        cn = cpp_particle.is_valid(<int> x)
 
     n = cn
     
@@ -319,7 +319,7 @@ def is_heavy_ion(x):
         x_bytes = x.encode()
         cn = cpp_particle.is_heavy_ion(std_string(<char *> x_bytes))
     elif isinstance(x, int):
-        cn = cpp_particle.is_heavy_ion(<int> long(x))
+        cn = cpp_particle.is_heavy_ion(<int> x)
 
     n = cn
     

--- a/pyne/rxname.pyx
+++ b/pyne/rxname.pyx
@@ -218,7 +218,7 @@ def name(x, y=None, z="n"):
 
     Parameters
     ----------
-    x : str, int, or long
+    x : str, int
         name, abbreviation, id, MT number, or from nuclide.
     y : str, int, or None, optional
         to nuclide.
@@ -237,8 +237,6 @@ def name(x, y=None, z="n"):
             x_bytes = x.encode()
             cn = cpp_rxname.name(std_string(<char *> x_bytes))
         elif isinstance(x, int):
-            cn = cpp_rxname.name(<extra_types.uint32> long(x))
-        elif isinstance(x, long):
             cn = cpp_rxname.name(<extra_types.uint32> x)
     else:
         if isinstance(x, str):
@@ -266,7 +264,7 @@ def id(x, y=None, z="n"):
 
     Parameters
     ----------
-    x : str, int, or long
+    x : str, int
         name, abbreviation, id, MT number, or from nuclide.
     y : str, int, or None, optional
         to nuclide.
@@ -275,7 +273,7 @@ def id(x, y=None, z="n"):
 
     Returns
     -------
-    rxid : int or long
+    rxid : int
         a unique reaction identifier.
     """
     cdef int from_nuc, to_nuc
@@ -284,8 +282,6 @@ def id(x, y=None, z="n"):
             x_bytes = x.encode()
             rxid = cpp_rxname.id(std_string(<char *> x_bytes))
         elif isinstance(x, int):
-            rxid = cpp_rxname.id(<extra_types.uint32> long(x))
-        elif isinstance(x, long):
             rxid = cpp_rxname.id(<extra_types.uint32> x)
     else:
         if isinstance(x, str):
@@ -310,7 +306,7 @@ def mt(x, y=None, z="n"):
 
     Parameters
     ----------
-    x : str, int, or long
+    x : str, int
         name, abbreviation, id, MT number, or from nuclide.
     y : str, int, or None, optional
         to nuclide.
@@ -319,7 +315,7 @@ def mt(x, y=None, z="n"):
 
     Returns
     -------
-    mtnum : int or long
+    mtnum : int
         a unique MT number.
     """
     cdef int from_nuc, to_nuc
@@ -328,8 +324,6 @@ def mt(x, y=None, z="n"):
             x_bytes = x.encode()
             mtnum = cpp_rxname.mt(std_string(<char *> x_bytes))
         elif isinstance(x, int):
-            mtnum = cpp_rxname.mt(<extra_types.uint32> long(x))
-        elif isinstance(x, long):
             mtnum = cpp_rxname.mt(<extra_types.uint32> x)
     else:
         if isinstance(x, str):
@@ -354,7 +348,7 @@ def label(x, y=None, z="n"):
 
     Parameters
     ----------
-    x : str, int, or long
+    x : str, in
         name, abbreviation, id, MT number, or from nuclide.
     y : str, int, or None, optional
         to nuclide.
@@ -373,8 +367,6 @@ def label(x, y=None, z="n"):
             x_bytes = x.encode()
             clab = cpp_rxname.label(std_string(<char *> x_bytes))
         elif isinstance(x, int):
-            clab = cpp_rxname.label(<extra_types.uint32> long(x))
-        elif isinstance(x, long):
             clab = cpp_rxname.label(<extra_types.uint32> x)
     else:
         if isinstance(x, str):
@@ -400,7 +392,7 @@ def doc(x, y=None, z="n"):
 
     Parameters
     ----------
-    x : str, int, or long
+    x : str, int
         name, abbreviation, id, MT number, or from nuclide.
     y : str, int, or None, optional
         to nuclide.
@@ -419,8 +411,6 @@ def doc(x, y=None, z="n"):
             x_bytes = x.encode()
             cd = cpp_rxname.doc(std_string(<char *> x_bytes))
         elif isinstance(x, int):
-            cd = cpp_rxname.doc(<extra_types.uint32> long(x))
-        elif isinstance(x, long):
             cd = cpp_rxname.doc(<extra_types.uint32> x)
     else:
         if isinstance(x, str):
@@ -478,9 +468,9 @@ def child(nuc, rx, z="n"):
     elif nuc_is_str and not rx_is_str:
         nuc_bytes = nuc.encode()
         to_nuc = cpp_rxname.child(std_string(<char *> nuc_bytes),
-                                  <extra_types.uint32> long(rx), ptype)
+                                  <extra_types.uint32> rx, ptype)
     elif not nuc_is_str and not rx_is_str:
-        to_nuc = cpp_rxname.child(<int> nuc, <extra_types.uint32> long(rx), ptype)
+        to_nuc = cpp_rxname.child(<int> nuc, <extra_types.uint32> rx, ptype)
     return int(to_nuc)
 
 
@@ -523,8 +513,8 @@ def parent(nuc, rx, z="n"):
     elif nuc_is_str and not rx_is_str:
         nuc_bytes = nuc.encode()
         from_nuc = cpp_rxname.parent(std_string(<char *> nuc_bytes),
-                                    <extra_types.uint32> long(rx), ptype)
+                                    <extra_types.uint32> rx, ptype)
     elif not nuc_is_str and not rx_is_str:
-        from_nuc = cpp_rxname.parent(<int> nuc, <extra_types.uint32> long(rx), ptype)
+        from_nuc = cpp_rxname.parent(<int> nuc, <extra_types.uint32> rx, ptype)
     return int(from_nuc)
 

--- a/pyne/stlcontainers.pyx
+++ b/pyne/stlcontainers.pyx
@@ -809,14 +809,14 @@ cdef class _MapStrUInt:
             for key, value in new_map.items():
                 key_bytes = key.encode()
 
-                item = pair[std_string, extra_types.uint32](std_string(<char *> key_bytes), <extra_types.uint32> long(value))
+                item = pair[std_string, extra_types.uint32](std_string(<char *> key_bytes), <extra_types.uint32> value)
                 self.map_ptr.insert(item)
         elif hasattr(new_map, '__len__'):
             self.map_ptr = new cpp_map[std_string, extra_types.uint32]()
             for key, value in new_map:
                 key_bytes = key.encode()
 
-                item = pair[std_string, extra_types.uint32](std_string(<char *> key_bytes), <extra_types.uint32> long(value))
+                item = pair[std_string, extra_types.uint32](std_string(<char *> key_bytes), <extra_types.uint32> value)
                 self.map_ptr.insert(item)
         elif bool(new_map):
             self.map_ptr = new cpp_map[std_string, extra_types.uint32]()
@@ -872,7 +872,7 @@ cdef class _MapStrUInt:
         cdef pair[std_string, extra_types.uint32] item
         key_bytes = key.encode()
 
-        item = pair[std_string, extra_types.uint32](std_string(<char *> key_bytes), <extra_types.uint32> long(value))
+        item = pair[std_string, extra_types.uint32](std_string(<char *> key_bytes), <extra_types.uint32> value)
         if 0 < self.map_ptr.count(std_string(<char *> key_bytes)):
             self.map_ptr.erase(std_string(<char *> key_bytes))
         self.map_ptr.insert(item)
@@ -960,14 +960,14 @@ cdef class _MapUIntStr:
             for key, value in new_map.items():
 
                 value_bytes = value.encode()
-                item = pair[extra_types.uint32, std_string](<extra_types.uint32> long(key), std_string(<char *> value_bytes))
+                item = pair[extra_types.uint32, std_string](<extra_types.uint32> key, std_string(<char *> value_bytes))
                 self.map_ptr.insert(item)
         elif hasattr(new_map, '__len__'):
             self.map_ptr = new cpp_map[extra_types.uint32, std_string]()
             for key, value in new_map:
 
                 value_bytes = value.encode()
-                item = pair[extra_types.uint32, std_string](<extra_types.uint32> long(key), std_string(<char *> value_bytes))
+                item = pair[extra_types.uint32, std_string](<extra_types.uint32> key, std_string(<char *> value_bytes))
                 self.map_ptr.insert(item)
         elif bool(new_map):
             self.map_ptr = new cpp_map[extra_types.uint32, std_string]()
@@ -985,7 +985,7 @@ cdef class _MapUIntStr:
         if not isinstance(key, int):
             return False
 
-        k = <extra_types.uint32> long(key)
+        k = <extra_types.uint32> key
 
         if 0 < self.map_ptr.count(k):
             return True
@@ -1008,7 +1008,7 @@ cdef class _MapUIntStr:
         if not isinstance(key, int):
             raise TypeError("Only unsigned integer keys are valid.")
 
-        k = <extra_types.uint32> long(key)
+        k = <extra_types.uint32> key
 
         if 0 < self.map_ptr.count(k):
             v = deref(self.map_ptr)[k]
@@ -1023,9 +1023,9 @@ cdef class _MapUIntStr:
         cdef pair[extra_types.uint32, std_string] item
 
         value_bytes = value.encode()
-        item = pair[extra_types.uint32, std_string](<extra_types.uint32> long(key), std_string(<char *> value_bytes))
-        if 0 < self.map_ptr.count(<extra_types.uint32> long(key)):
-            self.map_ptr.erase(<extra_types.uint32> long(key))
+        item = pair[extra_types.uint32, std_string](<extra_types.uint32> key, std_string(<char *> value_bytes))
+        if 0 < self.map_ptr.count(<extra_types.uint32> key):
+            self.map_ptr.erase(<extra_types.uint32> key)
         self.map_ptr.insert(item)
 
     def __delitem__(self, key):
@@ -1033,7 +1033,7 @@ cdef class _MapUIntStr:
 
         if key in self:
 
-            k = <extra_types.uint32> long(key)
+            k = <extra_types.uint32> key
             self.map_ptr.erase(k)
 
 
@@ -1262,14 +1262,14 @@ cdef class _MapUIntUInt:
             for key, value in new_map.items():
 
 
-                item = pair[extra_types.uint32, extra_types.uint32](<extra_types.uint32> long(key), <extra_types.uint32> long(value))
+                item = pair[extra_types.uint32, extra_types.uint32](<extra_types.uint32> key, <extra_types.uint32> value)
                 self.map_ptr.insert(item)
         elif hasattr(new_map, '__len__'):
             self.map_ptr = new cpp_map[extra_types.uint32, extra_types.uint32]()
             for key, value in new_map:
 
 
-                item = pair[extra_types.uint32, extra_types.uint32](<extra_types.uint32> long(key), <extra_types.uint32> long(value))
+                item = pair[extra_types.uint32, extra_types.uint32](<extra_types.uint32> key, <extra_types.uint32> value)
                 self.map_ptr.insert(item)
         elif bool(new_map):
             self.map_ptr = new cpp_map[extra_types.uint32, extra_types.uint32]()
@@ -1287,7 +1287,7 @@ cdef class _MapUIntUInt:
         if not isinstance(key, int):
             return False
 
-        k = <extra_types.uint32> long(key)
+        k = <extra_types.uint32> key
 
         if 0 < self.map_ptr.count(k):
             return True
@@ -1310,7 +1310,7 @@ cdef class _MapUIntUInt:
         if not isinstance(key, int):
             raise TypeError("Only unsigned integer keys are valid.")
 
-        k = <extra_types.uint32> long(key)
+        k = <extra_types.uint32> key
 
         if 0 < self.map_ptr.count(k):
             v = deref(self.map_ptr)[k]
@@ -1325,9 +1325,9 @@ cdef class _MapUIntUInt:
         cdef pair[extra_types.uint32, extra_types.uint32] item
 
 
-        item = pair[extra_types.uint32, extra_types.uint32](<extra_types.uint32> long(key), <extra_types.uint32> long(value))
-        if 0 < self.map_ptr.count(<extra_types.uint32> long(key)):
-            self.map_ptr.erase(<extra_types.uint32> long(key))
+        item = pair[extra_types.uint32, extra_types.uint32](<extra_types.uint32> key, <extra_types.uint32> value)
+        if 0 < self.map_ptr.count(<extra_types.uint32> key):
+            self.map_ptr.erase(<extra_types.uint32> key)
         self.map_ptr.insert(item)
 
     def __delitem__(self, key):
@@ -1335,7 +1335,7 @@ cdef class _MapUIntUInt:
 
         if key in self:
 
-            k = <extra_types.uint32> long(key)
+            k = <extra_types.uint32> key
             self.map_ptr.erase(k)
 
 
@@ -1866,14 +1866,14 @@ cdef class _MapUIntDouble:
             for key, value in new_map.items():
 
 
-                item = pair[extra_types.uint32, double](<extra_types.uint32> long(key), <double> value)
+                item = pair[extra_types.uint32, double](<extra_types.uint32> key, <double> value)
                 self.map_ptr.insert(item)
         elif hasattr(new_map, '__len__'):
             self.map_ptr = new cpp_map[extra_types.uint32, double]()
             for key, value in new_map:
 
 
-                item = pair[extra_types.uint32, double](<extra_types.uint32> long(key), <double> value)
+                item = pair[extra_types.uint32, double](<extra_types.uint32> key, <double> value)
                 self.map_ptr.insert(item)
         elif bool(new_map):
             self.map_ptr = new cpp_map[extra_types.uint32, double]()
@@ -1891,7 +1891,7 @@ cdef class _MapUIntDouble:
         if not isinstance(key, int):
             return False
 
-        k = <extra_types.uint32> long(key)
+        k = <extra_types.uint32> key
 
         if 0 < self.map_ptr.count(k):
             return True
@@ -1914,7 +1914,7 @@ cdef class _MapUIntDouble:
         if not isinstance(key, int):
             raise TypeError("Only unsigned integer keys are valid.")
 
-        k = <extra_types.uint32> long(key)
+        k = <extra_types.uint32> key
 
         if 0 < self.map_ptr.count(k):
             v = deref(self.map_ptr)[k]
@@ -1929,9 +1929,9 @@ cdef class _MapUIntDouble:
         cdef pair[extra_types.uint32, double] item
 
 
-        item = pair[extra_types.uint32, double](<extra_types.uint32> long(key), <double> value)
-        if 0 < self.map_ptr.count(<extra_types.uint32> long(key)):
-            self.map_ptr.erase(<extra_types.uint32> long(key))
+        item = pair[extra_types.uint32, double](<extra_types.uint32> key, <double> value)
+        if 0 < self.map_ptr.count(<extra_types.uint32> key):
+            self.map_ptr.erase(<extra_types.uint32> key)
         self.map_ptr.insert(item)
 
     def __delitem__(self, key):
@@ -1939,7 +1939,7 @@ cdef class _MapUIntDouble:
 
         if key in self:
 
-            k = <extra_types.uint32> long(key)
+            k = <extra_types.uint32> key
             self.map_ptr.erase(k)
 
 

--- a/setup.py
+++ b/setup.py
@@ -396,7 +396,7 @@ def parse_args():
     )
     other.add_argument(
         "--spatial_solvers",
-        default=True,
+        default=False,
         action="store_true",
         help="Build spatial solvers (Default)",
     )

--- a/src/source.h
+++ b/src/source.h
@@ -32,7 +32,7 @@ class Source {
   virtual std::string mcnp(int version=5) const {return "";}
 
   // fluka tally
-  virtual std::string fluka() {}
+  virtual std::string fluka() { return ""; }
 };
 
 class PointSource : public Source {


### PR DESCRIPTION
## Description
Updates the Dockerfile to build with more recent versions of dependencies.  Specifically,
* all references to `long` are removed.  They became identical to `int` in a recent version and now create an error, specifically in Cython compilations
* add a `make_cores` Docker build_arg to support variable sized parallel builds at all stages
* updated syntax of Docker `ENV` command
* newer standard version of HDF5 (with newer well-formed version string)
* add a `dagmc_version` Docker build_arg and set a new version as default
* force OpenMC to install in `--user` mode

## Motivation and Context
Build under CI had become unreliable.

## Changes
This addresses bugs in the Docker build
