### PR TITLE
Update cmake and cleanup Docker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ Next Version
    * Fix in operator for MaterialLibrary (#1564) 
    * Update Dockerfile syntax (#1566)
    * Remove reference to Python `long` (#1566)
-   * Update Ubuntu Docker configuration and fix compatibility issues (#1572)
+   * Update Ubuntu Docker configuration and fix compatibility issues (#1572, )
 
 v0.7.8
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ Next Version
    * Fix in operator for MaterialLibrary (#1564) 
    * Update Dockerfile syntax (#1566)
    * Remove reference to Python `long` (#1566)
-   * Update Ubuntu Docker configuration and fix compatibility issues (#1572, )
+   * Update Ubuntu Docker configuration and fix compatibility issues (#1572, #1575)
 
 v0.7.8
 ======

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Defines the CMake commands/policies
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.22.0)
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
   cmake_policy(SET CMP0074 NEW)

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -8,6 +8,8 @@ ARG INSTALL_PATH=/opt
 
 FROM ubuntu:${UBUNTU_VERSION} AS base
 
+ARG INSTALL_PATH
+
 # Set environment variables
 ENV TZ=America/Chicago \
     HOME=/root \
@@ -53,7 +55,7 @@ RUN python3 -m venv ${VENV_PATH} && \
         progress
 
 ENV PATH=${VENV_PATH}/bin:$PATH \
-    LD_LIBRARY_PATH=${VENV_PATH}/lib:$LD_LIBRARY_PATH
+    LD_LIBRARY_PATH=${VENV_PATH}/lib
 
 # HDF5 setup
 ARG HDF5_VERSION=1.14.6


### PR DESCRIPTION
## Description
Minor changes to address some build warnings, including:
* updating CMake version
* ensuring Docker variables are set

## Motivation and Context
Gradually reduce warnings that appear during the build process.

Replaced #1575
