### PR TITLE
fix: undefined name, swapped ORIGEN keys, Popen args, mesh broadcast

### DIFF
--- a/pyne/cccc.py
+++ b/pyne/cccc.py
@@ -751,7 +751,7 @@ class Spectr(_BinaryReader):
     """Reads ultra-fine group spectrum file from MC**2"""
 
     def __init__(self, filename):
-        super(SPECTR, self).__init__(filename)
+        super(Spectr, self).__init__(filename)
         self.fc = {}
         self.read1D()
         self.flux = self.read2D()

--- a/pyne/ensdf_processing.py
+++ b/pyne/ensdf_processing.py
@@ -244,8 +244,7 @@ def bricc(inputdict_unchecked):
         briccnh = inputdict_unchecked["BrIccNH"]
         if briccnh:
             proc = subprocess.Popen(
-                exe_path,
-                [input_file, "BrIccNH"],
+                [exe_path, input_file, "BrIccNH"],
                 stdout=subprocess.PIPE,
                 stdin=subprocess.PIPE,
             )

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -676,7 +676,7 @@ class NativeMeshTag(Tag):
                 raise ValueError("Incompatible shape for scalar or vector data")
         elif self.size > 1:
             try:
-                return _ops[op](self[:], other[:][None, :])
+                return _ops[op](self[:], other[:][:, None])
             except:
                 raise ValueError("Incompatible shape for vector or scalar data")
 

--- a/pyne/origen22.py
+++ b/pyne/origen22.py
@@ -2559,9 +2559,9 @@ def _parse_tape9_xsfpy(deck):
     pdeck["sigma_2n"] = dict([(nuc, val) for nuc, val in cards[["f0", "f2"]]])
 
     f3_keys = {
-        "fission_products": "sigma_alpha",
-        "actinides": "sigma_3n",
-        "activation_products": "sigma_alpha",
+        "fission_products": "sigma_3n",
+        "actinides": "sigma_alpha",
+        "activation_products": "sigma_3n",
     }
     pdeck[f3_keys[subtype]] = dict([(nuc, val) for nuc, val in cards[["f0", "f3"]]])
 


### PR DESCRIPTION
Four independent fixes found while auditing the parsers and mesh code.

### 1. `Spectr` class is unusable (`cccc.py`)
```python
class Spectr(_BinaryReader):
    def __init__(self, filename):
        super(SPECTR, self).__init__(filename)   # SPECTR is undefined
```
`SPECTR` is not defined anywhere; the class is `Spectr`. Instantiating `Spectr` raises `NameError`. Fixed to `super(Spectr, self)`.

### 2. Swapped ORIGEN cross-section keys (`origen22.py`, `_parse_tape9_xsfpy`)
```python
f3_keys = {
    "fission_products": "sigma_alpha",
    "actinides": "sigma_3n",
    "activation_products": "sigma_alpha",
}
pdeck[f3_keys[subtype]] = dict(... "f3" ...)
```
The write path (`_write_xsfpy`) stores the f3 column as `sigma_alpha` for actinides and `sigma_3n` otherwise, matching `ACTINIDE_FIELDS[0]`, `ACTIVATION_PRODUCT_FIELDS[0]`, and `FISSION_PRODUCT_FIELDS[0]`. The parse mapping had these swapped, so TAPE9 cross sections did not round-trip. Corrected to:
```python
f3_keys = {
    "fission_products": "sigma_3n",
    "actinides": "sigma_alpha",
    "activation_products": "sigma_3n",
}
```

### 3. `Popen` args in the bufsize slot (`ensdf_processing.py`)
```python
proc = subprocess.Popen(
    exe_path,
    [input_file, "BrIccNH"],   # -> bufsize, must be int
    ...)
```
The second positional arg to `Popen` is `bufsize`; passing a list raises `TypeError`, so the BrIccNH evaluation path is broken. Fixed to a single args list `[exe_path, input_file, "BrIccNH"]`.

### 4. Wrong broadcast axis (`mesh.py`, tag arithmetic)
The scalar-tag (op) vector-tag branch correctly uses `self[:][:, None]`; the mirror vector-tag (op) scalar-tag branch used `other[:][None, :]` (a row), which only broadcasts against `(N, M)` when `N == M`. Changed to `other[:][:, None]`.

### Testing
Localized fixes verified against the surrounding code / the write path and sibling branches; I didn't run the full suite locally (needs MOAB/OpenMC). Happy to adjust.