### PR TITLE
Allow metastable states higher than n

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Next Version
    * Update Dockerfile syntax (#1566)
    * Remove reference to Python `long` (#1566)
    * Update Ubuntu Docker configuration and fix compatibility issues (#1572, #1575)
+   * Allow `nucname.cpp` to read metastable states higher than m with `pyne.alara.num_dens_to_mesh()` (#1581)
 
 v0.7.8
 ======

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -13,9 +13,13 @@
 /***String used to check for metastable states***/
 std::string pyne::nucname::metastable_states = "mnopqrstuvxyz";
 //Capitalize all letters in the metastable states string
-std::string upper_metastable = pyne::nucname::metastable_states;
-std::transform(upper_metastable.begin(), upper_metastable.end(), upper_metastable.begin(),
-               [](char c){ return std::toupper(c); });
+std::string get_upper_metastable() {
+    std::string upper_metastable = pyne::nucname::metastable_states;
+    std::transform(upper_metastable.begin(), upper_metastable.end(), upper_metastable.begin(),
+                   [](char c){ return std::toupper(c); });
+    return upper_metastable;
+}
+std::string upper_metastable = get_upper_metastable();
 
 /*** Constructs the LL to zz Dictionary ***/
 pyne::nucname::name_zz_t pyne::nucname::get_name_zz() {
@@ -1124,8 +1128,7 @@ std::string pyne::nucname::serpent(int nuc) {
 
   // Add meta-stable flag
   if (0 < ssss)
-    char meta_char = pyne::nucname::metastable_states[ssss - 1];
-    newnuc += meta_char;
+    newnuc += pyne::nucname::metastable_states[ssss - 1];
   return newnuc;
 }
 

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -12,14 +12,21 @@
 
 /***String used to check for metastable states***/
 std::string pyne::nucname::metastable_states = "mnopqrstuvxyz";
-//Capitalize all letters in the metastable states string
-std::string get_upper_metastable() {
-    std::string upper_metastable = pyne::nucname::metastable_states;
-    std::transform(upper_metastable.begin(), upper_metastable.end(), upper_metastable.begin(),
-                   [](char c){ return std::toupper(c); });
-    return upper_metastable;
+
+int pyne::nucname::isomer_id(std::string end_char) {
+    
+    int id = -1;
+    size_t pos = pyne::nucname::metastable_states.find(std::tolower(end_char));
+
+    if (pos != std::string::npos) {
+        id = static_cast<int>(pos) + 1;
+    }
+    else if (pyne::contains_substring(pyne::digits, end_char)) {
+        id = 0;
+    }
+
+    return id;
 }
-std::string upper_metastable = get_upper_metastable();
 
 /*** Constructs the LL to zz Dictionary ***/
 pyne::nucname::name_zz_t pyne::nucname::get_name_zz() {
@@ -596,19 +603,15 @@ int pyne::nucname::id(std::string nuc) {
     if (anum < 0)
       throw NotANuclide(nucstr, anum);
 
-    // Figure out if we are meta-stable or not
+    // Figure out if we are metastable or not
     std::string end_char = pyne::last_char(nucstr);
-    size_t pos = upper_metastable.find(end_char);
-
-    if (pos != std::string::npos) {
-        newnuc = (10000 * anum) + static_cast<int>(pos) + 1;
+    int isomer_id = pyne::nucname::isomer_id(end_char);
+    if (isomer_id > -1) {
+        newnuc = (10000 * anum) + isomer_id;
     }
-    else if (pyne::contains_substring(pyne::digits, end_char)) {
-        newnuc = (10000 * anum);
+    else {
+        throw NotANuclide(nucstr, newnuc);
     }
-  else {
-      throw NotANuclide(nucstr, newnuc);
-  }
 
     // Add the Z-number
     elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
@@ -687,7 +690,7 @@ std::string pyne::nucname::name(int nuc) {
 
   // Add meta-stable flag
   if (0 < ssss)
-    newnuc += upper_metastable[ssss - 1];
+    newnuc += std::toupper(pyne::nucname::metastable_states[ssss - 1]);
 
   return newnuc;
 }
@@ -902,16 +905,14 @@ int pyne::nucname::zzllaaam_to_id(std::string nuc) {
 
   // Figure out if we are meta-stable or not
   std::string end_char = pyne::last_char(nucstr);
-  size_t pos = upper_metastable.find(end_char);
-  if (pos != std::string::npos) {
-      nucid = (10000 * anum) + static_cast<int>(pos) + 1;
-  }
-  else if (pyne::contains_substring(pyne::digits, end_char)) {
-      nucid = (10000 * anum);
+  int isomer_id = pyne::nucname::isomer_id(end_char);
+  if (isomer_id > -1) {
+      nucid = (10000 * anum) + isomer_id;
   }
   else {
       throw NotANuclide(nucstr, nucid);
   }
+
   // Add the Z-number
   elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
   elem_name = pyne::capitalize(elem_name);
@@ -1179,15 +1180,15 @@ int pyne::nucname::serpent_to_id(std::string nuc) {
   }
   int anum = pyne::to_int(anum_str);
 
-  // Figure out if we are meta-stable or not
+  // Figure out if we are metastable or not
   std::string end_char = pyne::last_char(nucstr);
-  size_t pos = upper_metastable.find(end_char);
-  if (pos != std::string::npos) 
-    nucid = (10000 * anum) + static_cast<int>(pos) + 1;
-  else if (pyne::contains_substring(pyne::digits, end_char))
-    nucid = (10000 * anum);
-  else
-    throw NotANuclide(nucstr, nucid);
+  int isomer_id = pyne::nucname::isomer_id(end_char);
+  if (isomer_id > -1) {
+      nucid = (10000 * anum) + isomer_id;
+  }
+  else {
+      throw NotANuclide(nucstr, nucid);
+  }
 
   // Add the Z-number
   elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -6,8 +6,16 @@
 #ifndef PYNE_IS_AMALGAMATED
 #include "nucname.h"
 #include "state_map.cpp"
+#include <cctype>
+#include <algorithm>
 #endif
 
+/***String used to check for metastable states***/
+std::string pyne::nucname::metastable_states = "mnopqrstuvxyz";
+//Capitalize all letters in the metastable states string
+std::string upper_metastable = metastable_states;
+std::transform(upper_metastable.begin(), upper_metastable.end(), upper_metastable.begin(),
+               [](char c){ return std::toupper(c); });
 
 /*** Constructs the LL to zz Dictionary ***/
 pyne::nucname::name_zz_t pyne::nucname::get_name_zz() {
@@ -586,8 +594,7 @@ int pyne::nucname::id(std::string nuc) {
 
     // Figure out if we are meta-stable or not
     std::string end_char = pyne::last_char(nucstr);
-    std::string metastable_states = "MNOPQRSTUVWXYZ";
-    size_t pos = metastable_states.find(end_char);
+    size_t pos = upper_metastable.find(end_char);
 
     if (pos != std::string::npos) {
         newnuc = (10000 * anum) + static_cast<int>(pos) + 1;
@@ -675,9 +682,8 @@ std::string pyne::nucname::name(int nuc) {
     newnuc += pyne::to_str(aaa);
 
   // Add meta-stable flag
-  std::string metastable_states = "MNOPQRSTUVWXYZ";
   if (0 < ssss)
-    newnuc += metastable_states[ssss - 1];
+    newnuc += upper_metastable[ssss - 1];
 
   return newnuc;
 }
@@ -840,9 +846,8 @@ std::string pyne::nucname::zzllaaam(int nuc) {
   if (0 < aaassss)
     newnuc += pyne::to_str(aaa);
   // Add meta-stable flag
-  std::string metastable_states = "mnopqrstuvwxyz";
   if (0 < ssss)
-    newnuc += metastable_states[ssss - 1];
+    newnuc += pyne::nucname::metastable_states[ssss - 1];
   return newnuc;
 }
 
@@ -893,8 +898,7 @@ int pyne::nucname::zzllaaam_to_id(std::string nuc) {
 
   // Figure out if we are meta-stable or not
   std::string end_char = pyne::last_char(nucstr);
-  std::string metastable_states = "MNOPQRSTUVWXYZ";
-  size_t pos = metastable_states.find(end_char);
+  size_t pos = upper_metastable.find(end_char);
   if (pos != std::string::npos) {
       nucid = (10000 * anum) + static_cast<int>(pos) + 1;
   }
@@ -1119,9 +1123,8 @@ std::string pyne::nucname::serpent(int nuc) {
     newnuc += "nat";
 
   // Add meta-stable flag
-  std::string metastable_states = "mnopqrstuvwxyz";
   if (0 < ssss)
-    char meta_char = metastable_states[ssss - 1];
+    char meta_char = pyne::nucname::metastable_states[ssss - 1];
     newnuc += meta_char;
   return newnuc;
 }
@@ -1175,8 +1178,7 @@ int pyne::nucname::serpent_to_id(std::string nuc) {
 
   // Figure out if we are meta-stable or not
   std::string end_char = pyne::last_char(nucstr);
-  std::string metastable_states = "MNOPQRSTUVWXYZ";
-  size_t pos = metastable_states.find(end_char);
+  size_t pos = upper_metastable.find(end_char);
   if (pos != std::string::npos) 
     nucid = (10000 * anum) + static_cast<int>(pos) + 1;
   else if (pyne::contains_substring(pyne::digits, end_char))

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -13,7 +13,7 @@
 /***String used to check for metastable states***/
 std::string pyne::nucname::metastable_states = "mnopqrstuvxyz";
 //Capitalize all letters in the metastable states string
-std::string upper_metastable = metastable_states;
+std::string upper_metastable = pyne::nucname::metastable_states;
 std::transform(upper_metastable.begin(), upper_metastable.end(), upper_metastable.begin(),
                [](char c){ return std::toupper(c); });
 

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -16,7 +16,7 @@ std::string pyne::nucname::metastable_states = "mnopqrstuvxyz";
 int pyne::nucname::isomer_id(std::string end_char) {
     
     int id = -1;
-    size_t pos = pyne::nucname::metastable_states.find(std::tolower(end_char));
+    size_t pos = pyne::nucname::metastable_states.find(std::tolower(end_char[0]));
 
     if (pos != std::string::npos) {
         id = static_cast<int>(pos) + 1;

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -586,12 +586,18 @@ int pyne::nucname::id(std::string nuc) {
 
     // Figure out if we are meta-stable or not
     std::string end_char = pyne::last_char(nucstr);
-    if (end_char == "M")
-      newnuc = (10000 * anum) + 1;
-    else if (pyne::contains_substring(pyne::digits, end_char))
-      newnuc = (10000 * anum);
-    else
+    std::string metastable_states = "MNOPQRSTUVWXYZ";
+    size_t pos = metastable_states.find(end_char);
+
+    if (pos != std::string::npos) {
+        newnuc = (10000 * anum) + static_cast<int>(pos) + 1;
+    }
+    else if (pyne::contains_substring(pyne::digits, end_char)) {
+        newnuc = (10000 * anum);
+    }
+  else {
       throw NotANuclide(nucstr, newnuc);
+  }
 
     // Add the Z-number
     elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
@@ -669,8 +675,10 @@ std::string pyne::nucname::name(int nuc) {
     newnuc += pyne::to_str(aaa);
 
   // Add meta-stable flag
+  std::string metastable_states = "MNOPQRSTUVWXYZ";
   if (0 < ssss)
-    newnuc += "M";
+    char meta_char = metastable_states[ssss - 1];
+    newnuc += meta_char;
 
   return newnuc;
 }
@@ -833,8 +841,10 @@ std::string pyne::nucname::zzllaaam(int nuc) {
   if (0 < aaassss)
     newnuc += pyne::to_str(aaa);
   // Add meta-stable flag
+  std::string metastable_states = "mnopqrstuvwxyz";
   if (0 < ssss)
-    newnuc += "m";
+    char meta_char = metastable_states[ssss - 1];
+    newnuc += meta_char;
   return newnuc;
 }
 
@@ -885,13 +895,17 @@ int pyne::nucname::zzllaaam_to_id(std::string nuc) {
 
   // Figure out if we are meta-stable or not
   std::string end_char = pyne::last_char(nucstr);
-  if (end_char == "M")
-    nucid = (10000 * anum) + 1;
-  else if (pyne::contains_substring(pyne::digits, end_char))
-    nucid = (10000 * anum);
-  else
-    throw NotANuclide(nucstr, nucid);
-
+  std::string metastable_states = "MNOPQRSTUVWXYZ";
+  size_t pos = metastable_states.find(end_char);
+  if (pos != std::string::npos) {
+      nucid = (10000 * anum) + static_cast<int>(pos) + 1;
+  }
+  else if (pyne::contains_substring(pyne::digits, end_char)) {
+      nucid = (10000 * anum);
+  }
+  else {
+      throw NotANuclide(nucstr, nucid);
+  }
   // Add the Z-number
   elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
   elem_name = pyne::capitalize(elem_name);
@@ -1107,9 +1121,10 @@ std::string pyne::nucname::serpent(int nuc) {
     newnuc += "nat";
 
   // Add meta-stable flag
+  std::string metastable_states = "mnopqrstuvwxyz";
   if (0 < ssss)
-    newnuc += "m";
-
+    char meta_char = metastable_states[ssss - 1];
+    newnuc += meta_char;
   return newnuc;
 }
 
@@ -1162,8 +1177,10 @@ int pyne::nucname::serpent_to_id(std::string nuc) {
 
   // Figure out if we are meta-stable or not
   std::string end_char = pyne::last_char(nucstr);
-  if (end_char == "M")
-    nucid = (10000 * anum) + 1;
+  std::string metastable_states = "MNOPQRSTUVWXYZ";
+  size_t pos = metastable_states.find(end_char);
+  if (pos != std::string::npos) 
+    nucid = (10000 * anum) + static_cast<int>(pos) + 1;
   else if (pyne::contains_substring(pyne::digits, end_char))
     nucid = (10000 * anum);
   else

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -677,8 +677,7 @@ std::string pyne::nucname::name(int nuc) {
   // Add meta-stable flag
   std::string metastable_states = "MNOPQRSTUVWXYZ";
   if (0 < ssss)
-    char meta_char = metastable_states[ssss - 1];
-    newnuc += meta_char;
+    newnuc += metastable_states[ssss - 1];
 
   return newnuc;
 }

--- a/src/nucname.cpp
+++ b/src/nucname.cpp
@@ -842,8 +842,7 @@ std::string pyne::nucname::zzllaaam(int nuc) {
   // Add meta-stable flag
   std::string metastable_states = "mnopqrstuvwxyz";
   if (0 < ssss)
-    char meta_char = metastable_states[ssss - 1];
-    newnuc += meta_char;
+    newnuc += metastable_states[ssss - 1];
   return newnuc;
 }
 

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -19,6 +19,7 @@ namespace pyne
 //! Nuclide naming conventions
 namespace nucname
 {
+  extern std::string metastable_states;
   typedef std::string name_t; ///< name type
   typedef int zz_t;           ///< Z number type
 

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -357,6 +357,8 @@ namespace nucname
   int zzaaam_to_id(std::string nuc);
   /// \}
 
+  /// \ function that checks for metastability and returns a number according to the state
+  extern int pyne::nucname::isomer_id(std::string end_char)
 
   /// \name ZZZAAA Form Functions
   /// \{

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -358,7 +358,7 @@ namespace nucname
   /// \}
 
   /// \ function that checks for metastability and returns a number according to the state
-  extern int pyne::nucname::isomer_id(std::string end_char)
+  extern int pyne::nucname::isomer_id(std::string end_char);
 
   /// \name ZZZAAA Form Functions
   /// \{

--- a/src/nucname.h
+++ b/src/nucname.h
@@ -358,7 +358,7 @@ namespace nucname
   /// \}
 
   /// \ function that checks for metastability and returns a number according to the state
-  extern int pyne::nucname::isomer_id(std::string end_char);
+  int isomer_id(std::string end_char);
 
   /// \name ZZZAAA Form Functions
   /// \{

--- a/tests/test_nucname.py
+++ b/tests/test_nucname.py
@@ -9,7 +9,6 @@ from pyne.utils import QAWarning
 warnings.simplefilter("ignore", QAWarning)
 from pyne import nucname
 
-
 def test_name_zz():
     assert nucname.name_zz["He"] == 2
     assert nucname.name_zz["U"] == 92
@@ -417,6 +416,7 @@ def test_id():
     assert nucname.id(95942) == 952420004
 
     assert nucname.id("Am-242m") == 952420001
+    assert nucname.id("Ta-182n") == 731820002
 
     assert nucname.id("he") == 20000000
     assert nucname.id("U") == 920000000
@@ -438,8 +438,12 @@ def test_id():
     assert nucname.id("95-Am-242m") == nucname.id("Am-242m")
     assert nucname.id("94-Pu-239") == nucname.id("Pu-239")
     assert nucname.id("95-Am-242") == nucname.id("Am-242")
+    assert nucname.id("72-Hf-179n") == nucname.id("Hf-179n")
 
     pytest.raises(RuntimeError, nucname.id, "0-H-1")
+    pytest.raises(RuntimeError, nucname.id, "Am-242j")
+    pytest.raises(RuntimeError, nucname.id, "") #nuc.empty()
+    pytest.raises(RuntimeError, nucname.id, -100) #nuc < 0
 
 
 def test_name():

--- a/tests/test_nucname.py
+++ b/tests/test_nucname.py
@@ -464,6 +464,8 @@ def test_name():
     assert nucname.name(2390940) == "Pu239"
     assert nucname.name(2420950) == "Am242"
 
+    assert nucname.name(1820732) == "Ta182N"
+
 
 @pytest.mark.parametrize("case, exp", zip(cases,[
         2,
@@ -654,6 +656,8 @@ def test_zzllaaam():
     assert nucname.zzllaaam(2390940) == "94-Pu-239"
     assert nucname.zzllaaam(2420951) == "95-Am-242m"
 
+    assert nucname.zzllaaam(1820732) == "73-Ta-182n"
+
 
 def test_zzllaaam_to_id():
     assert nucname.zzllaaam_to_id("94-Pu-239") == nucname.id("Pu-239")
@@ -662,6 +666,10 @@ def test_zzllaaam_to_id():
     assert nucname.zzllaaam_to_id("94-Pu-239") == nucname.id("Pu-239")
     assert nucname.zzllaaam_to_id("95-Am-242") == nucname.id("Am-242")
     assert nucname.zzllaaam_to_id("95-Am-242m") == nucname.id("Am-242m")
+
+    assert nucname.zzllaaam_to_id("73-Ta-182n") == nucname.id("Ta-182n")
+
+    pytest.raises(RuntimeError, nucname.zzllaaam_to_id, "Ta-182b")
 
 
 def test_mcnp():
@@ -810,6 +818,8 @@ def test_serpent():
 
     assert nucname.serpent(2390940) == "Pu-239"
     assert nucname.serpent(2420951) == "Am-242m"
+
+    assert nucname.serpent(1820732) == "Ta-182n"
 
 
 @pytest.mark.parametrize("val, id",set(zip([


### PR DESCRIPTION
## Description
`nucname.cpp` has been modified to accommodate metastable states higher than the first. These states are now allowed to be as high as the z-level. This was done by changing part of the code where the last character was hard-coded as "m" or "M." The openmc functions remain in their original format as openmc attaches numbers to the end of the nuclide to indicate different levels of metastability.  

## Motivation and Context
Fixes #1580

## Changes
This fixes the bug described in the issue referenced above. A documentation update to `nucname.h` is also likely in order.
